### PR TITLE
fix: add packages-write policy for npm publish

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -5,3 +5,4 @@ services:
       - dependabot
       - semantic-release
       - packages-read
+      - packages-write


### PR DESCRIPTION
## Summary

- Adds `packages-write` policy to `.contentful/vault-secrets.yaml` — fixes `E403 permission_denied: write_package` during release

## Test plan

- [ ] Merge and verify next release publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)