### PR TITLE
fix(ci): configure git identity for release commits

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,6 +44,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,8 +46,8 @@ jobs:
           fetch-depth: 0
       - name: Configure git identity
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "contentful-automation[bot]"
+          git config user.email "100587065+contentful-automation[bot]@users.noreply.github.com"
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- Set `github-actions[bot]` git identity in the release job so release-it can commit the version bump

The runner has no git identity by default. The npm publish succeeded but release-it rolled it back because the subsequent `git commit` failed.

## Test plan

- [ ] CI/CD release job completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)