### PR TITLE
fix(ci): add publishConfig for GitHub Packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "dist",
     "bin"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "packageManager": "pnpm@10.24.0",
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## Summary

- Add `publishConfig.registry` pointing to `https://npm.pkg.github.com/` so release-it's npm auth check and publish target the correct registry

Without this, release-it runs `npm whoami` against the default npm registry, which fails because `GITHUB_TOKEN` only authenticates against GitHub Packages.

## Test plan

- [ ] CI/CD release job passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)