### PR TITLE
fix(docs): remove base path for private Pages domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ pnpm exec tsc --noEmit && node --test --import tsx/esm 'src/**/*.test.ts' && pnp
 
 The docs site (`docs-site/`) is an Astro static site deployed to GitHub Pages. Its content pages are adapted from `docs/api.md`, `docs/architecture.md`, and the README. These are **not** auto-synced — when you change the markdown docs, update the corresponding MDX pages in `docs-site/src/pages/` and vice versa.
 
+**Known issue:** Pages is private, so GitHub assigns a random `*.pages.github.io` domain and serves at root (no base path). The `contentful.github.io/skill-kit/` URL 301-redirects there. Fix by either making Pages public (serves at `contentful.github.io/skill-kit/`, re-add `base: '/skill-kit/'` to `astro.config.mjs`) or configuring a custom domain.
+
 ## Key references
 
 - `SPEC.md` — the full SDK specification

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -2,8 +2,8 @@ import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 
 export default defineConfig({
+  // TODO: set custom domain or make Pages public so this serves at contentful.github.io/skill-kit/
   site: 'https://contentful.github.io',
-  base: '/skill-kit/',
   trailingSlash: 'always',
   output: 'static',
   integrations: [mdx()],


### PR DESCRIPTION
## Summary

- Remove `base: '/skill-kit/'` from Astro config — private GitHub Pages serves at root on a unique `*.pages.github.io` domain, so the base path caused all assets to 404
- Add CLAUDE.md note documenting the known issue and fix options (make Pages public or set custom domain)

## Context

Private GitHub Pages repos get a random domain like `redesigned-adventure-j1gz5j8.pages.github.io` instead of serving under `contentful.github.io/skill-kit/`. The org URL 301-redirects there, stripping the path.

## Test plan

- [ ] `cd docs-site && pnpm run build` — 13 pages, all links at root
- [ ] Deploy to Pages — site loads with styles and navigation working

🤖 Generated with [Claude Code](https://claude.com/claude-code)