### PR TITLE
chore(release): bump version to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/skill-kit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TypeScript SDK for building agent skills with CLI-driven workflows",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Syncs package.json with the published registry version (0.1.8)
- The release-it workflow published 0.1.8 and pushed the tag, but the version bump commit was rejected by org-level branch protection (Wiz Secret Scanner required, no bypass for `github-actions[bot]`)

## Test plan

- [ ] Verify `package.json` version matches npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)