### PR TITLE
chore: enable treeshaking + minification for node build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/skill-kit",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "TypeScript SDK for building agent skills with CLI-driven workflows",
   "type": "module",
   "exports": {

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -142,6 +142,8 @@ async function compileNodeBundle(entryPath: string, def: Buildable, outDir: stri
       platform: 'node',
       target: 'node24',
       outfile: bundlePath,
+      treeShaking: true,
+      minify: true,
     });
     process.stderr.write(`  ✓ ${bundlePath}\n`);
   } finally {


### PR DESCRIPTION
## Summary

- Enable explicit `treeShaking: true` and `minify: true` in the esbuild config for `--mode node` builds
- Reduces get-to-know-you example bundle from 559KB → 335KB (40% smaller)
- Bumps version to 0.1.9 to sync with registry (release automation couldn't push the version bump due to org branch protection)

## Test plan

- [ ] `pnpm exec tsc --noEmit` — typecheck passes
- [ ] `node --test --import tsx/esm 'src/**/*.test.ts'` — 133 tests pass
- [ ] `pnpm exec prettier --check .` — formatting clean
- [ ] Build example with `--mode node` — bundle is smaller and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)