### PR TITLE
fix(release): use secrets.GITHUB_TOKEN for npm publish

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -5,4 +5,3 @@ services:
       - dependabot
       - semantic-release
       - packages-read
-      - packages-write


### PR DESCRIPTION
## Summary

- **Use `secrets.GITHUB_TOKEN` for npm publish** — the Vault `GITHUB_PACKAGES_WRITE_TOKEN` doesn't have `write_package` scope for this repo. The built-in `GITHUB_TOKEN` gets it from `permissions: packages: write`.
- **Remove `GITHUB_PACKAGES_WRITE_TOKEN`** from Vault secrets block entirely — not needed
- **Remove `Setup npmrc for publishing` step** — `actions/setup-node` with `registry-url` + `NODE_AUTH_TOKEN` handles auth
- **Restore `.npmrc` before release-it** — `actions/setup-node` modifies the tracked `.npmrc`, which dirties the working dir
- **Remove nonexistent `packages-write` vault policy**

Token responsibilities after this change:
- `secrets.GITHUB_TOKEN` → npm install, npm publish (`NODE_AUTH_TOKEN`)
- Vault `GITHUB_TOKEN` → git push to main, GitHub Release creation

## Test plan

- [ ] Merge and verify next push to main publishes to GitHub Packages without E403

🤖 Generated with [Claude Code](https://claude.com/claude-code)