### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/skill-kit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK for building agent skills with CLI-driven workflows",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Align `package.json` version with the `v0.1.1` tag and the already-published registry entry

The previous release run published `0.1.1` to GitHub Packages before failing on git commit. The tag has been created manually. This syncs `package.json` so release-it can bump to `0.1.2` on the next release.

## Test plan

- [ ] CI/CD release job succeeds after merge, publishing `0.1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)