### PR TITLE
chore(oss): add OSS baseline docs and license automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a reproducible problem
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- What happened? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What did you expect to happen? -->
+
+## Environment
+
+- OS:
+- Node version:
+- Package manager version (pnpm):
+- Usage context (SDK app / built skill / CI):
+
+## Additional context
+
+<!-- Logs, screenshots, links -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://www.contentful.com/security/
+    about: Report vulnerabilities through Contentful's security channel.
+  - name: Support and help center
+    url: https://www.contentful.com/help/getting-started/how-to-get-help/
+    about: For account-specific or sensitive support requests.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem statement
+
+<!-- What problem are you trying to solve? -->
+
+## Proposed solution
+
+<!-- What change would you like to see? -->
+
+## Alternatives considered
+
+<!-- Any alternatives you evaluated -->
+
+## Additional context
+
+<!-- Links, references, examples -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- Short description of what this PR changes -->
+
+## Why this change
+
+<!-- Context and motivation -->
+
+## Validation
+
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+- [ ] `pnpm run format:check`
+- [ ] `pnpm run update-licenses` (if dependencies changed)
+
+## Checklist
+
+- [ ] I have read `CONTRIBUTING.md`
+- [ ] Documentation is updated where needed
+- [ ] No secrets or credentials are included
+- [ ] No breaking changes, or they are clearly documented

--- a/AUTOMATION-FOR-LICENSES.md
+++ b/AUTOMATION-FOR-LICENSES.md
@@ -1,0 +1,35 @@
+# License Automation
+
+This project includes an automated license management workflow that tracks direct dependencies and keeps compliance files up to date.
+
+## Running the license update script
+
+To regenerate licensing artifacts:
+
+```bash
+pnpm run update-licenses
+```
+
+The script will:
+
+1. Scan direct runtime and development dependencies from `package.json`
+2. Read dependency license metadata from installed packages in `node_modules`
+3. Update the root `NOTICE` file
+4. Rebuild the `licenses/` directory with one file per discovered license
+
+## When to run
+
+Run the script whenever dependencies change:
+
+- After adding a dependency
+- After removing a dependency
+- Before a release or tag
+- In CI (optional)
+
+## Output
+
+The command prints:
+
+- Runtime dependency count
+- Development dependency count
+- Discovered unique license ids

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to @contentful/skill-kit
+
+Thanks for your interest in contributing.
+
+## How to contribute
+
+- Open an issue to report bugs or suggest enhancements.
+- For larger changes, start with an issue before opening a PR.
+- For smaller fixes and docs updates, feel free to open a PR directly.
+
+## Local development
+
+Prerequisites:
+
+- Node.js 24+
+- pnpm
+
+Install dependencies:
+
+```sh
+pnpm install
+```
+
+## Validate your changes
+
+Run the checks before opening a PR:
+
+```sh
+pnpm typecheck
+pnpm test
+pnpm run format:check
+```
+
+If you changed dependencies, also refresh licensing files:
+
+```sh
+pnpm run update-licenses
+```
+
+## Pull request checklist
+
+- Keep PRs focused and easy to review.
+- Use conventional commits where possible.
+- Update docs when behavior or usage changes.
+- Do not include secrets or credentials.
+
+## Code of conduct
+
+By participating in this project, you agree to follow the Contentful Developer Code of Conduct:
+https://www.contentful.com/developers/code-of-conduct/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Contentful GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,36 @@
+This project includes the following third-party open-source software components. Each is provided under its respective license.
+
+Runtime Dependencies (Production)
+
+esbuild
+    License: MIT
+    https://github.com/evanw/esbuild [npmjs.com]
+tsx
+    License: MIT
+    https://tsx.is [npmjs.com]
+zod
+    License: MIT
+    https://zod.dev [npmjs.com]
+
+
+Development Dependencies
+
+@types/node
+    License: MIT
+    https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node [npmjs.com]
+prettier
+    License: MIT
+    https://prettier.io [npmjs.com]
+release-it
+    License: MIT
+    https://github.com/release-it/release-it#readme [npmjs.com]
+typescript
+    License: Apache-2.0
+    https://www.typescriptlang.org/ [npmjs.com]
+
+
+Each component is used in accordance with its open-source license. The
+applicable license texts are included in this repository under the
+licenses/ directory.
+
+For more details, please refer to the LICENSE file for this project.

--- a/README.md
+++ b/README.md
@@ -342,6 +342,27 @@ For modules, fragments, actions, render helpers, observers, and lint rules, see 
 
 ---
 
+## Help and Support
+
+- Open a GitHub issue for bugs and feature requests.
+- For security issues, follow [SECURITY.md](SECURITY.md).
+- Contentful support resources: https://www.contentful.com/help/getting-started/how-to-get-help/
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local development setup, validation commands, and pull request guidelines.
+
+## License and Notices
+
+This project is licensed under [MIT](LICENSE).
+
+Third-party notices and license automation docs:
+
+- [NOTICE](NOTICE)
+- [AUTOMATION-FOR-LICENSES.md](AUTOMATION-FOR-LICENSES.md)
+
+---
+
 <p align="center">
   <a href="./docs/api.md">Full API Reference</a> · <a href="./docs/architecture.md">Architecture</a> · <a href="./SPEC.md">Specification</a> · <a href="https://agentskills.io/specification">agentskills.io</a>
 </p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Use Contentful's security reporting channel instead:
+https://www.contentful.com/security/
+
+If you are unsure whether an issue is security-related, contact Contentful support:
+https://www.contentful.com/help/getting-started/how-to-get-help/

--- a/licenses/Apache-2.0.txt
+++ b/licenses/Apache-2.0.txt
@@ -1,0 +1,174 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.

--- a/licenses/MIT.txt
+++ b/licenses/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) YEAR COPYRIGHT HOLDER
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,15 @@
   "name": "@contentful/skill-kit",
   "version": "0.1.10",
   "description": "TypeScript SDK for building agent skills with CLI-driven workflows",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/contentful/skill-kit"
+  },
+  "bugs": {
+    "url": "https://github.com/contentful/skill-kit/issues"
+  },
+  "homepage": "https://github.com/contentful/skill-kit#readme",
   "type": "module",
   "exports": {
     ".": {
@@ -40,6 +49,7 @@
     "test": "node --test --import tsx/esm 'src/**/*.test.ts'",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "update-licenses": "node ./scripts/update-licenses.mjs",
     "build:examples": "pnpm run build:examples:get-to-know-you && pnpm run build:examples:ts-patterns",
     "build:examples:get-to-know-you": "node --import tsx/esm bin/skill-kit.js build examples/get-to-know-you/src/skill.ts -o examples/get-to-know-you/skill --mode node",
     "build:examples:ts-patterns": "node --import tsx/esm bin/skill-kit.js build examples/ts-patterns/src/skill.ts -o examples/ts-patterns/skill --mode node",

--- a/scripts/update-licenses.mjs
+++ b/scripts/update-licenses.mjs
@@ -1,0 +1,445 @@
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const PACKAGE_JSON_PATH = path.join(ROOT, 'package.json');
+const NOTICE_PATH = path.join(ROOT, 'NOTICE');
+const LICENSES_DIR = path.join(ROOT, 'licenses');
+
+const LICENSE_TEMPLATES = {
+  '0BSD': `BSD Zero Clause License
+
+Copyright (c) YEAR COPYRIGHT HOLDER
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+`,
+  'Apache-2.0': `Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+`,
+  ISC: `ISC License
+
+Copyright (c) YEAR, COPYRIGHT HOLDER
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+`,
+  MIT: `MIT License
+
+Copyright (c) YEAR COPYRIGHT HOLDER
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`,
+};
+
+function toNpmUrl(name) {
+  return `https://www.npmjs.com/package/${name}`;
+}
+
+function normalizeRepositoryUrl(url) {
+  if (!url) {
+    return undefined;
+  }
+
+  return String(url)
+    .replace(/^git\+/, '')
+    .replace(/\.git$/, '');
+}
+
+function readLicenseString(pkgJson) {
+  if (typeof pkgJson.license === 'string' && pkgJson.license.trim()) {
+    return pkgJson.license.trim();
+  }
+
+  if (pkgJson.license && typeof pkgJson.license.type === 'string' && pkgJson.license.type.trim()) {
+    return pkgJson.license.type.trim();
+  }
+
+  if (Array.isArray(pkgJson.licenses) && pkgJson.licenses.length > 0) {
+    const list = pkgJson.licenses
+      .map((license) => {
+        if (typeof license === 'string') {
+          return license;
+        }
+
+        if (license && typeof license.type === 'string') {
+          return license.type;
+        }
+
+        return undefined;
+      })
+      .filter(Boolean);
+
+    if (list.length > 0) {
+      return list.join(' OR ');
+    }
+  }
+
+  return 'UNKNOWN';
+}
+
+async function readDependencyMetadata(name) {
+  const dependencyPackageJsonPath = path.join(ROOT, 'node_modules', ...name.split('/'), 'package.json');
+
+  try {
+    const raw = await readFile(dependencyPackageJsonPath, 'utf8');
+    const pkg = JSON.parse(raw);
+
+    return {
+      name,
+      license: readLicenseString(pkg),
+      url: pkg.homepage || normalizeRepositoryUrl(pkg.repository?.url) || toNpmUrl(name),
+    };
+  } catch {
+    return {
+      name,
+      license: 'UNKNOWN',
+      url: toNpmUrl(name),
+    };
+  }
+}
+
+async function collectDependencies(depMap) {
+  const names = Object.keys(depMap || {}).sort((a, b) => a.localeCompare(b));
+  const items = [];
+
+  for (const name of names) {
+    items.push(await readDependencyMetadata(name));
+  }
+
+  return items;
+}
+
+function renderDependencies(items) {
+  if (items.length === 0) {
+    return 'None\n';
+  }
+
+  return `${items.map((item) => `${item.name}\n    License: ${item.license}\n    ${item.url} [npmjs.com]`).join('\n')}\n`;
+}
+
+function renderNotice(runtimeDependencies, developmentDependencies) {
+  return `This project includes the following third-party open-source software components. Each is provided under its respective license.
+
+Runtime Dependencies (Production)
+
+${renderDependencies(runtimeDependencies)}
+
+Development Dependencies
+
+${renderDependencies(developmentDependencies)}
+
+Each component is used in accordance with its open-source license. The
+applicable license texts are included in this repository under the
+licenses/ directory.
+
+For more details, please refer to the LICENSE file for this project.
+`;
+}
+
+function normalizeLicenseId(license) {
+  if (!license) {
+    return 'UNKNOWN';
+  }
+
+  const normalized = license.trim();
+
+  if (!normalized || normalized.includes(' OR ') || normalized.includes(' AND ')) {
+    return 'UNKNOWN';
+  }
+
+  return normalized;
+}
+
+function renderUnknownLicenseText(packages) {
+  const list = packages
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => `- ${name}`)
+    .join('\n');
+
+  return `Some dependencies do not expose a machine-readable SPDX license in their package metadata.
+
+The following direct dependencies are currently marked as UNKNOWN:
+
+${list}
+
+Please review these packages manually and update this file if needed.
+`;
+}
+
+async function updateLicenseFiles(allDependencies) {
+  await mkdir(LICENSES_DIR, { recursive: true });
+
+  const existingFiles = await readdir(LICENSES_DIR);
+  const licensesToPackages = new Map();
+
+  for (const dependency of allDependencies) {
+    const id = normalizeLicenseId(dependency.license);
+
+    if (!licensesToPackages.has(id)) {
+      licensesToPackages.set(id, []);
+    }
+
+    licensesToPackages.get(id).push(dependency.name);
+  }
+
+  const targetFileNames = new Set();
+  const writes = [];
+
+  for (const [licenseId, packages] of licensesToPackages.entries()) {
+    const fileName = `${licenseId}.txt`;
+    targetFileNames.add(fileName);
+
+    let content;
+
+    if (licenseId === 'UNKNOWN') {
+      content = renderUnknownLicenseText(packages);
+    } else if (LICENSE_TEMPLATES[licenseId]) {
+      content = LICENSE_TEMPLATES[licenseId];
+    } else {
+      content = `No built-in template is available for ${licenseId}.\n\nPlease add the full license text for this SPDX id manually.\n`;
+    }
+
+    writes.push(writeFile(path.join(LICENSES_DIR, fileName), content, 'utf8'));
+  }
+
+  await Promise.all(writes);
+
+  const deletes = existingFiles
+    .filter((fileName) => !targetFileNames.has(fileName))
+    .map((fileName) => rm(path.join(LICENSES_DIR, fileName)));
+
+  await Promise.all(deletes);
+}
+
+async function main() {
+  const packageJsonRaw = await readFile(PACKAGE_JSON_PATH, 'utf8');
+  const packageJson = JSON.parse(packageJsonRaw);
+
+  const runtimeDependencies = await collectDependencies(packageJson.dependencies);
+  const developmentDependencies = await collectDependencies(packageJson.devDependencies);
+  const allDependencies = [...runtimeDependencies, ...developmentDependencies];
+
+  const notice = renderNotice(runtimeDependencies, developmentDependencies);
+  await writeFile(NOTICE_PATH, notice, 'utf8');
+
+  await updateLicenseFiles(allDependencies);
+
+  const uniqueLicenses = [
+    ...new Set(allDependencies.map((dependency) => normalizeLicenseId(dependency.license))),
+  ].sort();
+
+  console.log(`Found ${runtimeDependencies.length} direct runtime dependencies`);
+  console.log(`Found ${developmentDependencies.length} direct development dependencies`);
+  console.log(`Found ${uniqueLicenses.length} unique license types: ${uniqueLicenses.join(', ')}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tasks/2026-04-21_1529_oss-baseline/TASK.md
+++ b/tasks/2026-04-21_1529_oss-baseline/TASK.md
@@ -1,0 +1,68 @@
+# OSS baseline for repository governance and licensing
+
+## Scope
+
+**In:**
+
+- Add OSS baseline repository documents and templates aligned with `contentful/contentful-mcp-server` and `contentful/skills#23`
+- Add issue templates and pull request template under `.github/`
+- Add governance docs (`CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`)
+- Add license compliance artifacts (`NOTICE`, `AUTOMATION-FOR-LICENSES.md`, `licenses/`)
+- Add automated license update script and wire it through `package.json`
+- Update README with support, security, and licensing references
+
+**Out:**
+
+- Changes to SDK runtime behavior or API design
+- CI workflow changes beyond what is needed for OSS baseline docs/scripts
+- Release process refactors unrelated to OSS baseline
+
+## Context
+
+User request:
+
+"We want to make this repo OSS soon. Please based on:
+
+- https://github.com/contentful/contentful-mcp-server
+- https://github.com/contentful/skills/pull/23
+
+add the same behaviour to this repo"
+
+The reference PR adds a practical OSS baseline: contributor-facing templates, security and contribution policy docs, and a repeatable license automation flow that updates `NOTICE` and `licenses/` from direct dependencies.
+
+## Plan
+
+- Mirror the behavior from `contentful/skills#23` while adapting language and commands to this repository (`pnpm`, `typecheck`, `test`, `format:check`).
+- Introduce a standalone `scripts/update-licenses.mjs` script that scans direct dependencies from `package.json`, reads package metadata from `node_modules`, updates `NOTICE`, and regenerates `licenses/*.txt` by SPDX id.
+- Keep implementation intentionally simple and deterministic so contributors can run one command after dependency changes.
+
+Alternatives considered:
+
+- Reusing the exact `contentful-mcp-server` script with `license-checker-rseidelsohn`. Rejected to avoid introducing another dependency when current repo can rely on installed package metadata for direct deps.
+- Manual, static NOTICE management. Rejected because it drifts easily as dependencies evolve.
+
+Trade-offs:
+
+- The script focuses on direct dependencies (runtime + dev), matching the referenced behavior and keeping generated output stable.
+- Non-SPDX or combined expressions are normalized to `UNKNOWN` and documented for manual follow-up.
+
+## Steps
+
+- [x] Commit task doc
+- [x] Add OSS issue/PR templates under `.github`
+- [x] Add `CONTRIBUTING.md`, `SECURITY.md`, and `LICENSE`
+- [x] Add license automation script and docs
+- [x] Generate `NOTICE` and `licenses/` from current dependency set
+- [x] Update `package.json` metadata and scripts
+- [x] Update `README.md` OSS support/licensing sections
+- [x] Run typecheck, tests, format check, and license update command
+
+## Notes
+
+- Starting from branch `chore/oss-baseline`.
+- Will keep wording closely aligned with Contentful OSS patterns while adapting repository-specific instructions.
+- Added `.github/ISSUE_TEMPLATE/{bug-report.md,feature-request.md,config.yml}` and `.github/pull_request_template.md` aligned to OSS baseline used in the reference PR.
+- Added root governance/legal docs: `CONTRIBUTING.md`, `SECURITY.md`, and `LICENSE` (MIT).
+- Added `scripts/update-licenses.mjs` plus `AUTOMATION-FOR-LICENSES.md`, then generated `NOTICE` and `licenses/{MIT.txt,Apache-2.0.txt}` with `pnpm run update-licenses`.
+- Updated package metadata (`license`, `repository`, `bugs`, `homepage`) and added `update-licenses` script in `package.json`.
+- Verification passed: `pnpm exec tsc --noEmit`, `node --test --import tsx/esm 'src/**/*.test.ts'`, and `pnpm exec prettier --check .`.


### PR DESCRIPTION
## Summary
- add OSS governance defaults for external contributors (`CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`, issue templates, and PR template)
- add license compliance automation with `scripts/update-licenses.mjs`, generated `NOTICE`, and `licenses/` artifacts
- update package metadata and README support/licensing sections for OSS readiness

## Context
- aligns this repo with the OSS baseline behavior used in `contentful/contentful-mcp-server` and `contentful/skills#23`

## Validation
- [x] `pnpm run update-licenses`
- [x] `pnpm exec tsc --noEmit`
- [x] `node --test --import tsx/esm 'src/**/*.test.ts'`
- [x] `pnpm exec prettier --check .`

## Notes
- task doc for this work: `tasks/2026-04-21_1529_oss-baseline/TASK.md`