### PR TITLE
fix(release): use secrets.GITHUB_TOKEN for npm publish

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,6 @@ jobs:
           path: github-actions
           exportEnv: false
           secrets: |
-            secret/data/github/github_packages_write GITHUB_PACKAGES_WRITE_TOKEN | GITHUB_PACKAGES_WRITE_TOKEN;
             github/token/${{ github.event.repository.name }}-semantic-release token | GITHUB_TOKEN ;
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -78,9 +77,6 @@ jobs:
           git config user.name 'contentful-automation[bot]'
           git config user.email '${{ steps.get-user-id.outputs.user-id }}+contentful-automation[bot]@users.noreply.github.com'
 
-      - name: Setup npmrc for publishing
-        run: echo "//npm.pkg.github.com/:_authToken=${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}" >> "$HOME/.npmrc"
-
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -90,11 +86,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: pnpm run build
+      - name: Restore .npmrc
+        run: git checkout -- .npmrc
       - name: Release
         run: pnpm exec release-it --ci
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- **Use `secrets.GITHUB_TOKEN` for npm publish** — the Vault `GITHUB_PACKAGES_WRITE_TOKEN` doesn't have `write_package` scope for this repo. The built-in `GITHUB_TOKEN` gets it from `permissions: packages: write`.
- **Remove `GITHUB_PACKAGES_WRITE_TOKEN`** from Vault secrets — not needed
- **Remove `Setup npmrc for publishing` step** — `actions/setup-node` with `registry-url` + `NODE_AUTH_TOKEN` handles auth
- **Restore `.npmrc` before release-it** — `actions/setup-node` modifies the tracked file, dirtying the working dir

Token responsibilities after this change:
| Token | Used for |
|-------|----------|
| `secrets.GITHUB_TOKEN` | npm install, npm publish (`NODE_AUTH_TOKEN`) |
| Vault `GITHUB_TOKEN` | git push to main, GitHub Release creation |

## Test plan

- [ ] Merge and verify next push to main publishes to GitHub Packages without E403

🤖 Generated with [Claude Code](https://claude.com/claude-code)