### PR TITLE
fix: resolve bin imports from dist/ and use self-reference in examples

### DIFF
--- a/bin/skill-kit.js
+++ b/bin/skill-kit.js
@@ -7,7 +7,7 @@ const args = process.argv.slice(2);
 const command = args[0];
 
 if (command === 'build') {
-  const { buildSkill } = await import('../src/build/index.js');
+  const { buildSkill } = await import('../dist/build/index.js');
 
   const flags = {};
   let entry = null;
@@ -64,10 +64,10 @@ if (command === 'build') {
   process.argv = [process.argv[0], absPath, ...args.slice(2)];
 
   if (def.kind === 'reference') {
-    const { referenceMain } = await import('../src/protocol/reference-entry.js');
+    const { referenceMain } = await import('../dist/protocol/reference-entry.js');
     referenceMain(def);
   } else {
-    const { main } = await import('../src/protocol/cli-entry.js');
+    const { main } = await import('../dist/protocol/cli-entry.js');
     await main(def);
   }
 } else if (command === 'check') {
@@ -83,7 +83,7 @@ if (command === 'build') {
 
   if (def.kind === 'skill') {
     const { dirname } = await import('node:path');
-    const { checkSkill } = await import('../src/lint/index.js');
+    const { checkSkill } = await import('../dist/lint/index.js');
     const diagnostics = checkSkill(def, dirname(absPath));
 
     for (const d of diagnostics) {

--- a/examples/get-to-know-you/src/skill.test.ts
+++ b/examples/get-to-know-you/src/skill.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { runSkill, mockModel } from '../../../src/test.js';
+import { runSkill, mockModel } from '@contentful/skill-kit/test';
 import skill from './skill.js';
 
 test('developer path: greet → ask-role → ask-stack → ask-hobby → confirm → profile-card', async () => {

--- a/examples/get-to-know-you/src/skill.ts
+++ b/examples/get-to-know-you/src/skill.ts
@@ -1,4 +1,4 @@
-import { skill, step, z, action, fragment, prompt, render, askUser } from '../../../src/index.js';
+import { skill, step, z, action, fragment, prompt, render, askUser } from '@contentful/skill-kit';
 
 // --- Fragments ---
 

--- a/examples/ts-patterns/src/skill.ts
+++ b/examples/ts-patterns/src/skill.ts
@@ -1,4 +1,4 @@
-import { reference, render } from '../../../src/index.js';
+import { reference, render } from '@contentful/skill-kit';
 
 export default reference({
   name: 'ts-patterns',


### PR DESCRIPTION
## Summary
- `bin/skill-kit.js` imported from `../src/` which doesn't exist in the published package (only `dist/` and `bin/` are shipped). Fixed all 4 imports to use `../dist/`.
- Examples used relative paths into `../../../src/` — replaced with `@contentful/skill-kit` self-reference via the package exports map. This works without tsx and matches how consumers import the SDK.

## Test plan
- [x] `node bin/skill-kit.js` prints help (no import errors without tsx)
- [x] `node bin/skill-kit.js build examples/get-to-know-you/src/skill.ts -o /tmp/test-skill --single` succeeds without tsx
- [x] All 123 tests pass (SDK + both example suites)
- [x] Typecheck and Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)