### PR TITLE
docs: redesign README, add docs/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 </p>
 
 <p align="center">
-  <a href="#quick-start">Quick Start</a> · <a href="#how-it-works">How It Works</a> · <a href="#api">API</a> · <a href="./SPEC.md">Spec</a>
+  <img src="https://img.shields.io/badge/TypeScript-5.9%2B-3178c6" alt="TypeScript 5.9+">
+  <img src="https://img.shields.io/badge/Node.js-24%2B-339933" alt="Node.js 24+">
+  <img src="https://img.shields.io/badge/Zod-4-3068b7" alt="Zod 4">
+</p>
+
+<p align="center">
+  <a href="#quick-start">Quick Start</a> · <a href="#skill-types">Skill Types</a> · <a href="#how-it-works">How It Works</a> · <a href="#examples">Examples</a> · <a href="#api">API</a> · <a href="./docs/api.md">Full API Reference</a> · <a href="./docs/architecture.md">Architecture</a> · <a href="./SPEC.md">Spec</a>
 </p>
 
 ---
@@ -50,160 +56,73 @@ That's a skill. The agent sees one step at a time, returns structured output, an
 pnpm add @contentful/skill-kit
 ```
 
-**Define** → **Test** → **Build** → **Ship**
-
 ### Define a skill
 
 ```typescript
-// examples/deploy-check/src/skill.ts
-import { skill, z, askUser } from '@contentful/skill-kit';
+import { skill, z } from '@contentful/skill-kit';
 
 export default skill({
-  name: 'deploy-check',
-  entry: 'choose',
-  context: z.object({ env: z.string().default('staging') }),
-  stash: z.object({ target: z.string() }),
+  name: 'greet',
+  entry: 'ask',
 })
-  .step('choose', {
-    ask: askUser({
-      type: 'structured',
-      question: 'Which environment?',
-      options: [
-        { value: 'production', label: 'Production' },
-        { value: 'staging', label: 'Staging' },
-      ],
-    }),
-    output: z.object({ target: z.enum(['production', 'staging']) }),
-    stash: ({ output }) => ({ target: output.target }),
-    next: 'verify',
+  .step('ask', {
+    prompt: 'Ask the user for their name.',
+    output: z.object({ name: z.string() }),
+    next: 'welcome',
   })
-  .step('verify', {
-    prompt: ({ stash }) => `Run pre-deploy checks for ${stash.target}. Report any blockers.`,
-    output: z.object({ blockers: z.array(z.string()), safe: z.boolean() }),
-    next: ({ output }) => (output.safe ? 'deploy' : 'abort'),
-  })
-  .step('deploy', {
-    prompt: 'Execute the deployment.',
-    output: z.object({ url: z.string() }),
-    next: { terminal: true },
-  })
-  .step('abort', {
-    prompt: 'Report the blockers and explain why deployment was aborted.',
-    output: z.object({ summary: z.string() }),
+  .step('welcome', {
+    prompt: ({ prev }) => `Say hello to ${(prev as { name: string }).name}.`,
+    output: z.object({ message: z.string() }),
     next: { terminal: true },
   })
   .build();
 ```
-
-Context and stash types flow into step callbacks automatically — `stash.target` is typed as `string`, no annotations needed.
 
 ### Test without an agent
 
 ```typescript
 import { runSkill, mockModel } from '@contentful/skill-kit/test';
-import deploy from './skill.ts';
+import greet from './skill.ts';
 
-const result = await runSkill(deploy, {
+const result = await runSkill(greet, {
   model: mockModel({
-    choose: { target: 'staging' },
-    verify: { blockers: [], safe: true },
-    deploy: { url: 'https://staging.example.com' },
+    ask: { name: 'Alice' },
+    welcome: { message: 'Hello, Alice!' },
   }),
 });
 
-// result.path → ['choose', 'verify', 'deploy']
-// result.output → { url: 'https://staging.example.com' }
+// result.path → ['ask', 'welcome']
+// result.output → { message: 'Hello, Alice!' }
 ```
 
 ### Build a distributable skill
 
 ```bash
-npx skill-kit build examples/deploy-check/src/skill.ts -o examples/deploy-check/skill
+npx skill-kit build src/skill.ts -o skill
 ```
 
 Output is an [agentskills.io](https://agentskills.io/specification)-compliant directory:
 
 ```
-examples/deploy-check/skill/
+skill/
   SKILL.md               ← Generated. Agents read this.
   package.json
   scripts/
     run                  ← Shell wrapper. The public interface.
   bin/
-    deploy-check-darwin-arm64
-    deploy-check-linux-x64
+    greet-darwin-arm64
+    greet-linux-x64
 ```
 
 Install it anywhere — `skills add`, `agents-kit install`, or just `git clone`.
 
-## How It Works
+## Skill Types
 
-```
-┌─────────┐  scripts/run start   ┌─────────────┐
-│         │ ───────────────────► │             │
-│  Agent  │  ◄ JSON: prompt,     │  Skill CLI  │
-│         │    schema            │  (compiled) │
-│         │                      │             │
-│         │  scripts/run advance │             │
-│         │ ───────────────────► │             │
-│         │  ◄ JSON: next prompt │             │
-│         │       ...or done     │             │
-└─────────┘                      └─────────────┘
-```
+### Workflow skills
 
-Each invocation is **stateless**. The agent passes the full conversation history via `--history` on every `advance` call. The binary reconstructs state, validates the output against the Zod schema, and returns the next step's prompt as JSON.
+Typed state machines with steps, Zod schemas, branching, and cross-step state. The hero example above shows the pattern — `skill()` → `.step()` → `.build()`. Add `context` for immutable input, `stash` for accumulated state, `askUser` for interactive questions, and `action` for side effects. See the [full API reference](./docs/api.md) for all options.
 
-No persistent processes. No stdin piping. Just Bash calls that every agent host already supports.
-
-### Host-aware primitives
-
-The SDK uses an abstract verb system. The preamble (sent on first response) maps verbs to host-specific tools:
-
-| Verb             | Claude Code             | Codex                   | Generic                 |
-| ---------------- | ----------------------- | ----------------------- | ----------------------- |
-| `ASK_STRUCTURED` | `AskUserQuestion` tool  | Prose with option list  | Prose with option list  |
-| `ASK_FREEFORM`   | Plain text conversation | Plain text conversation | Plain text conversation |
-| `PRESENT_PLAN`   | `EnterPlanMode`         | `update_plan`           | Numbered list           |
-| `CREATE_TASKS`   | `TaskCreate`            | `update_plan` checklist | Markdown checklist      |
-
-Step prose uses the verbs. The preamble handles the translation. Same skill, every host.
-
-### Modules
-
-Composable step groups with their own stash scope:
-
-```typescript
-import { module, z } from '@contentful/skill-kit';
-
-const authModule = module({
-  name: 'auth',
-  entry: 'auth-login',
-  stash: z.object({ userId: z.string() }),
-})
-  .step('auth-login', {
-    prompt: 'Ask for credentials.',
-    output: z.object({ userId: z.string() }),
-    stash: ({ output }) => ({ userId: output.userId }),
-    next: '__parent__', // exits back to the registering skill
-  })
-  .build();
-```
-
-Register into a skill — stash types merge automatically:
-
-```typescript
-skill({ name: 'app', entry: 'start', stash: z.object({ appName: z.string() }) })
-  .step('start', { ... next: 'auth-login' })
-  .register(authModule, { next: 'dashboard' })
-  .step('dashboard', {
-    // stash is now { appName: string } & { userId: string }
-    prompt: ({ stash }) => `Welcome ${stash.userId} to ${stash.appName}`,
-    ...
-  })
-  .build();
-```
-
-## Reference Skills
+### Reference skills
 
 For skills that don't need a workflow — just progressive disclosure of content:
 
@@ -236,13 +155,93 @@ No JSON, no history, no state machine. Just `topic <name>` → text.
 
 ---
 
+## How It Works
+
+```
+┌─────────┐  scripts/run start   ┌─────────────┐
+│         │ ───────────────────► │             │
+│  Agent  │  ◄ JSON: prompt,     │  Skill CLI  │
+│         │    schema            │  (compiled) │
+│         │                      │             │
+│         │  scripts/run advance │             │
+│         │ ───────────────────► │             │
+│         │  ◄ JSON: next prompt │             │
+│         │       ...or done     │             │
+└─────────┘                      └─────────────┘
+```
+
+Each invocation is **stateless**. The agent passes the full conversation history via `--history` on every `advance` call. The binary reconstructs state, validates the output against the Zod schema, and returns the next step's prompt as JSON. No persistent processes — just Bash calls that every agent host already supports.
+
+### Host-aware primitives
+
+The SDK uses an abstract verb system. The preamble (sent on first response) maps verbs to host-specific tools:
+
+| Verb             | Claude Code            | Codex / OpenCode        | Generic                |
+| ---------------- | ---------------------- | ----------------------- | ---------------------- |
+| `ASK_STRUCTURED` | `AskUserQuestion` tool | Prose with option list  | Prose with option list |
+| `PRESENT_PLAN`   | `EnterPlanMode`        | `update_plan`           | Numbered list          |
+| `CREATE_TASKS`   | `TaskCreate`           | Checklist / `todowrite` | Markdown checklist     |
+
+Same skill, every host. See the [architecture doc](./docs/architecture.md#the-host-aware-prose-system) for the full verb table and how prose generation works.
+
+---
+
+## Examples
+
+### get-to-know-you (workflow)
+
+A playful interview that builds a developer trading card. Shows branching, `askUser`, `confirm`, fragments, render helpers, actions, and loop guards.
+
+```typescript
+.step('ask-role', {
+  ask: askUser({
+    type: 'structured',
+    question: "What's your primary role?",
+    options: [
+      { value: 'dev', label: 'Developer' },
+      { value: 'designer', label: 'Designer' },
+      { value: 'manager', label: 'Manager' },
+    ],
+  }),
+  output: z.object({ role: z.enum(['dev', 'designer', 'manager', 'other']) }),
+  next: ({ output }) => {
+    switch (output.role) {
+      case 'dev': return 'ask-stack';
+      case 'designer': return 'ask-tools';
+      default: return 'ask-specialty';
+    }
+  },
+})
+```
+
+[Full source](./examples/get-to-know-you/src/skill.ts)
+
+### ts-patterns (reference)
+
+TypeScript patterns reference with on-demand topic loading. Shows `render.table`, `render.code`, and external markdown via `refs.load()`.
+
+```typescript
+.topic('error-handling', {
+  label: 'Error handling — Result types, custom errors, exhaustive matching',
+  content: () => render.table(
+    [
+      { pattern: 'try/catch', use: 'External APIs, I/O', note: 'Catch specific error types' },
+      { pattern: 'Result<T, E>', use: 'Domain logic', note: 'Forces caller to handle both paths' },
+    ],
+    { columns: ['pattern', 'use', 'note'] },
+  ),
+})
+```
+
+[Full source](./examples/ts-patterns/src/skill.ts)
+
+---
+
 ## API
 
 ### Workflow Builder
 
 ```typescript
-import { skill, z } from '@contentful/skill-kit';
-
 skill({ name, entry, context?, stash?, observers?, capabilities?, finalOutput? })
   .step(name, config)              // inline step — context/stash types inferred
   .extend(name, sharedStep, overrides)  // shared step with typed overrides
@@ -253,54 +252,20 @@ skill({ name, entry, context?, stash?, observers?, capabilities?, finalOutput? }
 ### Reference Builder
 
 ```typescript
-import { reference } from '@contentful/skill-kit';
-
 reference({ name, description, version? })
   .topic(name, { label, content: (ctx) => string })  // content receives { refs }
   .build()                                            // → ReferenceDefinition
 ```
 
-### askUser — structured or open
-
-```typescript
-import { askUser } from '@contentful/skill-kit';
-
-// Structured — becomes ASK_STRUCTURED verb → AskUserQuestion on Claude Code
-ask: askUser({
-  type: 'structured',
-  question: 'Which env?',
-  options: [{ value: 'prod', label: 'Production' }, ...],
-})
-
-// Open — becomes ASK_FREEFORM verb → plain text conversation, never a tool
-ask: askUser({
-  type: 'open',
-  question: "What's your tech stack?",
-})
-```
-
-### Other primitives
+### Primitives
 
 | Export                               | What it does                 |
 | ------------------------------------ | ---------------------------- |
+| `askUser({ type, question, ... })`   | Structured or open question  |
 | `confirm({ message, destructive? })` | Binary yes/no approval       |
 | `plan({ summary, steps })`           | Show plan, wait for approval |
 | `tasks({ create })`                  | Tracked subtask list         |
 | `subtask({ prompt, output })`        | Spawn isolated sub-agent     |
-
-### Standalone steps
-
-```typescript
-import { step, z } from '@contentful/skill-kit';
-
-// For shared/reusable steps defined outside a skill
-const openQuestion = step({
-  output: z.object({ answer: z.string() }),
-  next: '__parent__',
-});
-```
-
-Use via `.extend()` on the builder to get typed overrides.
 
 ### Testing
 
@@ -327,7 +292,6 @@ skill-kit check <skill.ts>                 # Lint for portability issues
 <summary><strong>Step config reference</strong></summary>
 
 ```typescript
-// Inline in .step() — context and stash typed via builder
 {
   prompt: string | (ctx: PromptContext) => string,
   output: z.ZodType,
@@ -360,12 +324,12 @@ skill-kit check <skill.ts>                 # Lint for portability issues
 
 </details>
 
+For modules, fragments, actions, render helpers, observers, and lint rules, see the [full API reference](./docs/api.md).
+
 ## Key Decisions
 
 - **Builder pattern.** `skill()` returns a builder. `.step()` callbacks get typed context/stash via contextual inference — no annotations.
 - **Schemas are Zod.** One validator, native TS types. No pluggable schema systems.
-- **State is append-only.** No mutation of prior step outputs. Enables replay.
-- **Cycles require guards.** Every loop must declare `maxVisits` + `onMaxVisits`. Enforced at load time.
 - **Abstract verb system.** Step prose uses verbs (`ASK_STRUCTURED`, `ASK_FREEFORM`). The preamble maps them to host-specific tools.
 - **Single invocation.** No persistent processes. Each call reconstructs from history.
 - **Two skill types, one build pipeline.** Workflow skills (`skill()`) for multi-step state machines. Reference skills (`reference()`) for progressive disclosure. Both compile to the same agentskills.io directory structure.
@@ -373,5 +337,5 @@ skill-kit check <skill.ts>                 # Lint for portability issues
 ---
 
 <p align="center">
-  <a href="./SPEC.md">Full specification</a> · <a href="https://agentskills.io/specification">agentskills.io format</a>
+  <a href="./docs/api.md">Full API Reference</a> · <a href="./docs/architecture.md">Architecture</a> · <a href="./SPEC.md">Specification</a> · <a href="https://agentskills.io/specification">agentskills.io</a>
 </p>

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,17 +18,17 @@ skill({ name, entry, context?, stash?, observers?, capabilities?, finalOutput?, 
 
 ### `skill()` config
 
-| Field          | Type                                         | Required | Description                                                       |
-| -------------- | -------------------------------------------- | -------- | ----------------------------------------------------------------- |
-| `name`         | `string`                                     | yes      | Skill identifier                                                  |
-| `entry`        | `string`                                     | yes      | Name of the first step                                            |
-| `version`      | `string`                                     | no       | Defaults to `'0.0.0'`                                             |
-| `description`  | `string`                                     | no       | Used in generated SKILL.md                                        |
-| `context`      | `z.ZodType`                                  | no       | Zod schema for immutable skill-wide context                       |
-| `stash`        | `z.ZodType`                                  | no       | Zod schema for mutable cross-step state                           |
-| `finalOutput`  | `z.ZodType`                                  | no       | Schema for the terminal step's output                             |
-| `capabilities` | `CapabilityManifest`                         | no       | Declares host tools, filesystem, subprocess, env var requirements |
-| `observers`    | `ObserverMap`                                | no       | Lifecycle hooks (see [Observers](#observers))                     |
+| Field          | Type                                           | Required | Description                                                       |
+| -------------- | ---------------------------------------------- | -------- | ----------------------------------------------------------------- |
+| `name`         | `string`                                       | yes      | Skill identifier                                                  |
+| `entry`        | `string`                                       | yes      | Name of the first step                                            |
+| `version`      | `string`                                       | no       | Defaults to `'0.0.0'`                                             |
+| `description`  | `string`                                       | no       | Used in generated SKILL.md                                        |
+| `context`      | `z.ZodType`                                    | no       | Zod schema for immutable skill-wide context                       |
+| `stash`        | `z.ZodType`                                    | no       | Zod schema for mutable cross-step state                           |
+| `finalOutput`  | `z.ZodType`                                    | no       | Schema for the terminal step's output                             |
+| `capabilities` | `CapabilityManifest`                           | no       | Declares host tools, filesystem, subprocess, env var requirements |
+| `observers`    | `ObserverMap`                                  | no       | Lifecycle hooks (see [Observers](#observers))                     |
 | `skillMd`      | `string \| (skill: SkillDefinition) => string` | no       | Custom SKILL.md template override                                 |
 
 Context and stash types flow into step callbacks automatically via contextual inference — no annotations needed.
@@ -93,16 +93,16 @@ The full shape of a step's config object, passed to `.step()` or `step()`:
 
 Available in dynamic `prompt` and `render` functions:
 
-| Field      | Type                     | Description                                    |
-| ---------- | ------------------------ | ---------------------------------------------- |
-| `prev`     | `unknown`                | Output of the previous step                    |
-| `history`  | `readonly StepResult[]`  | All prior step results                         |
-| `context`  | `TContext`               | Immutable skill context (typed from builder)    |
-| `rendered` | `string \| undefined`     | Output of this step's `render()`, if present   |
-| `refs`     | `ReferenceLoader`        | Loader for `references/` files                 |
-| `attempts` | `number`                 | How many times this step has been visited       |
-| `host`     | `Handshake`              | Current host info and available tools          |
-| `stash`    | `Readonly<TStash>`       | Accumulated stash (typed from builder, frozen) |
+| Field      | Type                    | Description                                    |
+| ---------- | ----------------------- | ---------------------------------------------- |
+| `prev`     | `unknown`               | Output of the previous step                    |
+| `history`  | `readonly StepResult[]` | All prior step results                         |
+| `context`  | `TContext`              | Immutable skill context (typed from builder)   |
+| `rendered` | `string \| undefined`   | Output of this step's `render()`, if present   |
+| `refs`     | `ReferenceLoader`       | Loader for `references/` files                 |
+| `attempts` | `number`                | How many times this step has been visited      |
+| `host`     | `Handshake`             | Current host info and available tools          |
+| `stash`    | `Readonly<TStash>`      | Accumulated stash (typed from builder, frozen) |
 
 ### Transitions
 
@@ -152,11 +152,11 @@ reference({ name, description, version? })
 
 ### `reference()` config
 
-| Field         | Type     | Required | Description                        |
-| ------------- | -------- | -------- | ---------------------------------- |
-| `name`        | `string` | yes      | Reference skill identifier         |
-| `description` | `string` | yes      | Used in generated SKILL.md         |
-| `version`     | `string` | no       | Defaults to `'0.0.0'`             |
+| Field         | Type     | Required | Description                |
+| ------------- | -------- | -------- | -------------------------- |
+| `name`        | `string` | yes      | Reference skill identifier |
+| `description` | `string` | yes      | Used in generated SKILL.md |
+| `version`     | `string` | no       | Defaults to `'0.0.0'`      |
 
 ### `.topic(name, config)`
 
@@ -193,7 +193,7 @@ const authModule = module({
     prompt: 'Ask for credentials.',
     output: z.object({ userId: z.string() }),
     stash: ({ output }) => ({ userId: output.userId }),
-    next: '__parent__',  // exits back to the registering skill
+    next: '__parent__', // exits back to the registering skill
   })
   .build();
 ```
@@ -241,14 +241,14 @@ ask: askUser({
     { value: 'production', label: 'Production', description: 'Live traffic' },
     { value: 'staging', label: 'Staging' },
   ],
-  multiSelect: false,  // optional, defaults to false
-})
+  multiSelect: false, // optional, defaults to false
+});
 
 // Open — free-text conversation, never a structured tool
 ask: askUser({
   type: 'open',
   question: "What's your tech stack?",
-})
+});
 ```
 
 ### `confirm` — binary approval
@@ -258,9 +258,9 @@ import { confirm } from '@contentful/skill-kit';
 
 confirm: confirm({
   message: 'This will delete 47 files in .cache/. Continue?',
-  destructive: true,       // optional — adds warning in prose
-  defaultAnswer: 'no',     // optional — 'yes' or 'no'
-})
+  destructive: true, // optional — adds warning in prose
+  defaultAnswer: 'no', // optional — 'yes' or 'no'
+});
 ```
 
 Step output should include `{ approved: z.boolean() }`.
@@ -273,7 +273,7 @@ import { plan } from '@contentful/skill-kit';
 plan: plan({
   summary: 'Migrate database schema',
   steps: ['Backup current schema', 'Run migration', 'Validate'],
-})
+});
 ```
 
 ### `tasks` — tracked task list
@@ -286,7 +286,7 @@ tasks: tasks({
     { title: 'Lint config', status: 'pending' },
     { title: 'Test suite', status: 'pending' },
   ],
-})
+});
 ```
 
 ### `subtask` — spawn isolated sub-agent
@@ -297,21 +297,21 @@ import { subtask } from '@contentful/skill-kit';
 subtask: subtask({
   prompt: 'Review the PR for security issues.',
   output: z.object({ findings: z.array(z.string()) }),
-  contextBudget: 'narrow',  // optional: 'narrow' | 'normal' | 'wide'
-})
+  contextBudget: 'narrow', // optional: 'narrow' | 'normal' | 'wide'
+});
 ```
 
 ### Host-aware verb mapping
 
 The SDK uses an abstract verb system. Step prose contains verbs; the preamble (sent once at session start) maps them to host-specific behavior:
 
-| Verb             | Claude Code                       | Codex                   | OpenCode                | Generic                 |
-| ---------------- | --------------------------------- | ----------------------- | ----------------------- | ----------------------- |
-| `ASK_STRUCTURED` | `AskUserQuestion` tool            | Prose with option list  | Prose with option list  | Prose with option list  |
-| `ASK_FREEFORM`   | Plain text conversation           | Plain text conversation | Plain text conversation | Plain text conversation |
-| `PRESENT_PLAN`   | `EnterPlanMode` / `ExitPlanMode`  | `update_plan`           | Numbered list           | Numbered list           |
-| `CREATE_TASKS`   | `TaskCreate` / `TaskUpdate`       | `update_plan` checklist | `todowrite`             | Markdown checklist      |
-| `SPAWN_SUBTASK`  | `Agent` tool                      | Focus locally           | `task` tool             | Focus locally           |
+| Verb             | Claude Code                      | Codex                   | OpenCode                | Generic                 |
+| ---------------- | -------------------------------- | ----------------------- | ----------------------- | ----------------------- |
+| `ASK_STRUCTURED` | `AskUserQuestion` tool           | Prose with option list  | Prose with option list  | Prose with option list  |
+| `ASK_FREEFORM`   | Plain text conversation          | Plain text conversation | Plain text conversation | Plain text conversation |
+| `PRESENT_PLAN`   | `EnterPlanMode` / `ExitPlanMode` | `update_plan`           | Numbered list           | Numbered list           |
+| `CREATE_TASKS`   | `TaskCreate` / `TaskUpdate`      | `update_plan` checklist | `todowrite`             | Markdown checklist      |
+| `SPAWN_SUBTASK`  | `Agent` tool                     | Focus locally           | `task` tool             | Focus locally           |
 
 Same skill, every host. The preamble handles the translation.
 
@@ -364,6 +364,7 @@ const myPrompt = prompt`
 ```
 
 The `prompt` tag:
+
 1. Detects Fragment objects in interpolation slots (duck-typed: `{ name, content }`) and inserts their content
 2. Converts non-Fragment values to strings
 3. **Auto-dedents** the result: strips leading/trailing empty lines, then removes the minimum shared indentation from all lines
@@ -404,12 +405,12 @@ Attach to a step via the `action` field:
 
 ### `action()` config
 
-| Field    | Type                                                     | Required | Description                     |
-| -------- | -------------------------------------------------------- | -------- | ------------------------------- |
-| `name`   | `string`                                                 | yes      | Action identifier               |
-| `input`  | `z.ZodType`                                              | yes      | Schema for what the action receives |
-| `output` | `z.ZodType`                                              | yes      | Schema for what the action returns  |
-| `run`    | `(ctx: { input, signal: AbortSignal }) => Promise<output>` | yes      | Async function with typed I/O   |
+| Field    | Type                                                       | Required | Description                         |
+| -------- | ---------------------------------------------------------- | -------- | ----------------------------------- |
+| `name`   | `string`                                                   | yes      | Action identifier                   |
+| `input`  | `z.ZodType`                                                | yes      | Schema for what the action receives |
+| `output` | `z.ZodType`                                                | yes      | Schema for what the action returns  |
+| `run`    | `(ctx: { input, signal: AbortSignal }) => Promise<output>` | yes      | Async function with typed I/O       |
 
 The `run` function receives the step's validated output (parsed through `input` schema) and an `AbortSignal`. Action results are recorded in history alongside step outputs.
 
@@ -492,13 +493,23 @@ Lifecycle hooks for telemetry, logging, or analytics:
 skill({
   // ...
   observers: {
-    onStepStart: ({ step, context }) => { /* ... */ },
-    onStepComplete: ({ step, output, durationMs }) => { /* ... */ },
-    onStepValidationFailed: ({ step, raw, error, attempt }) => { /* ... */ },
-    onTransition: ({ from, to, reason }) => { /* ... */ },
-    onSkillComplete: ({ path, finalOutput, durationMs }) => { /* ... */ },
+    onStepStart: ({ step, context }) => {
+      /* ... */
+    },
+    onStepComplete: ({ step, output, durationMs }) => {
+      /* ... */
+    },
+    onStepValidationFailed: ({ step, raw, error, attempt }) => {
+      /* ... */
+    },
+    onTransition: ({ from, to, reason }) => {
+      /* ... */
+    },
+    onSkillComplete: ({ path, finalOutput, durationMs }) => {
+      /* ... */
+    },
   },
-})
+});
 ```
 
 Observers are fire-and-forget — they don't affect workflow execution. All are optional.
@@ -517,15 +528,17 @@ Drives a skill to completion with a model adapter:
 
 ```typescript
 const result = await runSkill(mySkill, {
-  context: { repoPath: '.' },   // optional — parsed against skill's context schema
-  model: mockModel({ /* ... */ }),
+  context: { repoPath: '.' }, // optional — parsed against skill's context schema
+  model: mockModel({
+    /* ... */
+  }),
   host: { host: 'claude-code' }, // optional — defaults to generic
 });
 
-result.path;      // string[] — sequence of step names visited
-result.outputs;   // Record<string, unknown> — raw model responses by step
-result.output;    // unknown — final output
-result.history;   // readonly StepResult[] — validated outputs + action results
+result.path; // string[] — sequence of step names visited
+result.outputs; // Record<string, unknown> — raw model responses by step
+result.output; // unknown — final output
+result.history; // readonly StepResult[] — validated outputs + action results
 ```
 
 ### `mockModel(map)`
@@ -534,13 +547,14 @@ Maps step names to canned responses:
 
 ```typescript
 mockModel({
-  diagnose: { checks: [{ name: 'ci', status: 'fail' }] },   // static value
-  remediate: [                                                 // array — cycles through on repeated visits
+  diagnose: { checks: [{ name: 'ci', status: 'fail' }] }, // static value
+  remediate: [
+    // array — cycles through on repeated visits
     { action: 'add CI' },
     { action: 'fix lint' },
   ],
-  report: (prompt) => ({ summary: prompt.includes('fail') ? 'issues found' : 'clean' }),  // function
-})
+  report: (prompt) => ({ summary: prompt.includes('fail') ? 'issues found' : 'clean' }), // function
+});
 ```
 
 - **Static value:** returns the same response every visit.
@@ -565,11 +579,11 @@ skill-kit build <entry.ts> -o <dir> --targets darwin-arm64,linux-x64,linux-arm64
 skill-kit build <entry.ts> -o <dir> --single   # current platform only (fast dev builds)
 ```
 
-| Flag        | Required | Description                                                                              |
-| ----------- | -------- | ---------------------------------------------------------------------------------------- |
-| `-o, --out` | yes      | Output directory                                                                         |
-| `--targets` | no       | Comma-separated platforms. Defaults to `darwin-arm64,linux-x64`                          |
-| `--single`  | no       | Build only for current platform                                                          |
+| Flag        | Required | Description                                                     |
+| ----------- | -------- | --------------------------------------------------------------- |
+| `-o, --out` | yes      | Output directory                                                |
+| `--targets` | no       | Comma-separated platforms. Defaults to `darwin-arm64,linux-x64` |
+| `--single`  | no       | Build only for current platform                                 |
 
 Output:
 
@@ -601,13 +615,13 @@ skill-kit check <entry.ts>
 
 Rules:
 
-| Rule                        | Severity | What it catches                                                         |
-| --------------------------- | -------- | ----------------------------------------------------------------------- |
-| `cycle-guard`               | error    | Circular step transitions without `maxVisits` + `onMaxVisits`           |
-| `no-host-tool-names`        | error    | Direct host tool name references without `host.toolsAvailable` guard    |
-| `primitive-schema-mismatch` | error    | `askUser` option values missing from output enum (or vice versa)        |
-| `orphan-references`         | warning  | Files in `references/` not mentioned in any step prompt                 |
-| `unknown-tool-names`        | warning  | `host.toolsAvailable.includes()` checks referencing unrecognized tools  |
+| Rule                        | Severity | What it catches                                                                |
+| --------------------------- | -------- | ------------------------------------------------------------------------------ |
+| `cycle-guard`               | error    | Circular step transitions without `maxVisits` + `onMaxVisits`                  |
+| `no-host-tool-names`        | error    | Direct host tool name references without `host.toolsAvailable` guard           |
+| `primitive-schema-mismatch` | error    | `askUser` option values missing from output enum (or vice versa)               |
+| `orphan-references`         | warning  | Files in `references/` not mentioned in any step prompt                        |
+| `unknown-tool-names`        | warning  | `host.toolsAvailable.includes()` checks referencing unrecognized tools         |
 | `host-branching-density`    | warning  | Multiple steps branching on `host.toolsAvailable` (suggests missing primitive) |
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,685 @@
+# API Reference
+
+Full reference for `@contentful/skill-kit`. Start with the [README](../README.md) for an overview.
+
+---
+
+## Workflow Builder
+
+```typescript
+import { skill, z } from '@contentful/skill-kit';
+
+skill({ name, entry, context?, stash?, observers?, capabilities?, finalOutput?, skillMd? })
+  .step(name, config)                       // add a step
+  .extend(name, sharedStep, overrides)      // inherit + override a shared step
+  .register(module, { next })               // merge module steps, widen stash type
+  .build()                                  // → SkillDefinition (frozen)
+```
+
+### `skill()` config
+
+| Field          | Type                                         | Required | Description                                                       |
+| -------------- | -------------------------------------------- | -------- | ----------------------------------------------------------------- |
+| `name`         | `string`                                     | yes      | Skill identifier                                                  |
+| `entry`        | `string`                                     | yes      | Name of the first step                                            |
+| `version`      | `string`                                     | no       | Defaults to `'0.0.0'`                                             |
+| `description`  | `string`                                     | no       | Used in generated SKILL.md                                        |
+| `context`      | `z.ZodType`                                  | no       | Zod schema for immutable skill-wide context                       |
+| `stash`        | `z.ZodType`                                  | no       | Zod schema for mutable cross-step state                           |
+| `finalOutput`  | `z.ZodType`                                  | no       | Schema for the terminal step's output                             |
+| `capabilities` | `CapabilityManifest`                         | no       | Declares host tools, filesystem, subprocess, env var requirements |
+| `observers`    | `ObserverMap`                                | no       | Lifecycle hooks (see [Observers](#observers))                     |
+| `skillMd`      | `string \| (skill: SkillDefinition) => string` | no       | Custom SKILL.md template override                                 |
+
+Context and stash types flow into step callbacks automatically via contextual inference — no annotations needed.
+
+### `.step(name, config)`
+
+Adds a step. Returns the builder for chaining. See [Step Config](#step-config) for the full config shape.
+
+### `.extend(name, base, overrides)`
+
+Inherits a shared step definition and overrides specific fields. The base step's config is shallow-merged with overrides (overrides win).
+
+```typescript
+import { step, z } from '@contentful/skill-kit';
+
+const openQuestion = step({
+  output: z.object({ answer: z.string() }),
+  next: '__parent__',
+});
+
+// In the builder:
+.extend('ask-stack', openQuestion, {
+  ask: askUser({ type: 'open', question: "What's your tech stack?" }),
+  prompt: ({ stash }) => `Ask ${stash.name} about their tech stack.`,
+  next: 'ask-hobby',
+})
+```
+
+### `.register(module, { next })`
+
+Merges all steps from a module into the skill. Module steps with `next: '__parent__'` are rewritten to point to `next`. Stash types widen automatically — see [Modules](#modules).
+
+### `.build()`
+
+Validates the skill definition (entry exists, steps non-empty) and returns a frozen `SkillDefinition`. Throws on invalid configuration.
+
+---
+
+## Step Config
+
+The full shape of a step's config object, passed to `.step()` or `step()`:
+
+```typescript
+{
+  prompt: string | (ctx: PromptContext) => string,
+  output: z.ZodType,                                      // required
+  next: 'step-name' | ((ctx) => 'step-name') | { terminal: true },  // required
+  render?: (ctx: PromptContext) => string,
+  action?: ActionDefinition,
+  stash?: (ctx: { output }) => Partial<TStash>,
+  maxVisits?: number,
+  onMaxVisits?: string,
+  ask?: AskUserConfig,
+  confirm?: ConfirmConfig,
+  plan?: PlanConfig,
+  tasks?: TasksConfig,
+  subtask?: SubtaskConfig,
+}
+```
+
+### PromptContext
+
+Available in dynamic `prompt` and `render` functions:
+
+| Field      | Type                     | Description                                    |
+| ---------- | ------------------------ | ---------------------------------------------- |
+| `prev`     | `unknown`                | Output of the previous step                    |
+| `history`  | `readonly StepResult[]`  | All prior step results                         |
+| `context`  | `TContext`               | Immutable skill context (typed from builder)    |
+| `rendered` | `string \| undefined`     | Output of this step's `render()`, if present   |
+| `refs`     | `ReferenceLoader`        | Loader for `references/` files                 |
+| `attempts` | `number`                 | How many times this step has been visited       |
+| `host`     | `Handshake`              | Current host info and available tools          |
+| `stash`    | `Readonly<TStash>`       | Accumulated stash (typed from builder, frozen) |
+
+### Transitions
+
+- **Static:** `next: 'step-name'` — always goes to the named step.
+- **Dynamic:** `next: ({ output, attempts }) => 'step-name'` — choose based on output or visit count.
+- **Terminal:** `next: { terminal: true }` — ends the skill. Output becomes `finalOutput`.
+- **Self:** `next: 'self'` or returning the current step name — revisit the same step (requires `maxVisits`).
+
+### Loop guards
+
+Any step that can revisit itself (directly or through a cycle) must declare `maxVisits` and `onMaxVisits`:
+
+```typescript
+.step('ask-hobby', {
+  // ...
+  maxVisits: 3,
+  onMaxVisits: 'confirm-profile',  // fallback when limit hit
+  next: ({ output }) => output.wantsMore ? 'ask-hobby' : 'confirm-profile',
+})
+```
+
+Enforced at load time by the cycle guard validator.
+
+### Stash merging
+
+The `stash` callback receives the validated output and returns a partial stash object. The return value is shallow-merged into the accumulated stash:
+
+```typescript
+stash: ({ output }) => ({ target: output.target }),
+```
+
+All outputs and stash values are frozen with `Object.freeze()` to prevent mutation.
+
+---
+
+## Reference Builder
+
+For skills that don't need a workflow — just progressive disclosure of content:
+
+```typescript
+import { reference } from '@contentful/skill-kit';
+
+reference({ name, description, version? })
+  .topic(name, { label, content: (ctx) => string })
+  .build()                                           // → ReferenceDefinition (frozen)
+```
+
+### `reference()` config
+
+| Field         | Type     | Required | Description                        |
+| ------------- | -------- | -------- | ---------------------------------- |
+| `name`        | `string` | yes      | Reference skill identifier         |
+| `description` | `string` | yes      | Used in generated SKILL.md         |
+| `version`     | `string` | no       | Defaults to `'0.0.0'`             |
+
+### `.topic(name, config)`
+
+Registers a topic. `content` is a lazy function receiving `{ refs: ReferenceLoader }`:
+
+```typescript
+.topic('auth', {
+  label: 'Authentication and token management',
+  content: ({ refs }) => refs.load('auth.md'),
+})
+.topic('errors', {
+  label: 'Error codes and troubleshooting',
+  content: () => render.table(ERROR_CODES, { columns: ['code', 'meaning', 'fix'] }),
+})
+```
+
+At least one topic is required. `build()` throws if name, description, or topics are missing.
+
+---
+
+## Modules
+
+Composable step groups with their own stash scope:
+
+```typescript
+import { module, z } from '@contentful/skill-kit';
+
+const authModule = module({
+  name: 'auth',
+  entry: 'auth-login',
+  stash: z.object({ userId: z.string() }),
+})
+  .step('auth-login', {
+    prompt: 'Ask for credentials.',
+    output: z.object({ userId: z.string() }),
+    stash: ({ output }) => ({ userId: output.userId }),
+    next: '__parent__',  // exits back to the registering skill
+  })
+  .build();
+```
+
+Register into a skill — stash types merge automatically:
+
+```typescript
+skill({ name: 'app', entry: 'start', stash: z.object({ appName: z.string() }) })
+  .step('start', { /* ... */ next: 'auth-login' })
+  .register(authModule, { next: 'dashboard' })
+  .step('dashboard', {
+    // stash is now { appName: string } & { userId: string }
+    prompt: ({ stash }) => `Welcome ${stash.userId} to ${stash.appName}`,
+    // ...
+  })
+  .build();
+```
+
+### `module()` config
+
+| Field   | Type        | Required | Description                  |
+| ------- | ----------- | -------- | ---------------------------- |
+| `name`  | `string`    | yes      | Module identifier            |
+| `entry` | `string`    | yes      | Entry step within the module |
+| `stash` | `z.ZodType` | yes      | Local state schema           |
+
+The `__parent__` sentinel in `next` is rewritten to the `{ next }` value passed to `.register()`. Module steps that don't use `__parent__` pass through unchanged.
+
+---
+
+## Primitives
+
+Interactive building blocks that generate host-aware prose. Authors describe intent; the SDK translates to host-specific tool instructions.
+
+### `askUser` — structured or open
+
+```typescript
+import { askUser } from '@contentful/skill-kit';
+
+// Structured — fixed options, host uses best available tool
+ask: askUser({
+  type: 'structured',
+  question: 'Which environment?',
+  options: [
+    { value: 'production', label: 'Production', description: 'Live traffic' },
+    { value: 'staging', label: 'Staging' },
+  ],
+  multiSelect: false,  // optional, defaults to false
+})
+
+// Open — free-text conversation, never a structured tool
+ask: askUser({
+  type: 'open',
+  question: "What's your tech stack?",
+})
+```
+
+### `confirm` — binary approval
+
+```typescript
+import { confirm } from '@contentful/skill-kit';
+
+confirm: confirm({
+  message: 'This will delete 47 files in .cache/. Continue?',
+  destructive: true,       // optional — adds warning in prose
+  defaultAnswer: 'no',     // optional — 'yes' or 'no'
+})
+```
+
+Step output should include `{ approved: z.boolean() }`.
+
+### `plan` — present and approve
+
+```typescript
+import { plan } from '@contentful/skill-kit';
+
+plan: plan({
+  summary: 'Migrate database schema',
+  steps: ['Backup current schema', 'Run migration', 'Validate'],
+})
+```
+
+### `tasks` — tracked task list
+
+```typescript
+import { tasks } from '@contentful/skill-kit';
+
+tasks: tasks({
+  create: [
+    { title: 'Lint config', status: 'pending' },
+    { title: 'Test suite', status: 'pending' },
+  ],
+})
+```
+
+### `subtask` — spawn isolated sub-agent
+
+```typescript
+import { subtask } from '@contentful/skill-kit';
+
+subtask: subtask({
+  prompt: 'Review the PR for security issues.',
+  output: z.object({ findings: z.array(z.string()) }),
+  contextBudget: 'narrow',  // optional: 'narrow' | 'normal' | 'wide'
+})
+```
+
+### Host-aware verb mapping
+
+The SDK uses an abstract verb system. Step prose contains verbs; the preamble (sent once at session start) maps them to host-specific behavior:
+
+| Verb             | Claude Code                       | Codex                   | OpenCode                | Generic                 |
+| ---------------- | --------------------------------- | ----------------------- | ----------------------- | ----------------------- |
+| `ASK_STRUCTURED` | `AskUserQuestion` tool            | Prose with option list  | Prose with option list  | Prose with option list  |
+| `ASK_FREEFORM`   | Plain text conversation           | Plain text conversation | Plain text conversation | Plain text conversation |
+| `PRESENT_PLAN`   | `EnterPlanMode` / `ExitPlanMode`  | `update_plan`           | Numbered list           | Numbered list           |
+| `CREATE_TASKS`   | `TaskCreate` / `TaskUpdate`       | `update_plan` checklist | `todowrite`             | Markdown checklist      |
+| `SPAWN_SUBTASK`  | `Agent` tool                      | Focus locally           | `task` tool             | Focus locally           |
+
+Same skill, every host. The preamble handles the translation.
+
+---
+
+## Standalone Steps
+
+For shared, reusable steps defined outside a skill:
+
+```typescript
+import { step, z } from '@contentful/skill-kit';
+
+const openQuestion = step({
+  output: z.object({ answer: z.string() }),
+  next: '__parent__',
+});
+```
+
+Both `output` and `next` are required. Use via `.extend()` on the builder to get typed overrides that respect the parent skill's context/stash types.
+
+---
+
+## Fragments and Prompts
+
+### `fragment()` — named prose snippet
+
+```typescript
+import { fragment } from '@contentful/skill-kit';
+
+const playfulTone = fragment(
+  'playful-tone',
+  `Keep it light and fun. Use casual language.
+   Throw in a joke if it fits.`,
+);
+```
+
+Creates an immutable `{ name, content }` object. Content is trimmed on creation.
+
+### `prompt` — tagged template literal
+
+```typescript
+import { prompt } from '@contentful/skill-kit';
+
+const myPrompt = prompt`
+  ${playfulTone}
+
+  Now ask the user about their hobbies.
+  Be specific — "sports" is boring, "underwater basket weaving" is a personality.
+`;
+```
+
+The `prompt` tag:
+1. Detects Fragment objects in interpolation slots (duck-typed: `{ name, content }`) and inserts their content
+2. Converts non-Fragment values to strings
+3. **Auto-dedents** the result: strips leading/trailing empty lines, then removes the minimum shared indentation from all lines
+
+This means you can indent `prompt` blocks naturally in your code without the indentation leaking into the output.
+
+---
+
+## Actions
+
+Side effects that run after a step's output is validated:
+
+```typescript
+import { action, z } from '@contentful/skill-kit';
+
+const writeProfile = action({
+  name: 'write-profile',
+  input: z.object({ profile: ProfileSchema }),
+  output: z.object({ path: z.string() }),
+  run: async ({ input, signal }) => {
+    const path = `/tmp/profile-${Date.now()}.json`;
+    await writeFile(path, JSON.stringify(input.profile));
+    return { path };
+  },
+});
+```
+
+Attach to a step via the `action` field:
+
+```typescript
+.step('save', {
+  prompt: 'Generate the profile.',
+  output: z.object({ profile: ProfileSchema }),
+  action: writeProfile,
+  next: { terminal: true },
+})
+```
+
+### `action()` config
+
+| Field    | Type                                                     | Required | Description                     |
+| -------- | -------------------------------------------------------- | -------- | ------------------------------- |
+| `name`   | `string`                                                 | yes      | Action identifier               |
+| `input`  | `z.ZodType`                                              | yes      | Schema for what the action receives |
+| `output` | `z.ZodType`                                              | yes      | Schema for what the action returns  |
+| `run`    | `(ctx: { input, signal: AbortSignal }) => Promise<output>` | yes      | Async function with typed I/O   |
+
+The `run` function receives the step's validated output (parsed through `input` schema) and an `AbortSignal`. Action results are recorded in history alongside step outputs.
+
+---
+
+## Render Helpers
+
+Formatting utilities for generating markdown output in step prompts and render functions:
+
+```typescript
+import { render } from '@contentful/skill-kit';
+```
+
+### `render.table(rows, opts?)`
+
+```typescript
+render.table(
+  [
+    { name: 'ci', status: 'fail', detail: 'no config' },
+    { name: 'lint', status: 'pass', detail: 'eslint configured' },
+  ],
+  { columns: ['name', 'status', 'detail'] },
+);
+```
+
+Options: `columns?: string[]` (column order, defaults to first row's keys), `statusIcons?: Record<string, string>` (custom icons for status column values). Returns empty string for empty rows.
+
+### `render.checklist(items)`
+
+```typescript
+render.checklist([
+  { text: 'TypeScript', done: true },
+  { text: 'Bun', done: true },
+  { text: 'Deploy script', done: false },
+]);
+// - [x] TypeScript
+// - [x] Bun
+// - [ ] Deploy script
+```
+
+### `render.code(source, lang?)`
+
+```typescript
+render.code('const x = 42;', 'typescript');
+```
+
+Wraps in triple-backtick fence with optional language tag.
+
+### `render.kv(pairs)`
+
+```typescript
+render.kv({ Name: 'Alice', Role: 'Developer', Stack: 'TypeScript + Bun' });
+// Name   Alice
+// Role   Developer
+// Stack  TypeScript + Bun
+```
+
+Keys are padded to the longest key length. Returns empty string for empty input.
+
+### `render.section(title, body)`
+
+```typescript
+render.section('Health Checks', render.table(checks));
+// ## Health Checks
+//
+// | name | status | ...
+```
+
+### `render.diff(before, after)`
+
+Line-by-line diff with `--- before` / `+++ after` headers. Unchanged lines prefixed with space, removed with `-`, added with `+`.
+
+---
+
+## Observers
+
+Lifecycle hooks for telemetry, logging, or analytics:
+
+```typescript
+skill({
+  // ...
+  observers: {
+    onStepStart: ({ step, context }) => { /* ... */ },
+    onStepComplete: ({ step, output, durationMs }) => { /* ... */ },
+    onStepValidationFailed: ({ step, raw, error, attempt }) => { /* ... */ },
+    onTransition: ({ from, to, reason }) => { /* ... */ },
+    onSkillComplete: ({ path, finalOutput, durationMs }) => { /* ... */ },
+  },
+})
+```
+
+Observers are fire-and-forget — they don't affect workflow execution. All are optional.
+
+---
+
+## Testing
+
+```typescript
+import { runSkill, mockModel } from '@contentful/skill-kit/test';
+```
+
+### `runSkill(skill, opts)`
+
+Drives a skill to completion with a model adapter:
+
+```typescript
+const result = await runSkill(mySkill, {
+  context: { repoPath: '.' },   // optional — parsed against skill's context schema
+  model: mockModel({ /* ... */ }),
+  host: { host: 'claude-code' }, // optional — defaults to generic
+});
+
+result.path;      // string[] — sequence of step names visited
+result.outputs;   // Record<string, unknown> — raw model responses by step
+result.output;    // unknown — final output
+result.history;   // readonly StepResult[] — validated outputs + action results
+```
+
+### `mockModel(map)`
+
+Maps step names to canned responses:
+
+```typescript
+mockModel({
+  diagnose: { checks: [{ name: 'ci', status: 'fail' }] },   // static value
+  remediate: [                                                 // array — cycles through on repeated visits
+    { action: 'add CI' },
+    { action: 'fix lint' },
+  ],
+  report: (prompt) => ({ summary: prompt.includes('fail') ? 'issues found' : 'clean' }),  // function
+})
+```
+
+- **Static value:** returns the same response every visit.
+- **Array:** cycles through entries on repeated visits. Throws if exhausted.
+- **Function:** called with the step's prompt string. Can return conditional responses.
+
+### `liveModel()`
+
+Interactive testing adapter for manual evaluation. Not yet implemented in v0.1.
+
+---
+
+## CLI Commands
+
+### `skill-kit build`
+
+Compiles a skill into a distributable [agentskills.io](https://agentskills.io/specification)-compliant directory:
+
+```bash
+skill-kit build <entry.ts> -o <dir>
+skill-kit build <entry.ts> -o <dir> --targets darwin-arm64,linux-x64,linux-arm64
+skill-kit build <entry.ts> -o <dir> --single   # current platform only (fast dev builds)
+```
+
+| Flag        | Required | Description                                                                              |
+| ----------- | -------- | ---------------------------------------------------------------------------------------- |
+| `-o, --out` | yes      | Output directory                                                                         |
+| `--targets` | no       | Comma-separated platforms. Defaults to `darwin-arm64,linux-x64`                          |
+| `--single`  | no       | Build only for current platform                                                          |
+
+Output:
+
+```
+<dir>/
+  SKILL.md               ← Generated agent-facing docs
+  package.json           ← Name and version
+  scripts/run            ← Shell wrapper (public interface)
+  bin/<name>-<platform>  ← Compiled Bun executables
+  references/            ← Copied from source
+```
+
+### `skill-kit run`
+
+Dev mode — run a skill without compiling:
+
+```bash
+skill-kit run <entry.ts> start --context '{}' --host claude-code
+skill-kit run <entry.ts> advance --step greet --output '{"name":"Alice"}' --history '[]' --host claude-code
+```
+
+### `skill-kit check`
+
+Lint a skill for portability and correctness issues:
+
+```bash
+skill-kit check <entry.ts>
+```
+
+Rules:
+
+| Rule                        | Severity | What it catches                                                         |
+| --------------------------- | -------- | ----------------------------------------------------------------------- |
+| `cycle-guard`               | error    | Circular step transitions without `maxVisits` + `onMaxVisits`           |
+| `no-host-tool-names`        | error    | Direct host tool name references without `host.toolsAvailable` guard    |
+| `primitive-schema-mismatch` | error    | `askUser` option values missing from output enum (or vice versa)        |
+| `orphan-references`         | warning  | Files in `references/` not mentioned in any step prompt                 |
+| `unknown-tool-names`        | warning  | `host.toolsAvailable.includes()` checks referencing unrecognized tools  |
+| `host-branching-density`    | warning  | Multiple steps branching on `host.toolsAvailable` (suggests missing primitive) |
+
+---
+
+## Worked Example: deploy-check
+
+A complete skill showing context, stash, `askUser`, branching, and terminal steps:
+
+```typescript
+import { skill, z, askUser } from '@contentful/skill-kit';
+
+export default skill({
+  name: 'deploy-check',
+  entry: 'choose',
+  context: z.object({ env: z.string().default('staging') }),
+  stash: z.object({ target: z.string() }),
+})
+  .step('choose', {
+    ask: askUser({
+      type: 'structured',
+      question: 'Which environment?',
+      options: [
+        { value: 'production', label: 'Production' },
+        { value: 'staging', label: 'Staging' },
+      ],
+    }),
+    output: z.object({ target: z.enum(['production', 'staging']) }),
+    stash: ({ output }) => ({ target: output.target }),
+    next: 'verify',
+  })
+  .step('verify', {
+    prompt: ({ stash }) => `Run pre-deploy checks for ${stash.target}. Report any blockers.`,
+    output: z.object({ blockers: z.array(z.string()), safe: z.boolean() }),
+    next: ({ output }) => (output.safe ? 'deploy' : 'abort'),
+  })
+  .step('deploy', {
+    prompt: 'Execute the deployment.',
+    output: z.object({ url: z.string() }),
+    next: { terminal: true },
+  })
+  .step('abort', {
+    prompt: 'Report the blockers and explain why deployment was aborted.',
+    output: z.object({ summary: z.string() }),
+    next: { terminal: true },
+  })
+  .build();
+```
+
+**What's happening:**
+
+1. **`choose`** — Uses `askUser` structured to present environment options. The agent sees the options via host-appropriate tooling (AskUserQuestion on Claude Code, prose list elsewhere). The selected value is stashed for later steps.
+
+2. **`verify`** — Dynamic prompt reads `stash.target` to customize the instruction. Output schema enforces a `safe` boolean that drives the branch.
+
+3. **`deploy` / `abort`** — Two terminal paths. The skill ends cleanly regardless of which path is taken.
+
+**Testing it:**
+
+```typescript
+import { runSkill, mockModel } from '@contentful/skill-kit/test';
+import deploy from './skill.ts';
+
+const result = await runSkill(deploy, {
+  model: mockModel({
+    choose: { target: 'staging' },
+    verify: { blockers: [], safe: true },
+    deploy: { url: 'https://staging.example.com' },
+  }),
+});
+
+// result.path → ['choose', 'verify', 'deploy']
+// result.output → { url: 'https://staging.example.com' }
+```
+
+Context and stash types flow end-to-end — `stash.target` in the `verify` prompt is typed as `string`, and the `choose` step's stash callback is checked against the declared stash schema. No type annotations needed anywhere.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,307 @@
+# Architecture
+
+How `@contentful/skill-kit` works internally. For the author-facing API, see [api.md](./api.md). For the full specification, see [SPEC.md](../SPEC.md).
+
+---
+
+## The Stateless CLI Protocol
+
+A compiled skill is a binary invoked by agents via Bash — one call per step. Each call is stateless: the agent passes the full conversation history on every invocation. JSON goes to stdout, diagnostics to stderr.
+
+### Lifecycle
+
+**1. Start** — Agent calls `scripts/run start`:
+
+```bash
+scripts/run start --context '{"repoPath":"."}' --host claude-code
+```
+
+Returns a `PromptResult`:
+
+```json
+{
+  "preamble": "In this session you will follow a structured workflow...",
+  "step": "diagnose",
+  "prompt": "Inspect the repository and report failed health checks.",
+  "schema": { "type": "object", "properties": { "checks": { ... } } }
+}
+```
+
+The preamble is emitted once. It establishes session-wide conventions (verb mappings, rendering rules) so that later step prompts can be shorter.
+
+**2. Advance** — Agent submits output, gets next step:
+
+```bash
+scripts/run advance \
+  --step diagnose \
+  --output '{"checks":[{"name":"ci","status":"fail","detail":"no config"}]}' \
+  --history '[{"step":"diagnose","output":{...}}]' \
+  --host claude-code
+```
+
+Returns another `PromptResult` (next step) or a `DoneResult`:
+
+```json
+{ "done": true, "finalOutput": { "summary": "..." }, "completed": { "step": "report", "output": { ... } } }
+```
+
+**3. Validation error** — If the agent's output doesn't match the step schema:
+
+```json
+{ "error": "validation", "step": "diagnose", "message": "Expected object, received string", "retry": true }
+```
+
+The agent retries with corrected output. The `retry: true` flag tells the agent the step hasn't advanced.
+
+### CLI Flags
+
+| Flag        | Required     | Description                                                    |
+| ----------- | ------------ | -------------------------------------------------------------- |
+| `--context` | On `start`   | JSON string validated against the skill's context schema       |
+| `--step`    | On `advance` | Name of the step whose output is being submitted               |
+| `--output`  | On `advance` | JSON string — the agent's response for the step                |
+| `--history` | On `advance` | JSON array of `{ step, output, action? }` — full history       |
+| `--host`    | Optional     | Host identifier: `claude-code`, `codex`, `opencode`, `generic` |
+
+### Why stateless
+
+No persistent processes, no stdin piping, no subprocess lifecycle management. The agent makes sequential Bash calls and parses JSON — a pattern every agent host supports today. Statelessness also enables horizontal scaling, resumable workflows, and retry/redo logic without session corruption.
+
+History replay is cheap. The engine reconstructs state (stash, visit counts) from history data without re-executing actions or observers.
+
+---
+
+## The Host-Aware Prose System
+
+### The architectural constraint
+
+The skill CLI cannot call tools. It cannot invoke MCP methods. It cannot cause the host to render UI. Only the model can do those things, and only in response to prose it reads.
+
+When the SDK wants the model to use `AskUserQuestion` on Claude Code, all it can do is return prose that names the tool and describes how to use it. The model reads the prose, decides to call the tool, and passes the answer back on the next invocation. The answer shape is still enforced by the step's Zod schema.
+
+Everything in the host-aware system is downstream of this constraint. Primitives are prose generators with host-aware variants. The "capability system" is a lookup table that picks which variant to emit.
+
+### Two mechanisms
+
+**Preamble at session start.** Generated once per skill invocation. Establishes session conventions:
+
+> _When a step says "ASK_STRUCTURED", use the AskUserQuestion tool with exact options. When a step provides a "Rendered output" block, emit it verbatim. When a step says "SPAWN_SUBTASK", use the Agent tool._
+
+The preamble is generated per host — different tool names, different emphasis, same semantics. Later step prompts can be shorter because the preamble has set the context.
+
+Preambles are best-effort — the model may forget them under context pressure. For critical primitives, per-step prose also names the tool explicitly. Preambles optimize the common case; per-step prose guards correctness.
+
+**Per-step prose generation.** For any step using a primitive (`ask`, `confirm`, `plan`, `tasks`, `subtask`), the SDK generates prose calibrated to the current host. On Claude Code, an `askUser` step emits:
+
+> _Use the AskUserQuestion tool to ask: "Which target?" Options (pass exactly these values): "production", "staging". Do not modify option text._
+
+On a host without a structured-question tool:
+
+> _Ask the user: "Which target?" Present these options and no others: production, staging. Accept only a single answer matching one of those exact strings._
+
+### Prose generator resolution
+
+`resolveProseGenerator(handshake)` picks the generator by checking `handshake.toolsAvailable` for host-identifying tools. Falls back to the `handshake.host` name, then to `generic`.
+
+Each generator implements the `ProseGenerator` interface:
+
+```typescript
+interface ProseGenerator {
+  askUser(config: AskUserConfig): string;
+  confirm(config: ConfirmConfig): string;
+  plan(config: PlanConfig): string;
+  tasks(config: TasksConfig): string;
+  subtask(config: SubtaskConfig): string;
+}
+```
+
+Implementations exist for `claude-code`, `codex`, `opencode`, and `generic`.
+
+### Why primitives matter
+
+Three reasons, all load-bearing:
+
+1. **Centralized tuning.** The SDK owns the prose that produces reliable behavior per host. One tuning pass benefits every skill.
+2. **Host portability.** Authors write intent once; the SDK translates per host. No hardcoded tool names to break on a different agent.
+3. **SDK improvements propagate.** Better phrasing for Codex six months from now ships as an SDK update. Every skill using primitives gets it for free.
+
+Skills written against primitives inherit prompt-engineering work done in the SDK. Skills written as raw prose don't.
+
+### Escape hatch
+
+For cases where author-written prose must be host-aware, `PromptContext.host.toolsAvailable` is available in prompt functions:
+
+```typescript
+prompt: ({ host }) => {
+  if (host.toolsAvailable.includes('WebSearch')) {
+    return 'Search the web for recent CVEs affecting this dependency.';
+  }
+  return 'Check the changelog for known security issues.';
+},
+```
+
+The lint rule `no-host-tool-names` enforces that raw tool names only appear inside `host.toolsAvailable.includes()` guards.
+
+### Known host tool inventories
+
+**Claude Code:** AskUserQuestion, EnterPlanMode, ExitPlanMode, TaskCreate, TaskUpdate, TaskList, TaskGet, Agent, Skill, Read, Edit, Write, Bash, Glob, Grep, WebFetch, WebSearch, TodoWrite, and others.
+
+**Codex CLI:** shell, apply_patch, update_plan, web_search, view_image, request_permissions, exec_command, write_stdin.
+
+**OpenCode:** bash, read, write, edit, apply_patch, multiedit, glob, grep, list, webfetch, task, todowrite, todoread, skill, optional lsp.
+
+---
+
+## The Build Pipeline
+
+`skill-kit build <entry.ts> -o <dir>` produces a distributable, [agentskills.io](https://agentskills.io/specification)-compliant skill directory.
+
+### Pipeline steps
+
+1. **Load** — Import the entry file, extract the default export (must be a `SkillDefinition` or `ReferenceDefinition`).
+2. **Validate** — Run lint checks (cycle guards, schema consistency).
+3. **Generate wrapper** — Create a temporary entry point that imports the skill and calls `main()` from `@contentful/skill-kit/cli`.
+4. **Compile** — For each target platform, run `bun build --compile --target bun-<platform>`. Individual target failures don't halt the pipeline; zero successful targets does.
+5. **Generate scripts/run** — Shell wrapper that detects OS/architecture and delegates to the correct binary in `bin/`.
+6. **Generate SKILL.md** — Agent-facing documentation with invocation instructions, step descriptions, and reference pointers.
+7. **Generate package.json** — Minimal metadata (name, version).
+8. **Copy references/** — Markdown files from the source `references/` directory.
+9. **Clean up** — Remove temporary wrapper files.
+
+### Output structure
+
+```
+<dir>/
+  SKILL.md               ← Agent reads this first
+  package.json
+  scripts/
+    run                  ← Public interface (chmod +x)
+  bin/
+    <name>-darwin-arm64  ← macOS Apple Silicon
+    <name>-darwin-x64    ← macOS Intel
+    <name>-linux-x64     ← Linux x86_64
+    <name>-linux-arm64   ← Linux ARM
+  references/
+    *.md                 ← Bundled content files
+```
+
+Default targets: `darwin-arm64` and `linux-x64`. Override with `--targets`. Use `--single` for current-platform-only dev builds.
+
+### The scripts/run wrapper
+
+Agents call `scripts/run`, never `bin/` directly. The wrapper detects the current platform, selects the correct binary, and execs it with all arguments forwarded:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "$ARCH" in x86_64) ARCH="x64" ;; aarch64|arm64) ARCH="arm64" ;; esac
+BIN="$SKILL_DIR/bin/<name>-${OS}-${ARCH}"
+exec "$BIN" "$@"
+```
+
+This decouples the skill's contract (SKILL.md references `scripts/run`) from its internal layout.
+
+### The compile step
+
+The SDK generates a temporary entry point:
+
+```typescript
+import skill from './skill';
+import { main } from '@contentful/skill-kit/cli';
+main(skill);
+```
+
+`bun build --compile` bundles everything — the SDK, Zod, the skill code — into a single self-contained executable. The SDK itself has no Bun runtime dependency; Bun is used only as a build tool.
+
+---
+
+## Engine Internals
+
+The `WorkflowEngine` (`src/runtime/engine.ts`) is the core state machine.
+
+### Lifecycle
+
+**Constructor** — Takes a `SkillDefinition`, `Handshake`, context, and optional `ReferenceLoader`. Initializes the stash store and prose generator.
+
+**`start()`** — Validates the skill structure (parent sentinels resolved, cycle guards present). Generates the preamble. Fires `onStepStart`. Returns the first step's `PromptResult`.
+
+**`advance(stepName, rawOutput)`** — The main loop:
+
+1. **Validate** output against step's Zod schema via `safeParse()`.
+2. If invalid: fire `onStepValidationFailed`, return `ValidationErrorResult` with `retry: true`.
+3. **Merge stash** via the step's `stash()` callback (if present). Shallow merge into accumulator.
+4. **Execute action** (if configured). Action receives typed input and AbortSignal. Result recorded in history.
+5. **Freeze** the output object.
+6. **Append** to history.
+7. Fire `onStepComplete`.
+8. **Resolve next step:**
+   - `{ terminal: true }` → fire `onSkillComplete`, return `DoneResult`.
+   - Function → call with `{ output, attempts }`, get step name.
+   - `'self'` → rewrite to current step name.
+   - Apply `maxVisits` / `onMaxVisits` throttle.
+9. Fire `onTransition`.
+10. Return next step's `PromptResult`.
+
+### History replay
+
+`replayHistory(history)` reconstructs engine state from a previous execution. It validates each entry's output against the step schema and re-merges stash, but does not re-execute actions or fire observers. This is how the stateless protocol works — each `advance` call replays the full history to rebuild state before processing the new step.
+
+### StashStore
+
+Merge-only accumulator. Each `stash()` callback returns a partial stash object that's shallow-merged (`Object.assign`) into the current state. Values are frozen after merge. No deletions, no deep merges.
+
+### Observer dispatch
+
+Observers fire sequentially and are awaited (they can be async), but failures are caught and logged — they never block workflow execution. Observers receive read-only snapshots of engine state.
+
+---
+
+## Lint System
+
+`checkSkill(skill, rootDir)` runs static analysis on a skill definition. Returns an array of `LintDiagnostic` objects:
+
+```typescript
+interface LintDiagnostic {
+  rule: string;
+  severity: 'error' | 'warning';
+  message: string;
+  step?: string;
+  file?: string;
+}
+```
+
+### Rules
+
+**`cycle-guard`** (error) — Detects circular step transitions (self-loops and multi-step cycles) that lack `maxVisits` + `onMaxVisits`. Enforced at validation time, before the engine runs.
+
+**`no-host-tool-names`** (error) — Steps must not reference host tool names directly (e.g., `AskUserQuestion`, `apply_patch`, `TodoWrite`) in prompts without guarding behind `host.toolsAvailable.includes('ToolName')`. Scans both string prompts and function `.toString()` output. The guard pattern exempts the reference.
+
+**`primitive-schema-mismatch`** (error/warning) — For steps with `askUser` structured type: errors if option values are missing from the output Zod enum, warns if the enum has values not present in the options list.
+
+**`orphan-references`** (warning) — Files in the `references/` directory that aren't mentioned in any step prompt. May indicate dead content.
+
+**`unknown-tool-names`** (warning) — `host.toolsAvailable.includes()` calls that reference tool names not in the known registry (40+ tools across Claude Code, Codex, and OpenCode).
+
+**`host-branching-density`** (warning) — Multiple steps branching on `host.toolsAvailable.includes()`. Suggests a missing SDK primitive — if several steps need host-specific logic, the pattern should probably be elevated to a primitive.
+
+---
+
+## Design Decisions
+
+These are non-negotiable choices with specific rationale. For the full list, see [SPEC.md §14](../SPEC.md).
+
+**State is append-only.** Prior step outputs are never mutated. The stash accumulates via shallow merge; history is a linear append. This enables history replay — the engine can reconstruct state from data without re-executing side effects.
+
+**Cycles require explicit bounds.** Every loop must declare `maxVisits` and `onMaxVisits`. Enforced at load time by the cycle guard validator, not at runtime. An unguarded cycle is a build error, not a runtime surprise.
+
+**Capabilities are declared, not discovered.** Skills declare what host capabilities they need upfront via the `capabilities` manifest. The harness reads this at install time. No runtime probing.
+
+**Actions are declared, not inferred.** Any CLI-side side effect must exist as a named `action()` with typed input/output schemas. No implicit I/O in step callbacks.
+
+**Steps are named string keys.** The state machine is inspectable as data. Transitions reference step names as strings, not closures. This makes the workflow diffable, serializable, and debuggable.
+
+**Schemas are Zod.** One validator, one source of truth, native TypeScript types. No pluggable schema systems. The SDK re-exports `z` so skills don't need a separate Zod dependency.
+
+**Prose stays prose.** The SDK structures when prose is shown and what contract it satisfies. It never replaces prose with code. Nodes contain freely-written instructions; transitions between nodes are typed and explicit.

--- a/tasks/2026-04-17_1503_readme-redesign/TASK.md
+++ b/tasks/2026-04-17_1503_readme-redesign/TASK.md
@@ -1,0 +1,59 @@
+# README Redesign + docs/ Folder
+
+## Scope
+
+**In:**
+- Rewrite README.md — restructure, trim API section, add examples section, add badges
+- Create `docs/api.md` — full API reference with worked deploy-check example, modules, fragments, actions, render helpers
+- Create `docs/architecture.md` — stateless protocol, host-aware system, build pipeline, engine internals
+
+**Out:**
+- No changes to source code, SPEC.md, or CLAUDE.md
+- No new examples or tests
+- No license field addition to package.json
+
+## Context
+
+The current README (378 lines) is technically solid but front-loads too much API reference, buries the reference-skill type below the fold, never links the two working examples, and has no visual identity. The SPEC.md (1285 lines) covers architecture exhaustively but isn't user-facing docs.
+
+User requested the `/readme-design` skill to review and improve the README, plus creation of a `docs/` folder for content that would bloat the landing page.
+
+User choices:
+- Keep API section condensed in README (not moved to docs entirely)
+- Replace deploy-check Quick Start with a minimal ~15-line example
+- Create docs/architecture.md for protocol/host/build/engine details
+
+## Plan
+
+Restructure README to ~200 lines with developer-direct progressive-disclosure:
+1. Header with badges (TS 5.9+, Node 24+, Zod 4) and nav links
+2. Problem statement + hero code (keep as-is — it's the strongest part)
+3. Quick Start with minimal example, test, build
+4. Two skill types section (moved up from line 207)
+5. How It Works (keep ASCII diagram, trim host table, remove modules)
+6. Examples section (new — surface get-to-know-you and ts-patterns)
+7. API condensed (builder signatures, primitives table, testing, CLI, step config in collapsible)
+8. Key Decisions (trimmed from 7 to 5)
+9. Footer with doc links
+
+Create docs/api.md with full API reference: workflow builder, reference builder, modules, primitives, standalone steps, fragments, actions, render helpers, testing, CLI, worked deploy-check example.
+
+Create docs/architecture.md: stateless protocol, host-aware prose system, build pipeline, engine internals, lint system, design decisions.
+
+**Alternatives rejected:**
+- Moving API entirely to docs — user preferred keeping it condensed in README
+- Mermaid diagrams — ASCII renders everywhere, audience is comfortable with it
+- Separate getting-started tutorial — Quick Start + worked example in api.md covers it
+
+## Steps
+
+- [ ] Commit TASK.md
+- [ ] Create docs/api.md
+- [ ] Create docs/architecture.md
+- [ ] Rewrite README.md
+- [ ] Run prettier, typecheck, verify links
+- [ ] Commit each logical piece
+
+## Notes
+
+(Running log of decisions during implementation)

--- a/tasks/2026-04-17_1503_readme-redesign/TASK.md
+++ b/tasks/2026-04-17_1503_readme-redesign/TASK.md
@@ -3,11 +3,13 @@
 ## Scope
 
 **In:**
+
 - Rewrite README.md — restructure, trim API section, add examples section, add badges
 - Create `docs/api.md` — full API reference with worked deploy-check example, modules, fragments, actions, render helpers
 - Create `docs/architecture.md` — stateless protocol, host-aware system, build pipeline, engine internals
 
 **Out:**
+
 - No changes to source code, SPEC.md, or CLAUDE.md
 - No new examples or tests
 - No license field addition to package.json
@@ -19,6 +21,7 @@ The current README (378 lines) is technically solid but front-loads too much API
 User requested the `/readme-design` skill to review and improve the README, plus creation of a `docs/` folder for content that would bloat the landing page.
 
 User choices:
+
 - Keep API section condensed in README (not moved to docs entirely)
 - Replace deploy-check Quick Start with a minimal ~15-line example
 - Create docs/architecture.md for protocol/host/build/engine details
@@ -26,6 +29,7 @@ User choices:
 ## Plan
 
 Restructure README to ~200 lines with developer-direct progressive-disclosure:
+
 1. Header with badges (TS 5.9+, Node 24+, Zod 4) and nav links
 2. Problem statement + hero code (keep as-is — it's the strongest part)
 3. Quick Start with minimal example, test, build
@@ -41,19 +45,23 @@ Create docs/api.md with full API reference: workflow builder, reference builder,
 Create docs/architecture.md: stateless protocol, host-aware prose system, build pipeline, engine internals, lint system, design decisions.
 
 **Alternatives rejected:**
+
 - Moving API entirely to docs — user preferred keeping it condensed in README
 - Mermaid diagrams — ASCII renders everywhere, audience is comfortable with it
 - Separate getting-started tutorial — Quick Start + worked example in api.md covers it
 
 ## Steps
 
-- [ ] Commit TASK.md
-- [ ] Create docs/api.md
-- [ ] Create docs/architecture.md
-- [ ] Rewrite README.md
-- [ ] Run prettier, typecheck, verify links
-- [ ] Commit each logical piece
+- [x] Commit TASK.md
+- [x] Create docs/api.md
+- [x] Create docs/architecture.md
+- [x] Rewrite README.md
+- [x] Run prettier, typecheck, verify links
+- [x] Commit each logical piece
 
 ## Notes
 
-(Running log of decisions during implementation)
+- All 113 tests pass, typecheck clean. Pre-existing prettier warnings in generated skill outputs, lock file, and renovate config — not touched.
+- README went from 378 to ~240 lines (prettier-formatted). The deploy-check example moved to docs/api.md as a worked example.
+- docs/api.md is ~500 lines covering the full API surface including modules, fragments, actions, and render helpers — content that was either in the README or entirely undocumented.
+- docs/architecture.md is ~300 lines covering protocol, host system, build pipeline, engine internals, and lint rules — distilled from SPEC.md and source code.


### PR DESCRIPTION
## Summary

- **Rewrite README** with progressive-disclosure structure — badges, minimal Quick Start, skill types section moved up, new Examples section, trimmed API and Key Decisions. 378 → ~240 lines.
- **Create `docs/api.md`** — full API reference covering workflow builder, reference builder, modules, primitives, fragments, actions, render helpers, observers, testing, CLI, lint rules, and a worked deploy-check example.
- **Create `docs/architecture.md`** — stateless CLI protocol, host-aware prose system, build pipeline, engine internals, lint system, and design decisions.

## Test plan

- [x] Verify README renders correctly on GitHub (badges, nav links, collapsible step config, ASCII diagram)
- [x] Verify all internal links resolve (docs/api.md, docs/architecture.md, SPEC.md, example paths)
- [x] Confirm code examples in README match current API surface
- [x] `pnpm exec tsc --noEmit` passes (verified)
- [x] All 113 tests pass (verified)
- [x] `pnpm exec prettier --check .` clean on modified files (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)