### PR TITLE
docs: [NT-3037] fill composite skills documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,28 @@ scripts/run topic auth              # load a specific topic → plain text to st
 
 No JSON, no history, no state machine. Just `topic <name>` → text.
 
+### Composite skills
+
+When related skills share references and overlap in scope, combine them into a single composite. A composite is a regular `skill()` with sub-skills and topics registered on it — a dispatcher state machine that routes to independent sub-skill workflows or resolves reference topics directly.
+
+```typescript
+import doctorSkill from './subskills/doctor.js';
+import setupSkill from './subskills/setup.js';
+
+skill({ name: 'contentful-help', entry: 'choose', ... })
+  .step('choose', {
+    ask: askUser({ type: 'structured', question: 'What do you need?', options: [...] }),
+    output: z.object({ choice: z.string() }),
+    next: ({ output }) => `subskill:${output.choice}`,
+  })
+  .topic('rate-limits', { label: 'API rate limits', content: ({ refs }) => refs.load('rate-limits.md') })
+  .subskill('doctor', doctorSkill, { context: (_out, stash) => ({ spaceId: stash.spaceId }) })
+  .subskill('setup', setupSkill)
+  .build();
+```
+
+Sub-skills are standalone `skill().build()` definitions — testable independently. `next` returns `'subskill:<name>'` or `'topic:<name>'` to route. See the [Composite Skills guide](./docs-site/src/pages/guides/composite-skills.mdx).
+
 ---
 
 ## How It Works
@@ -237,6 +259,12 @@ TypeScript patterns reference with on-demand topic loading. Shows `render.table`
 
 [Full source](./examples/ts-patterns/src/skill.ts)
 
+### contentful-help (composite)
+
+A composite skill that dispatches to doctor and setup sub-skills, or resolves FAQ topics directly. Shows `.subskill()`, `.topic()`, `subskill:` / `topic:` routing, actions for deterministic env checks, and `runComposite` for testing.
+
+[Full source](./examples/contentful-help/src/skill.ts)
+
 ---
 
 ## API
@@ -248,6 +276,8 @@ skill({ name, entry, description?, triggers?, context?, stash?, observers?, fina
   .step(name, config)              // inline step — context/stash types inferred
   .extend(name, sharedStep, overrides)  // shared step with typed overrides
   .register(module, { next })      // merge module steps, widen stash type
+  .subskill(name, skillDef, opts?) // register a sub-skill with context mapping
+  .topic(name, { label, content }) // register a reference topic
   .build()                         // → SkillDefinition
 ```
 
@@ -278,6 +308,7 @@ import { runSkill, mockModel } from '@contentful/skill-kit/test';
 | Export                                        | What it does                                                   |
 | --------------------------------------------- | -------------------------------------------------------------- |
 | `runSkill(skill, { model, context?, host? })` | Drive a skill to completion                                    |
+| `runComposite(skill, { model, refs?, ... })`  | Drive a composite skill (handles sub-skill routing)            |
 | `mockModel({ stepName: output })`             | Canned outputs — static values, arrays for loops, or functions |
 
 ### CLI
@@ -338,7 +369,7 @@ For modules, fragments, actions, render helpers, observers, and lint rules, see 
 - **Schemas are Zod.** One validator, native TS types. No pluggable schema systems.
 - **Abstract verb system.** Step prose uses verbs (`ASK_STRUCTURED`, `ASK_FREEFORM`). The preamble maps them to host-specific tools.
 - **Single invocation.** No persistent processes. Each call reconstructs from history.
-- **Two skill types, one build pipeline.** Workflow skills (`skill()`) for multi-step state machines. Reference skills (`reference()`) for progressive disclosure. Both build to the same agentskills.io directory structure.
+- **Three skill patterns, one build pipeline.** Workflow skills for state machines, reference skills for progressive disclosure, and composite skills that combine sub-skills and topics under a single dispatcher. All build to the same agentskills.io directory structure.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -846,6 +846,28 @@ Each invocation reconstructs the workflow engine from the skill definition + his
 
 This design means no persistent process, no stdin piping, and no reliance on the agent managing a subprocess lifecycle. The agent makes sequential Bash calls and parses JSON output — a pattern every agent host supports today.
 
+### Composite CLI protocol
+
+Skills with registered sub-skills and/or topics accept additional commands. All go through `scripts/run` (hosts grant `scripts/run *` via "Always allow").
+
+**Direct sub-skill access** — bypass the dispatcher and start a sub-skill directly:
+
+```bash
+./scripts/run doctor --context '{"spaceId":"abc"}' --host claude-code
+./scripts/run doctor advance --step diagnose --output '{...}' --history '[...]'
+```
+
+**Reference topics** — list or load topics:
+
+```bash
+./scripts/run topics                 # list all topics with labels
+./scripts/run topic rate-limits      # load topic content to stdout
+```
+
+**Namespaced step names** — sub-skill steps are prefixed at the protocol layer. The host sees `doctor/diagnose` in the `step` field and passes it back on `advance`. The composite entry strips the prefix before routing to the sub-skill engine.
+
+**RedirectResult** — when the dispatcher's `next` resolves to `subskill:<name>` or `topic:<name>`, the engine returns a `RedirectResult` (the target doesn't exist in the local step map). The composite entry intercepts this and either starts the sub-skill or loads the topic. The host never sees `RedirectResult` — it receives the sub-skill's first `PromptResult` or a `DoneResult` with topic content.
+
 ### Script design conventions
 
 The binary follows the [agentskills.io script design conventions](https://agentskills.io/specification):
@@ -973,6 +995,12 @@ The build generates a SKILL.md with:
 
 Authors customize via `skill.description` and optional `skill.skillMd` template override.
 
+For composite skills, the generated SKILL.md also includes:
+
+- A **Sub-skills** section listing available sub-skills with descriptions and direct-access commands
+- A **Reference topics** section listing topics with `scripts/run topics` and `scripts/run topic <name>` commands
+- Context-aware guidance: when a dispatcher exists, the SKILL.md tells the agent to start normally and let the workflow route; direct sub-skill access is presented as a fallback for explicit user requests
+
 ### The compile/bundle step
 
 The build generates a temporary entry point:
@@ -986,6 +1014,8 @@ main(skill);
 **Bun mode:** `bun build --compile` bundles everything — the SDK, Zod, the skill code — into a single self-contained executable per target platform.
 
 **Node mode:** esbuild bundles the same dependency tree into a single `.mjs` file. All dependencies (SDK, Zod) are inlined; only Node.js built-ins are external. The result is a portable ESM module that runs under `node`.
+
+**Composite skills** build identically — same `skill-kit build` command, same output structure. The build pipeline detects `def.subskills` and generates a wrapper calling `compositeMain` instead of `main`. No special flags or separate build step needed.
 
 ---
 

--- a/docs-site/src/pages/api/index.mdx
+++ b/docs-site/src/pages/api/index.mdx
@@ -650,14 +650,19 @@ skill-kit check <entry.ts>
 
 Rules:
 
-| Rule                        | Severity      | What it catches                                                                                                                                                      |
-| --------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cycle-guard`               | warning/error | Warning when cycles lack `maxVisits` (implicit limit applies at runtime); error when cycle-guard config is invalid (e.g., `onMaxVisits` targets a non-existent step) |
-| `no-host-tool-names`        | error         | Direct host tool name references without `host.toolsAvailable` guard                                                                                                 |
-| `primitive-schema-mismatch` | error         | `askUser` option values missing from output enum (or vice versa)                                                                                                     |
-| `orphan-references`         | warning       | Files in `references/` not mentioned in any step prompt                                                                                                              |
-| `unknown-tool-names`        | warning       | `host.toolsAvailable.includes()` checks referencing unrecognized tools                                                                                               |
-| `host-branching-density`    | warning       | Multiple steps branching on `host.toolsAvailable` (suggests missing primitive)                                                                                       |
+| Rule                           | Severity      | What it catches                                                                                                                                                      |
+| ------------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cycle-guard`                  | warning/error | Warning when cycles lack `maxVisits` (implicit limit applies at runtime); error when cycle-guard config is invalid (e.g., `onMaxVisits` targets a non-existent step) |
+| `no-host-tool-names`           | error         | Direct host tool name references without `host.toolsAvailable` guard                                                                                                 |
+| `primitive-schema-mismatch`    | error         | `askUser` option values missing from output enum (or vice versa)                                                                                                     |
+| `orphan-references`            | warning       | Files in `references/` not mentioned in any step prompt                                                                                                              |
+| `unknown-tool-names`           | warning       | `host.toolsAvailable.includes()` checks referencing unrecognized tools                                                                                               |
+| `host-branching-density`       | warning       | Multiple steps branching on `host.toolsAvailable` (suggests missing primitive)                                                                                       |
+| `composite-step-name`          | error         | Dispatcher step name contains `/` (reserved for sub-skill namespacing)                                                                                               |
+| `composite-duplicate-subskill` | error         | Duplicate sub-skill name                                                                                                                                             |
+| `composite-duplicate-topic`    | error         | Duplicate topic name                                                                                                                                                 |
+
+For composite skills, `checkSkill` also recursively lints each registered sub-skill. Sub-skill diagnostics are prefixed with `[subskill:<name>]`.
 
 ---
 

--- a/docs-site/src/pages/examples/contentful-help.mdx
+++ b/docs-site/src/pages/examples/contentful-help.mdx
@@ -1,0 +1,145 @@
+---
+layout: ../../layouts/DocsLayout.astro
+title: 'Example: contentful-help'
+---
+
+A composite skill that dispatches to doctor and setup sub-skills, or resolves FAQ topics directly. This is the composite example in the SDK, demonstrating sub-skill registration, topic routing, actions, and multi-skill testing.
+
+**Source:** `examples/contentful-help/src/skill.ts`
+
+---
+
+## Skill structure
+
+```
+examples/contentful-help/src/
+  skill.ts                   # Dispatcher — routes to sub-skills or topics
+  skill.test.ts              # Tests with runComposite
+  subskills/
+    doctor.ts                # Diagnose and fix issues (standalone skill)
+    setup.ts                 # Guided space configuration (standalone skill)
+  references/
+    rate-limits.md           # API rate limit reference
+    locales.md               # Locale configuration reference
+```
+
+The dispatcher (`skill.ts`) is a regular `skill()` with `.subskill()` and `.topic()` calls. Each sub-skill is a standalone `skill().build()` in its own file.
+
+## The dispatcher
+
+The entry step uses `askUser` to let the user pick their intent:
+
+```typescript
+.step('choose', {
+  ask: askUser({
+    type: 'structured',
+    question: 'What would you like help with?',
+    options: [
+      { value: 'doctor', label: 'Diagnose issues', description: 'Find and fix problems' },
+      { value: 'setup', label: 'Set up Contentful', description: 'Configure your space' },
+      { value: 'faq', label: 'Quick question', description: 'Look up reference information' },
+    ],
+  }),
+  output: z.object({ choice: z.enum(['doctor', 'setup', 'faq']) }),
+  next: ({ output }) => {
+    if (output.choice === 'faq') return 'ask-topic';
+    if (output.choice === 'doctor') return 'get-space';
+    return `subskill:${output.choice}`;
+  },
+})
+```
+
+The dispatcher can have multiple steps before routing — `get-space` gathers the space ID before handing off to the doctor sub-skill, and `ask-topic` asks which topic to look up before resolving it.
+
+## Sub-skill registration
+
+Sub-skills are imported and registered with an optional context mapping:
+
+```typescript
+import doctorSkill from './subskills/doctor.js';
+import setupSkill from './subskills/setup.js';
+
+.subskill('doctor', doctorSkill, {
+  context: (_output, stash) => ({ spaceId: stash.spaceId }),
+})
+.subskill('setup', setupSkill)
+```
+
+The context function receives the dispatching step's output and the dispatcher's accumulated stash. Its return value becomes the sub-skill's context.
+
+## Topic registration
+
+Topics are reference entries that can be resolved directly from the dispatcher via `topic:<name>`:
+
+```typescript
+.topic('rate-limits', {
+  label: 'API rate limits and throttling',
+  content: ({ refs }) => refs.load('rate-limits.md'),
+})
+```
+
+When `next` returns `'topic:rate-limits'`, the skill loads the topic content and returns it as a `DoneResult` — no sub-skill workflow needed.
+
+## The doctor sub-skill
+
+A multi-step workflow: diagnose → suggest fixes → confirm → apply → report. Shows conditional branching (healthy spaces skip remediation) and `askUser` for fix confirmation.
+
+## The setup sub-skill
+
+Uses an `action` for deterministic environment variable detection — no LLM guessing. The `checkEnv` action reads `process.env` directly:
+
+```typescript
+const checkEnv = action({
+  name: 'check-env',
+  input: z.object({}),
+  output: z.object({ hasSpaceId: z.boolean(), hasToken: z.boolean() }),
+  run: async () => ({
+    hasSpaceId: !!process.env['CONTENTFUL_SPACE_ID'],
+    hasToken: !!process.env['CONTENTFUL_ACCESS_TOKEN'],
+  }),
+});
+```
+
+The step's `afterAction` callback stashes the results, and `next` routes based on the action output — either to guided setup or directly to configuration.
+
+## Testing
+
+Tests use `runComposite` which handles dispatcher→sub-skill routing automatically:
+
+```typescript
+import { runComposite, mockModel } from '@contentful/skill-kit/test';
+
+test('choose doctor routes through get-space to doctor sub-skill', async () => {
+  const result = await runComposite(skill, {
+    model: mockModel({
+      choose: { choice: 'doctor' },
+      'get-space': { spaceId: 'abc123' },
+      'doctor/diagnose': { issues: ['broken refs'], healthy: false },
+      'doctor/suggest-fix': { fixes: [{ issue: 'broken refs', fix: 'republish' }] },
+      'doctor/confirm-fix': { choice: 'skip' },
+      'doctor/report-issues': { summary: 'Found 1 issue.' },
+    }),
+  });
+
+  assert.equal(result.redirectedTo?.name, 'doctor');
+});
+```
+
+Sub-skill steps use prefixed names in the mock (`'doctor/diagnose'`). Topic tests provide a `refs` option pointing to the actual reference files:
+
+```typescript
+test('choose faq routes through ask-topic to topic content', async () => {
+  const result = await runComposite(skill, {
+    refs,
+    model: mockModel({
+      choose: { choice: 'faq' },
+      'ask-topic': { topicName: 'rate-limits' },
+    }),
+  });
+
+  assert.equal(result.redirectedTo?.name, 'rate-limits');
+  assert.ok(result.output.content.includes('78 requests/second'));
+});
+```
+
+Use `directSubskill` to test a sub-skill in isolation, bypassing the dispatcher entirely.

--- a/docs-site/src/pages/examples/index.mdx
+++ b/docs-site/src/pages/examples/index.mdx
@@ -3,7 +3,7 @@ layout: ../../layouts/DocsLayout.astro
 title: 'Examples'
 ---
 
-`@contentful/skill-kit` ships with two bundled examples that demonstrate different skill types.
+`@contentful/skill-kit` ships with three bundled examples that demonstrate different skill patterns.
 
 ---
 
@@ -20,3 +20,11 @@ A playful interview skill that asks the user a series of questions and produces 
 A TypeScript patterns and idioms reference skill built with the `reference()` builder. This example demonstrates the reference skill type: topic registration with labels, lazy content loading from `references/` files via `refs.load()`, inline content generation using `render.table` and `render.code`, and the progressive-disclosure pattern where the agent surfaces topic content on demand rather than dumping everything at once.
 
 [View full walkthrough](/examples/ts-patterns)
+
+---
+
+## contentful-help (Composite)
+
+A composite skill that dispatches to doctor and setup sub-skills, or resolves FAQ topics directly. This example demonstrates the composite pattern: a dispatcher state machine with `askUser` for intent selection, `.subskill()` registration with context mapping, `.topic()` registration for reference content, actions for deterministic environment checks, `subskill:` and `topic:` routing from `next`, step name namespacing, and `runComposite` for testing.
+
+[View full walkthrough](/examples/contentful-help)

--- a/docs-site/src/pages/getting-started/building.mdx
+++ b/docs-site/src/pages/getting-started/building.mdx
@@ -92,4 +92,16 @@ skill-kit check <entry.ts>
 | `unknown-tool-names`        | warning       | `host.toolsAvailable.includes()` checks referencing unrecognized tools                      |
 | `host-branching-density`    | warning       | Multiple steps branching on `host.toolsAvailable` (suggests missing primitive)              |
 
+For composite skills, additional rules apply:
+
+| Rule                           | Severity | What it catches                                              |
+| ------------------------------ | -------- | ------------------------------------------------------------ |
+| `composite-step-name`          | error    | Dispatcher step name contains `/` (reserved for namespacing) |
+| `composite-duplicate-subskill` | error    | Duplicate sub-skill name                                     |
+| `composite-duplicate-topic`    | error    | Duplicate topic name                                         |
+
 Run `check` before building to catch issues early. The `cycle-guard` and `primitive-schema-mismatch` rules in particular will save you from runtime errors that are hard to debug through an agent.
+
+## Building composite skills
+
+Composite skills build with the same `skill-kit build` command — no special flags needed. The pipeline detects registered sub-skills and generates the appropriate entry point. The output SKILL.md includes sections for sub-skills and reference topics.

--- a/docs-site/src/pages/getting-started/index.mdx
+++ b/docs-site/src/pages/getting-started/index.mdx
@@ -3,7 +3,7 @@ layout: ../../layouts/DocsLayout.astro
 title: 'Getting Started'
 ---
 
-`@contentful/skill-kit` is a TypeScript SDK for building agent skills. **Workflow skills** are typed state machines — steps with prompts, Zod schemas, and explicit transitions where the agent sees one step at a time. **Reference skills** are on-demand topic loaders for progressive disclosure of large docs. Both compile into self-contained packages that agents invoke via Bash.
+`@contentful/skill-kit` is a TypeScript SDK for building agent skills. **Workflow skills** are typed state machines — steps with prompts, Zod schemas, and explicit transitions where the agent sees one step at a time. **Reference skills** are on-demand topic loaders for progressive disclosure of large docs. **Composite skills** combine multiple sub-skills and reference topics under a single dispatcher. All compile into self-contained packages that agents invoke via Bash.
 
 ## Installation
 
@@ -72,3 +72,4 @@ const result = await runSkill(greet, {
 - [Building & Distribution](../getting-started/building/) — compile to executables or Node.js bundles, lint with `skill-kit check`
 - [Workflow Skills guide](../guides/workflow-skills/) — branching, stash, context, actions, modules
 - [Reference Skills guide](../guides/reference-skills/) — progressive disclosure with topics
+- [Composite Skills guide](../guides/composite-skills/) — sub-skills, topics, and dispatcher routing

--- a/docs-site/src/pages/getting-started/testing.mdx
+++ b/docs-site/src/pages/getting-started/testing.mdx
@@ -143,3 +143,42 @@ const result = await runSkill(mySkill, {
 ```
 
 See the [Handling validation errors](/guides/workflow-skills/#handling-validation-errors) section in the workflow skills guide for more detail.
+
+## Testing composite skills
+
+Use `runComposite` to drive a composite skill through its dispatcher and into sub-skills or topics:
+
+```typescript
+import { runComposite, mockModel } from '@contentful/skill-kit/test';
+import skill from './skill.ts';
+
+const result = await runComposite(skill, {
+  refs, // ReferenceLoader for topic content
+  model: mockModel({
+    choose: { choice: 'doctor' },
+    'get-space': { spaceId: 'abc123' },
+    'doctor/diagnose': { issues: [], healthy: true },
+    'doctor/report-clean': { summary: 'All good!' },
+  }),
+});
+
+// result.path → ['choose', 'get-space', 'doctor/diagnose', 'doctor/report-clean']
+// result.redirectedTo → { kind: 'subskill', name: 'doctor' }
+```
+
+Sub-skill steps use prefixed names in the mock model (`'doctor/diagnose'`). The `redirectedTo` field tells you which sub-skill or topic was activated.
+
+To test a sub-skill in isolation, bypassing the dispatcher:
+
+```typescript
+const result = await runComposite(skill, {
+  directSubskill: 'doctor',
+  context: { spaceId: 'test-space' },
+  model: mockModel({
+    'doctor/diagnose': { issues: [], healthy: true },
+    'doctor/report-clean': { summary: 'All good!' },
+  }),
+});
+```
+
+See the [Composite Skills guide](/guides/composite-skills/) for the full API.

--- a/docs-site/src/pages/guides/modules.mdx
+++ b/docs-site/src/pages/guides/modules.mdx
@@ -262,6 +262,10 @@ export const gatherFacts = step({
 
 For groups of steps that belong together, are reused across skills, and carry their own state. Use when you have a multi-step sequence (auth, onboarding, data collection) that appears in more than one skill.
 
+### 4. Composite skills (sub-skills)
+
+For independent workflows bundled into a single artifact with shared references. Sub-skills have isolated stash, their own entry points, and can be tested standalone — unlike modules which flatten into the parent. Use when you have related skills that overlap in scope (e.g., doctor + setup + FAQ under one dispatcher). See the [Composite Skills guide](/guides/composite-skills/).
+
 ## Testing skills with modules
 
 When testing a composed skill, the `mockModel` map uses the original step names from the module — they are merged directly into the skill's step map.

--- a/docs-site/src/pages/guides/workflow-skills.mdx
+++ b/docs-site/src/pages/guides/workflow-skills.mdx
@@ -515,3 +515,7 @@ test('remediation path: failed checks trigger fixes', async () => {
   assert.ok(result.path.includes('approve'));
 });
 ```
+
+## See also
+
+- [Composite Skills](/guides/composite-skills/) — combine multiple workflow skills under a single dispatcher with shared references

--- a/docs/api.md
+++ b/docs/api.md
@@ -312,7 +312,7 @@ const result = await runComposite(skill, {
   context: { query: 'help' },
   refs, // optional ReferenceLoader for topic content
   model: mockModel({
-    classify: { intent: 'doctor', confidence: 0.9 },
+    choose: { choice: 'doctor' },
     'get-space': { spaceId: 'abc' },
     'doctor/diagnose': { issues: [], healthy: true },
     'doctor/report-clean': { summary: 'All good!' },
@@ -322,7 +322,15 @@ const result = await runComposite(skill, {
 assert.equal(result.redirectedTo?.name, 'doctor');
 ```
 
-Use `directSubskill: 'doctor'` to bypass the dispatcher in tests.
+| Option           | Type              | Required | Description                                           |
+| ---------------- | ----------------- | -------- | ----------------------------------------------------- |
+| `model`          | `ModelAdapter`    | yes      | Provides responses for dispatcher and sub-skill steps |
+| `context`        | `object`          | no       | Dispatcher context                                    |
+| `refs`           | `ReferenceLoader` | no       | For topic content resolution (defaults to no-op)      |
+| `host`           | `Handshake`       | no       | Host identity. Defaults to generic                    |
+| `directSubskill` | `string`          | no       | Skip dispatcher, start a sub-skill directly           |
+
+The return value adds `redirectedTo?: { kind: 'subskill' | 'topic', name: string }` alongside the standard `path`, `outputs`, `output`, and `history` fields.
 
 ---
 
@@ -741,14 +749,19 @@ skill-kit check <entry.ts>
 
 Rules:
 
-| Rule                        | Severity      | What it catches                                                                                                                                                      |
-| --------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cycle-guard`               | warning/error | Warning when cycles lack `maxVisits` (implicit limit applies at runtime); error when cycle-guard config is invalid (e.g., `onMaxVisits` targets a non-existent step) |
-| `no-host-tool-names`        | error         | Direct host tool name references without `host.toolsAvailable` guard                                                                                                 |
-| `primitive-schema-mismatch` | error         | `askUser` option values missing from output enum (or vice versa)                                                                                                     |
-| `orphan-references`         | warning       | Files in `references/` not mentioned in any step prompt                                                                                                              |
-| `unknown-tool-names`        | warning       | `host.toolsAvailable.includes()` checks referencing unrecognized tools                                                                                               |
-| `host-branching-density`    | warning       | Multiple steps branching on `host.toolsAvailable` (suggests missing primitive)                                                                                       |
+| Rule                           | Severity      | What it catches                                                                                                                                                      |
+| ------------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cycle-guard`                  | warning/error | Warning when cycles lack `maxVisits` (implicit limit applies at runtime); error when cycle-guard config is invalid (e.g., `onMaxVisits` targets a non-existent step) |
+| `no-host-tool-names`           | error         | Direct host tool name references without `host.toolsAvailable` guard                                                                                                 |
+| `primitive-schema-mismatch`    | error         | `askUser` option values missing from output enum (or vice versa)                                                                                                     |
+| `orphan-references`            | warning       | Files in `references/` not mentioned in any step prompt                                                                                                              |
+| `unknown-tool-names`           | warning       | `host.toolsAvailable.includes()` checks referencing unrecognized tools                                                                                               |
+| `host-branching-density`       | warning       | Multiple steps branching on `host.toolsAvailable` (suggests missing primitive)                                                                                       |
+| `composite-step-name`          | error         | Dispatcher step name contains `/` (reserved for sub-skill namespacing)                                                                                               |
+| `composite-duplicate-subskill` | error         | Duplicate sub-skill name                                                                                                                                             |
+| `composite-duplicate-topic`    | error         | Duplicate topic name                                                                                                                                                 |
+
+For composite skills, `checkSkill` also recursively lints each registered sub-skill. Sub-skill diagnostics are prefixed with `[subskill:<name>]`.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,7 +174,7 @@ The `--mode` flag selects the bundling strategy:
 
 1. **Load** — Import the entry file, extract the default export (must be a `SkillDefinition` or `ReferenceDefinition`).
 2. **Validate** — Run lint checks (cycle guards, schema consistency).
-3. **Generate wrapper** — Create a temporary entry point that imports the skill and calls `main()` from `@contentful/skill-kit/cli`.
+3. **Generate wrapper** — Create a temporary entry point that imports the skill and calls `main()` (or `compositeMain()` if the skill has subskills) from `@contentful/skill-kit/cli`.
 4. **Bundle** — Mode-dependent:
    - **Bun mode:** For each target platform, run `bun build --compile --target bun-<platform>`. Individual target failures don't halt the pipeline; zero successful targets does.
    - **Node mode:** Run esbuild to produce a single `.mjs` bundle with all dependencies inlined.
@@ -343,6 +343,12 @@ interface LintDiagnostic {
 **`unknown-tool-names`** (warning) — `host.toolsAvailable.includes()` calls that reference tool names not in the known registry (40+ tools across Claude Code, Codex, and OpenCode).
 
 **`host-branching-density`** (warning) — Multiple steps branching on `host.toolsAvailable.includes()`. Suggests a missing SDK primitive — if several steps need host-specific logic, the pattern should probably be elevated to a primitive.
+
+**`composite-step-name`** (error) — Dispatcher step names containing `/`, which conflicts with sub-skill step namespacing.
+
+**`composite-duplicate-subskill`** / **`composite-duplicate-topic`** (error) — Duplicate names in sub-skill or topic registrations.
+
+For composite skills, `checkSkill` recursively lints each registered sub-skill. Diagnostics from sub-skills are prefixed with `[subskill:<name>]` for clarity.
 
 ---
 


### PR DESCRIPTION
## Summary

- **README.md**: Add composite as third skill type, contentful-help example, `runComposite` in testing table, update key decisions
- **SPEC.md**: Add § 10 composite CLI protocol (subskill access, topics, namespacing, RedirectResult), § 11 composite build notes (wrapper generation, SKILL.md sections)
- **docs/api.md**: Expand `runComposite` with full options table and `directSubskill`, add composite CLI commands, add composite lint rules
- **docs/architecture.md**: Composite wrapper generation in build pipeline, composite lint rules in lint system
- **docs-site getting-started**: Mention composites in intro, `runComposite` testing section, composite build/lint notes
- **docs-site guides**: Composites as 4th composition pattern in modules guide, "See also" link in workflow skills
- **docs-site examples**: Add contentful-help to index, new `contentful-help.mdx` walkthrough page
- **docs-site API**: Sync composite lint rules from docs/api.md

## Test plan

- [ ] `pnpm exec prettier --check .` passes
- [ ] Cross-check docs/api.md and docs-site/src/pages/api/index.mdx are in sync for composite sections
- [ ] Review contentful-help.mdx walkthrough against actual example code
- [ ] Verify all internal links resolve (composite-skills guide, contentful-help example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)