### PR TITLE
fix: published bin resolves dist/ and auto-loads tsx

### DIFF
--- a/bin/skill-kit.js
+++ b/bin/skill-kit.js
@@ -2,6 +2,19 @@
 
 import { resolve } from 'node:path';
 import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const tsxLoaded = process.execArgv.some((a) => a.includes('tsx'));
+if (!tsxLoaded) {
+  const self = fileURLToPath(import.meta.url);
+  try {
+    execFileSync(process.execPath, ['--import', 'tsx/esm', self, ...process.argv.slice(2)], { stdio: 'inherit' });
+  } catch (e) {
+    process.exit(e.status ?? 1);
+  }
+  process.exit(0);
+}
 
 const args = process.argv.slice(2);
 const command = args[0];

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "build:examples": "node --import tsx/esm bin/skill-kit.js build examples/get-to-know-you/src/skill.ts -o examples/get-to-know-you/skill"
   },
   "dependencies": {
+    "tsx": "^4.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.2.3",
     "prettier": "^3.8.1",
     "release-it": "^20.0.0",
-    "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -20,9 +23,6 @@ importers:
       release-it:
         specifier: ^20.0.0
         version: 20.0.0(@types/node@25.6.0)
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/src/build/bun-wrapper-template.ts
+++ b/src/build/bun-wrapper-template.ts
@@ -2,7 +2,7 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const sdkRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const cliEntryAbs = resolve(sdkRoot, 'src', 'cli.ts');
+const cliEntryAbs = resolve(sdkRoot, 'dist', 'cli.js');
 
 export function generateBunWrapper(entryAbsPath: string, kind: 'skill' | 'reference'): string {
   const mainFn = kind === 'reference' ? 'referenceMain' : 'main';

--- a/tasks/2026-04-20_1509_fix-published-bin-runtime/TASK.md
+++ b/tasks/2026-04-20_1509_fix-published-bin-runtime/TASK.md
@@ -1,0 +1,43 @@
+# Fix published bin runtime
+
+## Scope
+
+**In:** Make `npx skill-kit build|run|check` work out of the box when installed from the registry.
+
+**Out:** Changing the CLI's API surface, adding new commands, or restructuring the build pipeline.
+
+## Context
+
+The published `@contentful/skill-kit` binary had two remaining issues after PR #13 fixed the `../src/` → `../dist/` imports:
+
+1. **bun-wrapper-template** resolved `src/cli.ts` as the entry for compiled binaries. Since `src/` isn't shipped (only `dist/` and `bin/`), `bun build --compile` failed for consumers with "Could not resolve".
+
+2. **bin/skill-kit.js** did `await import(absPath)` on `.ts` files under plain Node. Without a tsx loader, TypeScript imports fail. Consumers had to manually invoke `node --import tsx/esm bin/skill-kit.js ...`, defeating the purpose of a bin entry.
+
+## Plan
+
+**Fix 1 — bun-wrapper-template:** Change `resolve(sdkRoot, 'src', 'cli.ts')` → `resolve(sdkRoot, 'dist', 'cli.js')`.
+
+**Fix 2 — auto-load tsx:** The bin script detects whether tsx is already loaded via `process.execArgv`. If not, it re-execs itself with `--import tsx/esm` and forwards all args + exit code. This is necessary because Node 25 doesn't support `register('tsx/esm', ...)` — tsx requires the `--import` hook.
+
+**Fix 3 — move tsx to dependencies:** Required for fix 2 to work at install time.
+
+**Alternative rejected:** Using the shebang to pass `--import tsx/esm` — Linux shebangs don't support multiple arguments. A shell wrapper was considered but adds complexity vs. the re-exec pattern.
+
+## Steps
+
+- [x] Change `src/build/bun-wrapper-template.ts` line 5: `'src', 'cli.ts'` → `'dist', 'cli.js'`
+- [x] Add re-exec guard to `bin/skill-kit.js` with exit code forwarding
+- [x] Move `tsx` from devDependencies to dependencies in `package.json`
+- [x] Verify: `node bin/skill-kit.js` prints help
+- [x] Verify: `node bin/skill-kit.js run examples/.../skill.ts start` works without manual tsx
+- [x] Verify: `node bin/skill-kit.js build examples/.../skill.ts -o /tmp/... --single` succeeds
+- [x] All 123 tests pass, typecheck + prettier clean
+- [x] PR #15 created
+
+## Notes
+
+- `register('tsx/esm', import.meta.url)` was the first attempt — fails on Node 25 with "tsx must be loaded with --import instead of --loader". The `--loader` API was deprecated in Node 20.6.
+- The re-exec pattern uses `execFileSync` with `stdio: 'inherit'` so stdin/stdout/stderr pass through transparently.
+- Detection uses `process.execArgv.some((a) => a.includes('tsx'))` — reliable since tsx is the only loader we use.
+- The existing `build:examples` script in package.json still works (it passes `--import tsx/esm` explicitly, which means tsx is already detected as loaded on re-entry — no double re-exec).


### PR DESCRIPTION
## Summary
- `src/build/bun-wrapper-template.ts` resolved `src/cli.ts` for the compiled binary — changed to `dist/cli.js` which is what's actually shipped.
- `bin/skill-kit.js` now auto-re-execs with `--import tsx/esm` when the loader isn't present, so `npx skill-kit build my-skill.ts` works without consumers needing to know about tsx.
- Moved `tsx` from devDependencies to dependencies so it's available at install time.

## Test plan
- [x] `node bin/skill-kit.js` prints help (no import errors)
- [x] `node bin/skill-kit.js run examples/get-to-know-you/src/skill.ts start --context '{}'` works without manual `--import tsx/esm`
- [x] `node bin/skill-kit.js build examples/get-to-know-you/src/skill.ts -o /tmp/test-skill --single` succeeds (bun wrapper resolves dist/cli.js)
- [x] All 123 tests pass (SDK + both example suites)
- [x] Typecheck and Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)