### PR TITLE
feat: [NT-3038] file-based session protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Sub-skills are standalone `skill().build()` definitions — testable independent
 └─────────┘                      └─────────────┘
 ```
 
-Each invocation is **stateless**. The agent passes the full conversation history via `--history` on every `advance` call. The skill reconstructs state, validates the output against the Zod schema, and returns the next step's prompt as JSON. No persistent processes — just Bash calls that every agent host already supports.
+The SDK supports two invocation modes. **Session mode** (recommended) writes protocol data to a JSONL temp file — the agent reads/writes the file instead of parsing verbose JSON from stdout. **Stateless mode** passes the full conversation history via `--history` on every `advance` call. Both modes reconstruct state, validate against Zod schemas, and return the next step's prompt. No persistent processes — just Bash calls that every agent host already supports.
 
 ### Host-aware primitives
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -831,14 +831,17 @@ The compiled skill binary is invoked by agents via Bash — one call per step. E
 
 ### Flags
 
-| Flag        | Required     | Description                                                                                                               |
-| ----------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `--context` | On `start`   | JSON string. Validated against the skill's context schema.                                                                |
-| `--step`    | On `advance` | Name of the step whose output is being submitted.                                                                         |
-| `--output`  | On `advance` | JSON string. The agent's response for the step.                                                                           |
-| `--history` | On `advance` | JSON array of `{"step": string, "output": unknown}` objects. Full conversation history.                                   |
-| `--host`    | Optional     | Host identifier for host-aware prose generation. Defaults to `generic`. Known values: `claude-code`, `codex`, `opencode`. |
-| `--help`    | —            | Print usage to stderr, exit 0.                                                                                            |
+| Flag            | Required     | Description                                                                                                               |
+| --------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `--context`     | On `start`   | JSON string. Validated against the skill's context schema.                                                                |
+| `--step`        | On `advance` | Name of the step whose output is being submitted. Not needed with `--session` in file mode.                               |
+| `--output`      | On `advance` | JSON string. The agent's response for the step. Not needed with `--session` in file mode.                                 |
+| `--history`     | On `advance` | JSON array of `{"step": string, "output": unknown}` objects. Full conversation history. Not needed with `--session`.      |
+| `--host`        | Optional     | Host identifier for host-aware prose generation. Defaults to `generic`. Known values: `claude-code`, `codex`, `opencode`. |
+| `--session`     | Optional     | `new` to create a session (start), or session ID (advance). See [Session protocol](#session-protocol-file-based).         |
+| `--session-dir` | Optional     | Directory for session files. Default: OS temp directory.                                                                  |
+| `--output-mode` | Optional     | `file` (default) or `flag`. How the agent passes step output. Only on start with `--session new`.                         |
+| `--help`        | —            | Print usage to stderr, exit 0.                                                                                            |
 
 ### Statelessness
 
@@ -877,6 +880,87 @@ The binary follows the [agentskills.io script design conventions](https://agents
 - JSON to stdout, diagnostics to stderr
 - `--long-name` flags only
 - Non-zero exit on failure with descriptive error messages
+
+### Session protocol (file-based)
+
+The stateless protocol works but produces noisy UX — every invocation dumps verbose JSON to stdout (visible in the agent's Bash tool output), and the `--history` flag grows with every step. The session protocol is an opt-in alternative that moves protocol data to a temp file.
+
+**Creating a session:**
+
+```bash
+./scripts/run --context '{"repoPath":"."}' --host claude-code --session new
+```
+
+Returns a `SessionPointer` to stdout:
+
+```json
+{ "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
+```
+
+The session file is JSONL. Line 1 is the header; line 2 is the first prompt.
+
+**Session JSONL format:**
+
+| Line type | `type` field | Description                                                                          |
+| --------- | ------------ | ------------------------------------------------------------------------------------ |
+| Header    | `header`     | Session metadata: `sessionId`, `skill`, `host`, `context`, `createdAt`, `outputMode` |
+| Prompt    | `prompt`     | Step prompt with `step`, `prompt`, `schema`, optional `preamble` and `completed`     |
+| Output    | `output`     | Agent's step response: `step`, `output`                                              |
+| Done      | `done`       | Terminal: `done: true`, `finalOutput`, `completed`                                   |
+| Error     | `error`      | Validation error: `error`, `step`, `message`, `retry`                                |
+
+Example session file:
+
+```jsonl
+{"type":"header","sessionId":"abc123","skill":"doctor","host":"claude-code","context":{},"createdAt":"2026-04-22T10:00:00Z","outputMode":"file"}
+{"type":"prompt","step":"diagnose","prompt":"Inspect the repo...","schema":{...},"preamble":"..."}
+{"type":"output","step":"diagnose","output":{"checks":[...]}}
+{"type":"prompt","step":"remediate","prompt":"Fix these...","schema":{...},"completed":{"step":"diagnose","output":{...}}}
+{"type":"output","step":"remediate","output":{"fixed":true}}
+{"type":"done","finalOutput":{"fixed":true},"completed":{"step":"remediate","output":{...}}}
+```
+
+**Output modes** — how the agent passes its step output back:
+
+- **`file` (default):** The agent appends a `{"type":"output","step":"<name>","output":{...}}` line to the JSONL file, then calls `advance --session <id>` with no `--step` or `--output` flags. The CLI reads the last output line from the file.
+- **`flag`:** The agent passes `--step <name> --output '{...}'` on the advance call. The CLI writes the output line to the file itself. Set via `--output-mode flag` at session creation.
+
+**Advancing with a session:**
+
+```bash
+# file mode (default) — agent already appended output line
+./scripts/run advance --session abc123
+# → stdout: 4    (line number of the next prompt/done)
+
+# flag mode — agent passes output as CLI args
+./scripts/run advance --step diagnose --output '{...}' --session abc123
+# → stdout: 4
+```
+
+The line number tells the agent which line to read from the session file.
+
+**History reconstruction:** The CLI reads `completed` fields from `prompt` and `done` lines to rebuild the history array. This matches the existing `--history` format exactly. No `--history` flag is needed with `--session`.
+
+**Session flags:**
+
+| Flag                       | Description                                                         |
+| -------------------------- | ------------------------------------------------------------------- |
+| `--session new`            | Create a new session (on `start`). Returns `SessionPointer`.        |
+| `--session <id>`           | Use existing session (on `advance`). Returns line number.           |
+| `--session-dir <path>`     | Override temp directory. Default: `os.tmpdir()`.                    |
+| `--output-mode file\|flag` | Set output mode (on `start` with `--session new`). Default: `file`. |
+
+**Composite skills and sessions:** One session spans the entire composite workflow. Subskill step names are prefixed in the session file (e.g., `doctor/diagnose`), same as in the stateless protocol. Direct subskill access (`./scripts/run doctor --session new`) creates a separate session for that subskill.
+
+**The `SessionPointer` type:**
+
+```typescript
+interface SessionPointer {
+  sessionId: string;
+  file: string;
+  line: number;
+}
+```
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -994,6 +994,19 @@ The `--mode` flag selects the bundling strategy:
 
 Node mode is the right choice for skills that live inside a Node.js codebase where Node is already available. Bun mode produces standalone executables that work without any runtime dependency.
 
+### Protocol mode
+
+The `--protocol` flag controls which invocation instructions the generated SKILL.md contains:
+
+| Protocol              | Flag                   | SKILL.md instructions                                                              |
+| --------------------- | ---------------------- | ---------------------------------------------------------------------------------- |
+| **session** (default) | `--protocol session`   | File-based session protocol (see [Session protocol](#session-protocol-file-based)) |
+| **stateless**         | `--protocol stateless` | Traditional `--history`-passing protocol                                           |
+
+Session mode is the default and recommended choice — it produces cleaner agent UX and shorter Bash output. Use `--protocol stateless` only for hosts that cannot write to the filesystem (e.g., sandboxed environments where the agent has no Write/echo capability).
+
+The flag only affects the generated SKILL.md. The binary itself always supports both protocols — an agent can use `--session` or `--history` regardless of what the SKILL.md says.
+
 ### Output structure
 
 **Bun mode** (default):

--- a/bin/skill-kit.js
+++ b/bin/skill-kit.js
@@ -40,13 +40,22 @@ if (command === 'build') {
         process.exit(1);
       }
       flags.mode = mode;
+    } else if (arg === '--protocol') {
+      const protocol = args[++i];
+      if (protocol !== 'session' && protocol !== 'stateless') {
+        process.stderr.write(`error: --protocol must be "session" or "stateless", got "${protocol}"\n`);
+        process.exit(1);
+      }
+      flags.protocol = protocol;
     } else if (!arg.startsWith('-')) {
       entry = arg;
     }
   }
 
   if (!entry) {
-    process.stderr.write('Usage: skill-kit build <entry.ts> -o <outdir> [--mode bun|node]\n');
+    process.stderr.write(
+      'Usage: skill-kit build <entry.ts> -o <outdir> [--mode bun|node] [--protocol session|stateless]\n',
+    );
     process.exit(1);
   }
 
@@ -56,7 +65,14 @@ if (command === 'build') {
   }
 
   try {
-    await buildSkill({ entry, outDir: flags.outDir, targets: flags.targets, single: flags.single, mode: flags.mode });
+    await buildSkill({
+      entry,
+      outDir: flags.outDir,
+      targets: flags.targets,
+      single: flags.single,
+      mode: flags.mode,
+      protocol: flags.protocol,
+    });
   } catch (err) {
     process.stderr.write(`error: ${err.message}\n`);
     process.exit(1);

--- a/docs-site/src/pages/api/index.mdx
+++ b/docs-site/src/pages/api/index.mdx
@@ -596,18 +596,20 @@ mockModel({
 Compiles a skill into a distributable [agentskills.io](https://agentskills.io/specification)-compliant directory:
 
 ```bash
-skill-kit build <entry.ts> -o <dir>                        # default (bun mode)
+skill-kit build <entry.ts> -o <dir>                        # default (bun mode, session protocol)
 skill-kit build <entry.ts> -o <dir> --mode node             # Node.js bundle
+skill-kit build <entry.ts> -o <dir> --protocol stateless    # stateless invocation instructions
 skill-kit build <entry.ts> -o <dir> --targets darwin-arm64,linux-x64,linux-arm64
 skill-kit build <entry.ts> -o <dir> --single                # current platform only (fast dev builds)
 ```
 
-| Flag        | Required | Description                                                                     |
-| ----------- | -------- | ------------------------------------------------------------------------------- |
-| `-o, --out` | yes      | Output directory                                                                |
-| `--mode`    | no       | `bun` (default, platform-specific executables) or `node` (single `.mjs` bundle) |
-| `--targets` | no       | Comma-separated platforms. Defaults to `darwin-arm64,linux-x64`. Bun mode only. |
-| `--single`  | no       | Build only for current platform. Bun mode only.                                 |
+| Flag         | Required | Description                                                                     |
+| ------------ | -------- | ------------------------------------------------------------------------------- |
+| `-o, --out`  | yes      | Output directory                                                                |
+| `--mode`     | no       | `bun` (default, platform-specific executables) or `node` (single `.mjs` bundle) |
+| `--protocol` | no       | `session` (default) or `stateless`. Controls SKILL.md invocation instructions   |
+| `--targets`  | no       | Comma-separated platforms. Defaults to `darwin-arm64,linux-x64`. Bun mode only. |
+| `--single`   | no       | Build only for current platform. Bun mode only.                                 |
 
 Output (bun mode):
 

--- a/docs-site/src/pages/api/index.mdx
+++ b/docs-site/src/pages/api/index.mdx
@@ -636,6 +636,11 @@ Output (node mode):
 Dev mode — run a skill without compiling:
 
 ```bash
+# Session mode (recommended)
+skill-kit run <entry.ts> start --context '{}' --host claude-code --session new
+skill-kit run <entry.ts> advance --session <id>
+
+# Stateless mode
 skill-kit run <entry.ts> start --context '{}' --host claude-code
 skill-kit run <entry.ts> advance --step greet --output '{"name":"Alice"}' --history '[]' --host claude-code
 ```

--- a/docs-site/src/pages/architecture/index.mdx
+++ b/docs-site/src/pages/architecture/index.mdx
@@ -7,11 +7,47 @@ How `@contentful/skill-kit` works internally. For the author-facing API, see the
 
 ---
 
-## The Stateless CLI Protocol
+## CLI Protocol
 
-A built skill is invoked by agents via Bash — one call per step. Each call is stateless: the agent passes the full conversation history on every invocation. JSON goes to stdout, diagnostics to stderr.
+A built skill is invoked by agents via Bash — one call per step. The SDK supports two invocation modes: **session mode** (recommended) which uses a temp file for communication, and **stateless mode** (fallback) which passes everything via CLI args and stdout.
 
-### Lifecycle
+### Session mode (recommended)
+
+Session mode moves protocol data to a JSONL temp file, reducing noise in the agent's Bash output and eliminating the growing `--history` flag.
+
+**1. Start** — Agent creates a session:
+
+```bash
+scripts/run --context '{"repoPath":"."}' --host claude-code --session new
+```
+
+Returns a minimal `SessionPointer` to stdout:
+
+```json
+{ "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
+```
+
+The agent reads line 2 from the session file (via the host's Read tool) to get the prompt, schema, and preamble.
+
+**2. Write output** — Agent appends its response to the session file:
+
+```bash
+echo '{"type":"output","step":"diagnose","output":{"checks":[...]}}' >> /tmp/skill-kit-abc123.jsonl
+```
+
+**3. Advance** — Agent calls advance with just the session ID:
+
+```bash
+scripts/run advance --session abc123
+```
+
+Returns a line number (e.g., `4`). The agent reads that line for the next prompt or done signal.
+
+**4. Repeat** until the line contains `"type":"done"`.
+
+### Stateless mode (fallback)
+
+In stateless mode, the agent passes the full conversation history on every invocation. JSON goes to stdout.
 
 **1. Start** — Agent calls `scripts/run` (defaults to `start`):
 
@@ -67,15 +103,18 @@ The agent retries with corrected output. The `retry: true` flag tells the agent 
 
 ### CLI Flags
 
-| Flag        | Required     | Description                                                    |
-| ----------- | ------------ | -------------------------------------------------------------- |
-| `--context` | On `start`   | JSON string validated against the skill's context schema       |
-| `--step`    | On `advance` | Name of the step whose output is being submitted               |
-| `--output`  | On `advance` | JSON string — the agent's response for the step                |
-| `--history` | On `advance` | JSON array of `{ step, output, action? }` — full history       |
-| `--host`    | Optional     | Host identifier: `claude-code`, `codex`, `opencode`, `generic` |
+| Flag            | Required     | Description                                                                  |
+| --------------- | ------------ | ---------------------------------------------------------------------------- |
+| `--context`     | On `start`   | JSON string validated against the skill's context schema                     |
+| `--step`        | On `advance` | Name of the step being submitted. Not needed with `--session` in file mode   |
+| `--output`      | On `advance` | JSON string — the agent's response. Not needed with `--session` in file mode |
+| `--history`     | On `advance` | JSON array of `{ step, output, action? }`. Not needed with `--session`       |
+| `--host`        | Optional     | Host identifier: `claude-code`, `codex`, `opencode`, `generic`               |
+| `--session`     | Optional     | `new` (start) or session ID (advance). Enables session mode                  |
+| `--session-dir` | Optional     | Directory for session files. Default: OS temp directory                      |
+| `--output-mode` | Optional     | `file` (default) or `flag`. How agent passes step output in session mode     |
 
-### Why stateless
+### Why stateless is still supported
 
 No persistent processes, no stdin piping, no subprocess lifecycle management. The agent makes sequential Bash calls and parses JSON — a pattern every agent host supports today. Statelessness also enables horizontal scaling, resumable workflows, and retry/redo logic without session corruption.
 

--- a/docs-site/src/pages/getting-started/building.mdx
+++ b/docs-site/src/pages/getting-started/building.mdx
@@ -8,20 +8,22 @@ skill-kit compiles skills into self-contained, [agentskills.io](https://agentski
 ## `skill-kit build`
 
 ```bash
-skill-kit build <entry.ts> -o <dir>                        # default: bun mode
+skill-kit build <entry.ts> -o <dir>                        # default: bun mode, session protocol
 skill-kit build <entry.ts> -o <dir> --mode node             # Node.js bundle
+skill-kit build <entry.ts> -o <dir> --protocol stateless    # stateless invocation instructions
 skill-kit build <entry.ts> -o <dir> --targets darwin-arm64,linux-x64,linux-arm64
 skill-kit build <entry.ts> -o <dir> --single                # current platform only (fast)
 ```
 
 ### Flags
 
-| Flag        | Required | Description                                                                     |
-| ----------- | -------- | ------------------------------------------------------------------------------- |
-| `-o, --out` | yes      | Output directory                                                                |
-| `--mode`    | no       | `bun` (default, platform-specific executables) or `node` (single `.mjs` bundle) |
-| `--targets` | no       | Comma-separated platforms. Defaults to `darwin-arm64,linux-x64`. Bun mode only  |
-| `--single`  | no       | Build only for current platform. Bun mode only                                  |
+| Flag         | Required | Description                                                                     |
+| ------------ | -------- | ------------------------------------------------------------------------------- |
+| `-o, --out`  | yes      | Output directory                                                                |
+| `--mode`     | no       | `bun` (default, platform-specific executables) or `node` (single `.mjs` bundle) |
+| `--protocol` | no       | `session` (default) or `stateless`. Controls SKILL.md invocation instructions   |
+| `--targets`  | no       | Comma-separated platforms. Defaults to `darwin-arm64,linux-x64`. Bun mode only  |
+| `--single`   | no       | Build only for current platform. Bun mode only                                  |
 
 ## Build modes
 

--- a/docs-site/src/pages/getting-started/building.mdx
+++ b/docs-site/src/pages/getting-started/building.mdx
@@ -67,11 +67,16 @@ skill/
 Dev mode — run a skill directly from source without compiling:
 
 ```bash
+# Session mode (recommended)
+skill-kit run <entry.ts> start --context '{}' --host claude-code --session new
+skill-kit run <entry.ts> advance --session <id>
+
+# Stateless mode
 skill-kit run <entry.ts> start --context '{}' --host claude-code
 skill-kit run <entry.ts> advance --step greet --output '{"name":"Alice"}' --history '[]' --host claude-code
 ```
 
-Useful for rapid iteration. The `start` command initializes the skill and returns the first step's prompt. The `advance` command feeds output back and returns the next step (or signals completion).
+Useful for rapid iteration. The `start` command initializes the skill and returns the first step's prompt. The `advance` command feeds output back and returns the next step (or signals completion). With `--session new`, protocol data is written to a JSONL temp file instead of stdout.
 
 ## `skill-kit check`
 

--- a/docs-site/src/pages/guides/composite-skills.mdx
+++ b/docs-site/src/pages/guides/composite-skills.mdx
@@ -81,20 +81,28 @@ The engines never see prefixes — the composite entry handles this automaticall
 
 ## CLI protocol
 
-All commands go through `scripts/run`:
+All commands go through `scripts/run`. Session mode is recommended:
 
 ```bash
-# Dispatcher flow
+# Session mode (recommended)
+scripts/run --context '{"query":"my types are broken"}' --session new
+# → {"sessionId":"abc123","file":"/tmp/skill-kit-abc123.jsonl","line":2}
+scripts/run advance --session abc123
+# → 4  (line number to read)
+
+# Stateless mode (fallback)
 scripts/run --context '{"query":"my types are broken"}'
 scripts/run advance --step classify --output '{"intent":"doctor","confidence":0.9}' --history '[...]'
 
 # Direct sub-skill access (bypasses dispatcher)
-scripts/run doctor --context '{"spaceId":"abc123"}'
+scripts/run doctor --context '{"spaceId":"abc123"}' --session new
 
 # Reference topics
 scripts/run topics
 scripts/run topic rate-limits
 ```
+
+One session spans the entire composite workflow — dispatcher and subskill steps are tracked in the same JSONL file.
 
 ## Testing composites
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -293,15 +293,39 @@ The composite entry point handles this — the host never sees `RedirectResult` 
 
 ### CLI protocol for composites
 
+Session mode (recommended):
+
 ```bash
-scripts/run --context '{...}'                        # dispatcher start
-scripts/run advance --step doctor/diagnose --output ..  # sub-skill advance
-scripts/run doctor --context '{...}'                 # direct sub-skill start
-scripts/run topics                                   # list topics
-scripts/run topic rate-limits                        # load a topic
+scripts/run --context '{...}' --session new           # dispatcher start → SessionPointer
+scripts/run advance --session <id>                     # advance (agent wrote output to file)
+scripts/run doctor --context '{...}' --session new     # direct sub-skill start
+```
+
+Stateless mode (fallback):
+
+```bash
+scripts/run --context '{...}'                          # dispatcher start
+scripts/run advance --step doctor/diagnose --output .. # sub-skill advance
+scripts/run doctor --context '{...}'                   # direct sub-skill start
+scripts/run topics                                     # list topics
+scripts/run topic rate-limits                          # load a topic
 ```
 
 Sub-skill step names are prefixed `<subskill>/<step>` at the protocol layer.
+
+### `SessionPointer`
+
+Returned by `--session new` on start:
+
+```typescript
+interface SessionPointer {
+  sessionId: string; // 8-char hex ID
+  file: string; // path to the JSONL session file
+  line: number; // line number to read for the first prompt
+}
+```
+
+See [Architecture — Session mode](./architecture.md#session-mode-recommended) for the full session lifecycle.
 
 ### Testing composites
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -719,18 +719,20 @@ mockModel({
 Compiles a skill into a distributable [agentskills.io](https://agentskills.io/specification)-compliant directory:
 
 ```bash
-skill-kit build <entry.ts> -o <dir>                        # default (bun mode)
+skill-kit build <entry.ts> -o <dir>                        # default (bun mode, session protocol)
 skill-kit build <entry.ts> -o <dir> --mode node             # Node.js bundle
+skill-kit build <entry.ts> -o <dir> --protocol stateless    # stateless invocation instructions
 skill-kit build <entry.ts> -o <dir> --targets darwin-arm64,linux-x64,linux-arm64
 skill-kit build <entry.ts> -o <dir> --single                # current platform only (fast dev builds)
 ```
 
-| Flag        | Required | Description                                                                     |
-| ----------- | -------- | ------------------------------------------------------------------------------- |
-| `-o, --out` | yes      | Output directory                                                                |
-| `--mode`    | no       | `bun` (default, platform-specific executables) or `node` (single `.mjs` bundle) |
-| `--targets` | no       | Comma-separated platforms. Defaults to `darwin-arm64,linux-x64`. Bun mode only. |
-| `--single`  | no       | Build only for current platform. Bun mode only.                                 |
+| Flag         | Required | Description                                                                     |
+| ------------ | -------- | ------------------------------------------------------------------------------- |
+| `-o, --out`  | yes      | Output directory                                                                |
+| `--mode`     | no       | `bun` (default, platform-specific executables) or `node` (single `.mjs` bundle) |
+| `--protocol` | no       | `session` (default) or `stateless`. Controls SKILL.md invocation instructions   |
+| `--targets`  | no       | Comma-separated platforms. Defaults to `darwin-arm64,linux-x64`. Bun mode only. |
+| `--single`   | no       | Build only for current platform. Bun mode only.                                 |
 
 Output (bun mode):
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,11 +4,49 @@ How `@contentful/skill-kit` works internally. For the author-facing API, see [ap
 
 ---
 
-## The Stateless CLI Protocol
+## CLI Protocol
 
-A built skill is invoked by agents via Bash — one call per step. Each call is stateless: the agent passes the full conversation history on every invocation. JSON goes to stdout, diagnostics to stderr.
+A built skill is invoked by agents via Bash — one call per step. The SDK supports two invocation modes: **session mode** (recommended) which uses a temp file for communication, and **stateless mode** (fallback) which passes everything via CLI args and stdout.
 
-### Lifecycle
+### Session mode (recommended)
+
+Session mode moves protocol data to a JSONL temp file, reducing noise in the agent's Bash output and eliminating the growing `--history` flag.
+
+**1. Start** — Agent creates a session:
+
+```bash
+scripts/run --context '{"repoPath":"."}' --host claude-code --session new
+```
+
+Returns a minimal `SessionPointer` to stdout:
+
+```json
+{ "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
+```
+
+The agent reads line 2 from the session file (via the host's Read tool) to get the prompt, schema, and preamble.
+
+**2. Write output** — Agent appends its response to the session file:
+
+```bash
+echo '{"type":"output","step":"diagnose","output":{"checks":[...]}}' >> /tmp/skill-kit-abc123.jsonl
+```
+
+**3. Advance** — Agent calls advance with just the session ID:
+
+```bash
+scripts/run advance --session abc123
+```
+
+Returns a line number (e.g., `4`). The agent reads that line for the next prompt or done signal.
+
+**4. Repeat** until the line contains `"type":"done"`.
+
+The session file is JSONL with typed lines: `header`, `prompt`, `output`, `done`, `error`. See [SPEC.md §10](../SPEC.md) for the full session file format.
+
+### Stateless mode (fallback)
+
+In stateless mode, the agent passes the full conversation history on every invocation. JSON goes to stdout.
 
 **1. Start** — Agent calls `scripts/run` (defaults to `start`):
 
@@ -55,19 +93,22 @@ The agent retries with corrected output. The `retry: true` flag tells the agent 
 
 ### CLI Flags
 
-| Flag        | Required     | Description                                                    |
-| ----------- | ------------ | -------------------------------------------------------------- |
-| `--context` | On `start`   | JSON string validated against the skill's context schema       |
-| `--step`    | On `advance` | Name of the step whose output is being submitted               |
-| `--output`  | On `advance` | JSON string — the agent's response for the step                |
-| `--history` | On `advance` | JSON array of `{ step, output, action? }` — full history       |
-| `--host`    | Optional     | Host identifier: `claude-code`, `codex`, `opencode`, `generic` |
+| Flag            | Required     | Description                                                                  |
+| --------------- | ------------ | ---------------------------------------------------------------------------- |
+| `--context`     | On `start`   | JSON string validated against the skill's context schema                     |
+| `--step`        | On `advance` | Name of the step being submitted. Not needed with `--session` in file mode   |
+| `--output`      | On `advance` | JSON string — the agent's response. Not needed with `--session` in file mode |
+| `--history`     | On `advance` | JSON array of `{ step, output, action? }`. Not needed with `--session`       |
+| `--host`        | Optional     | Host identifier: `claude-code`, `codex`, `opencode`, `generic`               |
+| `--session`     | Optional     | `new` (start) or session ID (advance). Enables session mode                  |
+| `--session-dir` | Optional     | Directory for session files. Default: OS temp directory                      |
+| `--output-mode` | Optional     | `file` (default) or `flag`. How agent passes step output in session mode     |
 
-### Why stateless
+### Why stateless is still supported
 
 No persistent processes, no stdin piping, no subprocess lifecycle management. The agent makes sequential Bash calls and parses JSON — a pattern every agent host supports today. Statelessness also enables horizontal scaling, resumable workflows, and retry/redo logic without session corruption.
 
-History replay is cheap. The engine reconstructs state (stash, visit counts) from history data without re-executing actions or observers.
+History replay is cheap. The engine reconstructs state (stash, visit counts) from history data without re-executing actions or observers. Session mode uses the same replay mechanism — it just reads history from the file instead of CLI args.
 
 ---
 

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -43,7 +43,7 @@ This returns a small JSON pointer:
 { "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
 ```
 
-Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
+Read **exactly and only** the line indicated by `line` from the session file. It contains the step prompt, schema, and preamble. Do not read any other lines.
 
 **Read the `preamble` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.
@@ -62,7 +62,7 @@ Pass your output back with the step name:
 <skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123 2>/dev/null
 ```
 
-This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.
+This returns a single line number (e.g., `4`). Read **exactly and only that line** from the session file — it contains the next prompt. Do not read any other lines.
 
 ### Step 4: Repeat until done
 

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -37,13 +37,10 @@ Determine which agent host you are running in, and pass it as `--host`:
 <skill>/scripts/run --context '{}' --host claude-code --session new 2>/dev/null
 ```
 
-This returns a small JSON pointer:
+This returns a JSON pointer with `sessionId`, `file`, and `line`. The `line` field tells you
+which line to read — it will be `2`, not `1` (line 1 is an internal header, never read it).
 
-```json
-{ "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
-```
-
-Read **exactly and only** the line indicated by `line` from the session file. It contains the step prompt, schema, and preamble. Do not read any other lines.
+Read **only** line `line` from `file`. It contains the step prompt, schema, and preamble.
 
 **Read the `preamble` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -19,6 +19,9 @@ Bash commands — do not `cd` into the skill directory.
 
 In the examples below, `<skill>/scripts/run` is a placeholder for this absolute path.
 
+**Before you begin:** Tell the user that they may be prompted to allow `scripts/run` and to
+read a file called `skill-kit-<id>.jsonl`. They should allow both permanently.
+
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
@@ -39,9 +42,6 @@ This returns a small JSON pointer:
 ```json
 { "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
 ```
-
-Before making the first call, tell the user they may be asked to allow `scripts/run` and to
-read a file called `skill-kit-<id>.jsonl` — they should allow both permanently.
 
 Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
 

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -25,7 +25,7 @@ Determine which agent host you are running in, and pass it as `--host`:
 ### Step 1: Start
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/run --context '{}' --host claude-code
+scripts/run --context '{}' --host claude-code
 ```
 
 The output is JSON with these fields:
@@ -46,7 +46,7 @@ Do what the prompt says, then produce a JSON object matching the `schema`.
 Pass your JSON output back, along with the conversation history:
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
+scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
 ```
 
 - `--step`: the step name from the previous response
@@ -85,8 +85,8 @@ Sub-skill step names are prefixed: `<subskill>/<step>` (e.g., `doctor/diagnose`)
 ### Direct sub-skill access
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/run <subskill> --context '{}'
-${CLAUDE_SKILL_DIR}/scripts/run <subskill> advance --step <step> --output '...' --history '[...]'
+scripts/run <subskill> --context '{}'
+scripts/run <subskill> advance --step <step> --output '...' --history '[...]'
 ```
 
 ### Available sub-skills
@@ -99,8 +99,8 @@ ${CLAUDE_SKILL_DIR}/scripts/run <subskill> advance --step <step> --output '...' 
 Quick-reference topics accessible without running the full workflow:
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/run topics              # list all topics
-${CLAUDE_SKILL_DIR}/scripts/run topic <name>         # load a specific topic
+scripts/run topics              # list all topics
+scripts/run topic <name>         # load a specific topic
 ```
 
 - **rate-limits**: API rate limits and throttling

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -13,6 +13,12 @@ field, and passing your response back. **Do not show the raw JSON or Bash comman
 
 ## How to run this skill
 
+This SKILL.md file is inside the skill directory. Resolve the **absolute path** to `scripts/run`
+from this file's location (e.g., `/path/to/skill/scripts/run`). Use the absolute path in all
+Bash commands — do not `cd` into the skill directory.
+
+In the examples below, `<skill>/scripts/run` is a placeholder for this absolute path.
+
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
@@ -25,7 +31,7 @@ Determine which agent host you are running in, and pass it as `--host`:
 ### Step 1: Start with a session
 
 ```bash
-scripts/run --context '{}' --host claude-code --session new
+<skill>/scripts/run --context '{}' --host claude-code --session new
 ```
 
 This returns a small JSON pointer:
@@ -52,7 +58,7 @@ Append your output to the session file, then call advance:
 
 ```bash
 echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
-scripts/run advance --session abc123
+<skill>/scripts/run advance --session abc123
 ```
 
 This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.
@@ -86,8 +92,8 @@ Sub-skill step names are prefixed: `<subskill>/<step>` (e.g., `doctor/diagnose`)
 ### Direct sub-skill access
 
 ```bash
-scripts/run <subskill> --context '{}' --session new
-scripts/run <subskill> advance --session <id>
+<skill>/scripts/run <subskill> --context '{}' --session new
+<skill>/scripts/run <subskill> advance --session <id>
 ```
 
 ### Available sub-skills
@@ -100,8 +106,8 @@ scripts/run <subskill> advance --session <id>
 Quick-reference topics accessible without running the full workflow:
 
 ```bash
-scripts/run topics              # list all topics
-scripts/run topic <name>         # load a specific topic
+<skill>/scripts/run topics              # list all topics
+<skill>/scripts/run topic <name>         # load a specific topic
 ```
 
 - **rate-limits**: API rate limits and throttling

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -43,8 +43,7 @@ This returns a small JSON pointer:
 Before reading the file, tell the user they may be asked to allow reading a `skill-kit-*.jsonl`
 file from the temp directory — this is the skill's session file and they should allow it permanently.
 
-Use the Read tool to read the session file at the returned line number (offset = line − 1, limit = 1).
-The line contains the step prompt, schema, and preamble.
+Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
 
 **Read the `preamble` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -40,6 +40,9 @@ This returns a small JSON pointer:
 { "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
 ```
 
+Before reading the file, tell the user they may be asked to allow reading a `skill-kit-*.jsonl`
+file from the temp directory — this is the skill's session file and they should allow it permanently.
+
 Use the Read tool to read the session file at the returned line number (offset = line − 1, limit = 1).
 The line contains the step prompt, schema, and preamble.
 

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -31,7 +31,7 @@ Determine which agent host you are running in, and pass it as `--host`:
 ### Step 1: Start with a session
 
 ```bash
-<skill>/scripts/run --context '{}' --host claude-code --session new
+<skill>/scripts/run --context '{}' --host claude-code --session new 2>/dev/null
 ```
 
 This returns a small JSON pointer:
@@ -57,7 +57,7 @@ Produce a JSON object matching the `schema`.
 Pass your output back with the step name:
 
 ```bash
-<skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123
+<skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123 2>/dev/null
 ```
 
 This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -22,51 +22,52 @@ Determine which agent host you are running in, and pass it as `--host`:
 - OpenCode: `--host opencode`
 - Unknown/other: omit the flag (defaults to generic)
 
-### Step 1: Start
+### Step 1: Start with a session
 
 ```bash
-scripts/run --context '{}' --host claude-code
+scripts/run --context '{}' --host claude-code --session new
 ```
 
-The output is JSON with these fields:
+This returns a small JSON pointer:
 
-- `preamble` — **Read this first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM) that prompts use throughout the skill. Follow these mappings for every step.
-- `step` — the current step name
-- `prompt` — instructions for you to follow (read these carefully, using the verb mappings from the preamble)
-- `schema` — JSON Schema describing the output you must produce
+```json
+{ "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
+```
+
+Use the Read tool to read the session file at the returned line number (offset = line − 1, limit = 1).
+The line contains the step prompt, schema, and preamble.
+
+**Read the `preamble` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
+that prompts use throughout the skill. Follow these mappings for every step.
 
 ### Step 2: Follow the prompt
 
-Read the `prompt` field. It contains instructions — follow them. The prompt may ask you to
-use specific tools (like AskUserQuestion), write files, analyze code, or interact with the user.
-Do what the prompt says, then produce a JSON object matching the `schema`.
+Read the `prompt` field from the session file line. It contains instructions — follow them.
+The prompt may ask you to use specific tools, write files, analyze code, or interact with the user.
+Produce a JSON object matching the `schema`.
 
-### Step 3: Advance
+### Step 3: Write output and advance
 
-Pass your JSON output back, along with the conversation history:
+Append your output to the session file, then call advance:
 
 ```bash
-scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
+echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
+scripts/run advance --session abc123
 ```
 
-- `--step`: the step name from the previous response
-- `--output`: your JSON response matching the schema
-- `--history`: a JSON array tracking the conversation. Start with `[]`. After each advance,
-  the response includes a `completed` field — append it to the array for the next call.
+This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.
 
 ### Step 4: Repeat until done
 
-Keep advancing until the response contains `"done": true`. The `finalOutput` field
+Keep advancing until the line you read contains `"type":"done"`. The `finalOutput` field
 contains the skill's result. Present it to the user.
 
 ### Important
 
 - **Never show raw JSON output or Bash commands to the user.** The user sees your natural
   language responses, not the protocol.
-- **Always pass `--history`** with the accumulated array. The binary is stateless — it
-  reconstructs context from the history on each call.
-- **If you get a validation error** (the response has `"error": "validation"`), read the
-  `message` field, fix your output, and retry the same step.
+- **If you get a validation error** (the response has `"error": "validation"` or `"type":"error"`),
+  read the `message` field, fix your output, and retry the same step.
 
 ## Steps in this skill
 
@@ -85,8 +86,8 @@ Sub-skill step names are prefixed: `<subskill>/<step>` (e.g., `doctor/diagnose`)
 ### Direct sub-skill access
 
 ```bash
-scripts/run <subskill> --context '{}'
-scripts/run <subskill> advance --step <step> --output '...' --history '[...]'
+scripts/run <subskill> --context '{}' --session new
+scripts/run <subskill> advance --session <id>
 ```
 
 ### Available sub-skills

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -52,13 +52,12 @@ Read the `prompt` field from the session file line. It contains instructions —
 The prompt may ask you to use specific tools, write files, analyze code, or interact with the user.
 Produce a JSON object matching the `schema`.
 
-### Step 3: Write output and advance
+### Step 3: Advance
 
-Append your output to the session file, then call advance:
+Pass your output back with the step name:
 
 ```bash
-echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
-<skill>/scripts/run advance --session abc123
+<skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123
 ```
 
 This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -40,8 +40,8 @@ This returns a small JSON pointer:
 { "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
 ```
 
-Before reading the file, tell the user they may be asked to allow reading a `skill-kit-*.jsonl`
-file from the temp directory — this is the skill's session file and they should allow it permanently.
+Before making the first call, tell the user they may be asked to allow `scripts/run` and to
+read a file called `skill-kit-<id>.jsonl` — they should allow both permanently.
 
 Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
 

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -43,7 +43,7 @@ This returns a small JSON pointer:
 { "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
 ```
 
-Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
+Read **exactly and only** the line indicated by `line` from the session file. It contains the step prompt, schema, and preamble. Do not read any other lines.
 
 **Read the `preamble` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.
@@ -62,7 +62,7 @@ Pass your output back with the step name:
 <skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123 2>/dev/null
 ```
 
-This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.
+This returns a single line number (e.g., `4`). Read **exactly and only that line** from the session file — it contains the next prompt. Do not read any other lines.
 
 ### Step 4: Repeat until done
 

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -37,13 +37,10 @@ Determine which agent host you are running in, and pass it as `--host`:
 <skill>/scripts/run --context '{}' --host claude-code --session new 2>/dev/null
 ```
 
-This returns a small JSON pointer:
+This returns a JSON pointer with `sessionId`, `file`, and `line`. The `line` field tells you
+which line to read — it will be `2`, not `1` (line 1 is an internal header, never read it).
 
-```json
-{ "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
-```
-
-Read **exactly and only** the line indicated by `line` from the session file. It contains the step prompt, schema, and preamble. Do not read any other lines.
+Read **only** line `line` from `file`. It contains the step prompt, schema, and preamble.
 
 **Read the `preamble` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -19,6 +19,9 @@ Bash commands — do not `cd` into the skill directory.
 
 In the examples below, `<skill>/scripts/run` is a placeholder for this absolute path.
 
+**Before you begin:** Tell the user that they may be prompted to allow `scripts/run` and to
+read a file called `skill-kit-<id>.jsonl`. They should allow both permanently.
+
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
@@ -39,9 +42,6 @@ This returns a small JSON pointer:
 ```json
 { "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
 ```
-
-Before making the first call, tell the user they may be asked to allow `scripts/run` and to
-read a file called `skill-kit-<id>.jsonl` — they should allow both permanently.
 
 Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
 

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -13,6 +13,12 @@ field, and passing your response back. **Do not show the raw JSON or Bash comman
 
 ## How to run this skill
 
+This SKILL.md file is inside the skill directory. Resolve the **absolute path** to `scripts/run`
+from this file's location (e.g., `/path/to/skill/scripts/run`). Use the absolute path in all
+Bash commands — do not `cd` into the skill directory.
+
+In the examples below, `<skill>/scripts/run` is a placeholder for this absolute path.
+
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
@@ -25,7 +31,7 @@ Determine which agent host you are running in, and pass it as `--host`:
 ### Step 1: Start with a session
 
 ```bash
-scripts/run --context '{}' --host claude-code --session new
+<skill>/scripts/run --context '{}' --host claude-code --session new
 ```
 
 This returns a small JSON pointer:
@@ -52,7 +58,7 @@ Append your output to the session file, then call advance:
 
 ```bash
 echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
-scripts/run advance --session abc123
+<skill>/scripts/run advance --session abc123
 ```
 
 This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -43,8 +43,7 @@ This returns a small JSON pointer:
 Before reading the file, tell the user they may be asked to allow reading a `skill-kit-*.jsonl`
 file from the temp directory — this is the skill's session file and they should allow it permanently.
 
-Use the Read tool to read the session file at the returned line number (offset = line − 1, limit = 1).
-The line contains the step prompt, schema, and preamble.
+Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
 
 **Read the `preamble` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -40,6 +40,9 @@ This returns a small JSON pointer:
 { "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
 ```
 
+Before reading the file, tell the user they may be asked to allow reading a `skill-kit-*.jsonl`
+file from the temp directory — this is the skill's session file and they should allow it permanently.
+
 Use the Read tool to read the session file at the returned line number (offset = line − 1, limit = 1).
 The line contains the step prompt, schema, and preamble.
 

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -22,51 +22,52 @@ Determine which agent host you are running in, and pass it as `--host`:
 - OpenCode: `--host opencode`
 - Unknown/other: omit the flag (defaults to generic)
 
-### Step 1: Start
+### Step 1: Start with a session
 
 ```bash
-scripts/run --context '{}' --host claude-code
+scripts/run --context '{}' --host claude-code --session new
 ```
 
-The output is JSON with these fields:
+This returns a small JSON pointer:
 
-- `preamble` — **Read this first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM) that prompts use throughout the skill. Follow these mappings for every step.
-- `step` — the current step name
-- `prompt` — instructions for you to follow (read these carefully, using the verb mappings from the preamble)
-- `schema` — JSON Schema describing the output you must produce
+```json
+{ "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
+```
+
+Use the Read tool to read the session file at the returned line number (offset = line − 1, limit = 1).
+The line contains the step prompt, schema, and preamble.
+
+**Read the `preamble` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
+that prompts use throughout the skill. Follow these mappings for every step.
 
 ### Step 2: Follow the prompt
 
-Read the `prompt` field. It contains instructions — follow them. The prompt may ask you to
-use specific tools (like AskUserQuestion), write files, analyze code, or interact with the user.
-Do what the prompt says, then produce a JSON object matching the `schema`.
+Read the `prompt` field from the session file line. It contains instructions — follow them.
+The prompt may ask you to use specific tools, write files, analyze code, or interact with the user.
+Produce a JSON object matching the `schema`.
 
-### Step 3: Advance
+### Step 3: Write output and advance
 
-Pass your JSON output back, along with the conversation history:
+Append your output to the session file, then call advance:
 
 ```bash
-scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
+echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
+scripts/run advance --session abc123
 ```
 
-- `--step`: the step name from the previous response
-- `--output`: your JSON response matching the schema
-- `--history`: a JSON array tracking the conversation. Start with `[]`. After each advance,
-  the response includes a `completed` field — append it to the array for the next call.
+This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.
 
 ### Step 4: Repeat until done
 
-Keep advancing until the response contains `"done": true`. The `finalOutput` field
+Keep advancing until the line you read contains `"type":"done"`. The `finalOutput` field
 contains the skill's result. Present it to the user.
 
 ### Important
 
 - **Never show raw JSON output or Bash commands to the user.** The user sees your natural
   language responses, not the protocol.
-- **Always pass `--history`** with the accumulated array. The binary is stateless — it
-  reconstructs context from the history on each call.
-- **If you get a validation error** (the response has `"error": "validation"`), read the
-  `message` field, fix your output, and retry the same step.
+- **If you get a validation error** (the response has `"error": "validation"` or `"type":"error"`),
+  read the `message` field, fix your output, and retry the same step.
 
 ## Steps in this skill
 

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -31,7 +31,7 @@ Determine which agent host you are running in, and pass it as `--host`:
 ### Step 1: Start with a session
 
 ```bash
-<skill>/scripts/run --context '{}' --host claude-code --session new
+<skill>/scripts/run --context '{}' --host claude-code --session new 2>/dev/null
 ```
 
 This returns a small JSON pointer:
@@ -57,7 +57,7 @@ Produce a JSON object matching the `schema`.
 Pass your output back with the step name:
 
 ```bash
-<skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123
+<skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123 2>/dev/null
 ```
 
 This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -52,13 +52,12 @@ Read the `prompt` field from the session file line. It contains instructions —
 The prompt may ask you to use specific tools, write files, analyze code, or interact with the user.
 Produce a JSON object matching the `schema`.
 
-### Step 3: Write output and advance
+### Step 3: Advance
 
-Append your output to the session file, then call advance:
+Pass your output back with the step name:
 
 ```bash
-echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
-<skill>/scripts/run advance --session abc123
+<skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123
 ```
 
 This returns a line number (e.g., `4`). Read that line from the session file for the next prompt.

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -40,8 +40,8 @@ This returns a small JSON pointer:
 { "sessionId": "abc123", "file": "/tmp/skill-kit-abc123.jsonl", "line": 2 }
 ```
 
-Before reading the file, tell the user they may be asked to allow reading a `skill-kit-*.jsonl`
-file from the temp directory — this is the skill's session file and they should allow it permanently.
+Before making the first call, tell the user they may be asked to allow `scripts/run` and to
+read a file called `skill-kit-<id>.jsonl` — they should allow both permanently.
 
 Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
 

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -25,7 +25,7 @@ Determine which agent host you are running in, and pass it as `--host`:
 ### Step 1: Start
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/run --context '{}' --host claude-code
+scripts/run --context '{}' --host claude-code
 ```
 
 The output is JSON with these fields:
@@ -46,7 +46,7 @@ Do what the prompt says, then produce a JSON object matching the `schema`.
 Pass your JSON output back, along with the conversation history:
 
 ```bash
-${CLAUDE_SKILL_DIR}/scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
+scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
 ```
 
 - `--step`: the step name from the previous response

--- a/examples/ts-patterns/skill/SKILL.md
+++ b/examples/ts-patterns/skill/SKILL.md
@@ -9,9 +9,9 @@ metadata:
 
 This skill provides reference information on demand. Load any topic for details:
 
-- `${CLAUDE_SKILL_DIR}/scripts/run topic generics` — Generics cheat sheet — constraints, conditional types, mapped types, infer
-- `${CLAUDE_SKILL_DIR}/scripts/run topic discriminated-unions` — Discriminated unions — type narrowing with literal discriminants
-- `${CLAUDE_SKILL_DIR}/scripts/run topic builder-pattern` — Builder pattern — fluent APIs with type accumulation
-- `${CLAUDE_SKILL_DIR}/scripts/run topic error-handling` — Error handling — Result types, custom errors, exhaustive matching
+- `scripts/run topic generics` — Generics cheat sheet — constraints, conditional types, mapped types, infer
+- `scripts/run topic discriminated-unions` — Discriminated unions — type narrowing with literal discriminants
+- `scripts/run topic builder-pattern` — Builder pattern — fluent APIs with type accumulation
+- `scripts/run topic error-handling` — Error handling — Result types, custom errors, exhaustive matching
 
-To list all available topics: `${CLAUDE_SKILL_DIR}/scripts/run`
+To list all available topics: `scripts/run`

--- a/examples/ts-patterns/skill/SKILL.md
+++ b/examples/ts-patterns/skill/SKILL.md
@@ -7,11 +7,13 @@ metadata:
 
 # ts-patterns
 
-This skill provides reference information on demand. Load any topic for details:
+This skill provides reference information on demand. Resolve the **absolute path** to `scripts/run`
+from this SKILL.md file's directory. Use the absolute path in all commands — do not `cd` into the
+skill directory. In the examples below, `<skill>/scripts/run` is a placeholder for this absolute path.
 
-- `scripts/run topic generics` — Generics cheat sheet — constraints, conditional types, mapped types, infer
-- `scripts/run topic discriminated-unions` — Discriminated unions — type narrowing with literal discriminants
-- `scripts/run topic builder-pattern` — Builder pattern — fluent APIs with type accumulation
-- `scripts/run topic error-handling` — Error handling — Result types, custom errors, exhaustive matching
+- `<skill>/scripts/run topic generics` — Generics cheat sheet — constraints, conditional types, mapped types, infer
+- `<skill>/scripts/run topic discriminated-unions` — Discriminated unions — type narrowing with literal discriminants
+- `<skill>/scripts/run topic builder-pattern` — Builder pattern — fluent APIs with type accumulation
+- `<skill>/scripts/run topic error-handling` — Error handling — Result types, custom errors, exhaustive matching
 
-To list all available topics: `scripts/run`
+To list all available topics: `<skill>/scripts/run`

--- a/src/build/index.test.ts
+++ b/src/build/index.test.ts
@@ -55,7 +55,7 @@ test('generateSkillMd produces valid frontmatter and invocation instructions', (
   assert.ok(result.includes('version: "1.0.0"'));
   assert.ok(result.includes('scripts/run --context'));
   assert.ok(result.includes('scripts/run advance'));
-  assert.ok(result.includes('"done": true'));
+  assert.ok(result.includes('"type":"done"'));
   assert.ok(result.includes('**start**: Begin the process.'));
 });
 
@@ -66,6 +66,36 @@ test('generateSkillMd uses default description when none provided', () => {
 
   const result = generateSkillMd(s);
   assert.ok(result.includes('minimal skill powered by @contentful/skill-kit'));
+});
+
+test('generateSkillMd with protocol=session omits stateless instructions', () => {
+  const s = skill({ name: 'test', entry: 'a' })
+    .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
+    .build();
+
+  const result = generateSkillMd(s, 'session');
+  assert.ok(result.includes('--session new'));
+  assert.ok(!result.includes('--history'));
+});
+
+test('generateSkillMd with protocol=stateless omits session instructions', () => {
+  const s = skill({ name: 'test', entry: 'a' })
+    .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
+    .build();
+
+  const result = generateSkillMd(s, 'stateless');
+  assert.ok(result.includes('--history'));
+  assert.ok(!result.includes('--session new'));
+});
+
+test('generateSkillMd default protocol is session', () => {
+  const s = skill({ name: 'test', entry: 'a' })
+    .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
+    .build();
+
+  const result = generateSkillMd(s);
+  assert.ok(result.includes('--session new'));
+  assert.ok(!result.includes('--history'));
 });
 
 test('generatePackageJson produces valid JSON with name and version', () => {

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -16,6 +16,7 @@ import { resolveTargets, type BuildTarget } from './targets.js';
 const exec = promisify(execFile);
 
 export type BuildMode = 'bun' | 'node';
+export type BuildProtocol = 'session' | 'stateless';
 
 export interface BuildOptions {
   entry: string;
@@ -23,6 +24,7 @@ export interface BuildOptions {
   targets?: string[];
   single?: boolean;
   mode?: BuildMode;
+  protocol?: BuildProtocol;
 }
 
 export interface BuildResult {
@@ -66,7 +68,8 @@ export async function buildSkill(opts: BuildOptions): Promise<BuildResult> {
   writeFileSync(runPath, runScript);
   chmodSync(runPath, 0o755);
 
-  const skillMdContent = def.kind === 'reference' ? generateReferenceMd(def) : generateSkillMd(def);
+  const protocol = opts.protocol ?? 'session';
+  const skillMdContent = def.kind === 'reference' ? generateReferenceMd(def) : generateSkillMd(def, protocol);
   const skillMdPath = join(outDir, 'SKILL.md');
   writeFileSync(skillMdPath, skillMdContent);
 

--- a/src/build/reference-md-template.ts
+++ b/src/build/reference-md-template.ts
@@ -11,17 +11,19 @@ export function generateReferenceMd(def: ReferenceDefinition): string {
   frontmatter.push('---');
 
   const topicList = Object.entries(def.topics)
-    .map(([name, topic]) => `- \`scripts/run topic ${name}\` — ${topic.label}`)
+    .map(([name, topic]) => `- \`<skill>/scripts/run topic ${name}\` — ${topic.label}`)
     .join('\n');
 
   const body = `
 # ${def.name}
 
-This skill provides reference information on demand. Load any topic for details:
+This skill provides reference information on demand. Resolve the **absolute path** to \`scripts/run\`
+from this SKILL.md file's directory. Use the absolute path in all commands — do not \`cd\` into the
+skill directory. In the examples below, \`<skill>/scripts/run\` is a placeholder for this absolute path.
 
 ${topicList}
 
-To list all available topics: \`scripts/run\`
+To list all available topics: \`<skill>/scripts/run\`
 `.trim();
 
   return frontmatter.join('\n') + '\n\n' + body + '\n';

--- a/src/build/reference-md-template.ts
+++ b/src/build/reference-md-template.ts
@@ -11,7 +11,7 @@ export function generateReferenceMd(def: ReferenceDefinition): string {
   frontmatter.push('---');
 
   const topicList = Object.entries(def.topics)
-    .map(([name, topic]) => `- \`\${CLAUDE_SKILL_DIR}/scripts/run topic ${name}\` — ${topic.label}`)
+    .map(([name, topic]) => `- \`scripts/run topic ${name}\` — ${topic.label}`)
     .join('\n');
 
   const body = `
@@ -21,7 +21,7 @@ This skill provides reference information on demand. Load any topic for details:
 
 ${topicList}
 
-To list all available topics: \`\${CLAUDE_SKILL_DIR}/scripts/run\`
+To list all available topics: \`scripts/run\`
 `.trim();
 
   return frontmatter.join('\n') + '\n\n' + body + '\n';

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -81,7 +81,7 @@ This returns a small JSON pointer:
 {"sessionId":"abc123","file":"/tmp/skill-kit-abc123.jsonl","line":2}
 \`\`\`
 
-Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
+Read **exactly and only** the line indicated by \`line\` from the session file. It contains the step prompt, schema, and preamble. Do not read any other lines.
 
 **Read the \`preamble\` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.
@@ -100,7 +100,7 @@ Pass your output back with the step name:
 <skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123 2>/dev/null
 \`\`\`
 
-This returns a line number (e.g., \`4\`). Read that line from the session file for the next prompt.
+This returns a single line number (e.g., \`4\`). Read **exactly and only that line** from the session file — it contains the next prompt. Do not read any other lines.
 
 ### Step 4: Repeat until done
 

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -70,7 +70,7 @@ function generateSessionInstructions(): string {
   return `### Step 1: Start with a session
 
 \`\`\`bash
-<skill>/scripts/run --context '{}' --host claude-code --session new
+<skill>/scripts/run --context '{}' --host claude-code --session new 2>/dev/null
 \`\`\`
 
 This returns a small JSON pointer:
@@ -95,7 +95,7 @@ Produce a JSON object matching the \`schema\`.
 Pass your output back with the step name:
 
 \`\`\`bash
-<skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123
+<skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123 2>/dev/null
 \`\`\`
 
 This returns a line number (e.g., \`4\`). Read that line from the session file for the next prompt.
@@ -111,7 +111,7 @@ function generateStatelessInstructions(): string {
   return `### Step 1: Start
 
 \`\`\`bash
-<skill>/scripts/run --context '{}' --host claude-code
+<skill>/scripts/run --context '{}' --host claude-code 2>/dev/null
 \`\`\`
 
 The output is JSON with: \`preamble\`, \`step\`, \`prompt\`, \`schema\`.
@@ -126,7 +126,7 @@ Read the \`prompt\` field. Do what it says, then produce a JSON object matching 
 ### Step 3: Advance
 
 \`\`\`bash
-<skill>/scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
+<skill>/scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code 2>/dev/null
 \`\`\`
 
 - \`--step\`: the step name from the previous response

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -42,6 +42,9 @@ field, and passing your response back. **Do not show the raw JSON or Bash comman
 
 ${SKILL_DIR_INSTRUCTION}
 
+**Before you begin:** Tell the user that they may be prompted to allow \`scripts/run\` and to
+read a file called \`skill-kit-<id>.jsonl\`. They should allow both permanently.
+
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as \`--host\`:
@@ -77,9 +80,6 @@ This returns a small JSON pointer:
 \`\`\`json
 {"sessionId":"abc123","file":"/tmp/skill-kit-abc123.jsonl","line":2}
 \`\`\`
-
-Before making the first call, tell the user they may be asked to allow \`scripts/run\` and to
-read a file called \`skill-kit-<id>.jsonl\` — they should allow both permanently.
 
 Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
 

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -39,27 +39,66 @@ Determine which agent host you are running in, and pass it as \`--host\`:
 - OpenCode: \`--host opencode\`
 - Unknown/other: omit the flag (defaults to generic)
 
-### Step 1: Start
+### Session mode (recommended)
+
+Session mode reduces output noise and manages conversation history automatically via a temp file.
+
+#### Step 1: Start with a session
+
+\`\`\`bash
+\${CLAUDE_SKILL_DIR}/scripts/run --context '{}' --host claude-code --session new
+\`\`\`
+
+This returns a small JSON pointer:
+\`\`\`json
+{"sessionId":"abc123","file":"/tmp/skill-kit-abc123.jsonl","line":2}
+\`\`\`
+
+Use the Read tool to read the session file at the returned line number (offset = line − 1, limit = 1).
+The line contains the step prompt, schema, and preamble.
+
+**Read the \`preamble\` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
+that prompts use throughout the skill. Follow these mappings for every step.
+
+#### Step 2: Follow the prompt
+
+Read the \`prompt\` field from the session file line. It contains instructions — follow them.
+The prompt may ask you to use specific tools, write files, analyze code, or interact with the user.
+Produce a JSON object matching the \`schema\`.
+
+#### Step 3: Write output and advance
+
+Append your output to the session file, then call advance:
+
+\`\`\`bash
+echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
+\${CLAUDE_SKILL_DIR}/scripts/run advance --session abc123
+\`\`\`
+
+This returns a line number (e.g., \`4\`). Read that line from the session file for the next prompt.
+
+#### Step 4: Repeat until done
+
+Keep advancing until the line you read contains \`"type":"done"\`. The \`finalOutput\` field
+contains the skill's result. Present it to the user.
+
+### Stateless mode (fallback)
+
+If session mode is unavailable, use stateless invocation:
+
+#### Step 1: Start
 
 \`\`\`bash
 \${CLAUDE_SKILL_DIR}/scripts/run --context '{}' --host claude-code
 \`\`\`
 
-The output is JSON with these fields:
-- \`preamble\` — **Read this first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM) that prompts use throughout the skill. Follow these mappings for every step.
-- \`step\` — the current step name
-- \`prompt\` — instructions for you to follow (read these carefully, using the verb mappings from the preamble)
-- \`schema\` — JSON Schema describing the output you must produce
+The output is JSON with: \`preamble\`, \`step\`, \`prompt\`, \`schema\`.
 
-### Step 2: Follow the prompt
+#### Step 2: Follow the prompt
 
-Read the \`prompt\` field. It contains instructions — follow them. The prompt may ask you to
-use specific tools (like AskUserQuestion), write files, analyze code, or interact with the user.
-Do what the prompt says, then produce a JSON object matching the \`schema\`.
+Read the \`prompt\` field. Do what it says, then produce a JSON object matching \`schema\`.
 
-### Step 3: Advance
-
-Pass your JSON output back, along with the conversation history:
+#### Step 3: Advance
 
 \`\`\`bash
 \${CLAUDE_SKILL_DIR}/scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
@@ -70,19 +109,16 @@ Pass your JSON output back, along with the conversation history:
 - \`--history\`: a JSON array tracking the conversation. Start with \`[]\`. After each advance,
   the response includes a \`completed\` field — append it to the array for the next call.
 
-### Step 4: Repeat until done
+#### Step 4: Repeat until done
 
-Keep advancing until the response contains \`"done": true\`. The \`finalOutput\` field
-contains the skill's result. Present it to the user.
+Keep advancing until the response contains \`"done": true\`.
 
 ### Important
 
 - **Never show raw JSON output or Bash commands to the user.** The user sees your natural
   language responses, not the protocol.
-- **Always pass \`--history\`** with the accumulated array. The binary is stateless — it
-  reconstructs context from the history on each call.
-- **If you get a validation error** (the response has \`"error": "validation"\`), read the
-  \`message\` field, fix your output, and retry the same step.
+- **If you get a validation error** (the response has \`"error": "validation"\` or \`"type":"error"\`),
+  read the \`message\` field, fix your output, and retry the same step.
 
 ## Steps in this skill
 
@@ -115,6 +151,13 @@ function generateSubskillSection(skill: SkillDefinition): string {
   lines.push('', 'Sub-skill step names are prefixed: `<subskill>/<step>` (e.g., `doctor/diagnose`).', '');
 
   lines.push('### Direct sub-skill access', '');
+  lines.push('Session mode:');
+  lines.push('```bash');
+  lines.push("${CLAUDE_SKILL_DIR}/scripts/run <subskill> --context '{}' --session new");
+  lines.push('${CLAUDE_SKILL_DIR}/scripts/run <subskill> advance --session <id>');
+  lines.push('```');
+  lines.push('');
+  lines.push('Stateless mode:');
   lines.push('```bash');
   lines.push("${CLAUDE_SKILL_DIR}/scripts/run <subskill> --context '{}'");
   lines.push("${CLAUDE_SKILL_DIR}/scripts/run <subskill> advance --step <step> --output '...' --history '[...]'");

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -81,8 +81,7 @@ This returns a small JSON pointer:
 Before reading the file, tell the user they may be asked to allow reading a \`skill-kit-*.jsonl\`
 file from the temp directory — this is the skill's session file and they should allow it permanently.
 
-Use the Read tool to read the session file at the returned line number (offset = line − 1, limit = 1).
-The line contains the step prompt, schema, and preamble.
+Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
 
 **Read the \`preamble\` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -90,13 +90,12 @@ Read the \`prompt\` field from the session file line. It contains instructions â
 The prompt may ask you to use specific tools, write files, analyze code, or interact with the user.
 Produce a JSON object matching the \`schema\`.
 
-### Step 3: Write output and advance
+### Step 3: Advance
 
-Append your output to the session file, then call advance:
+Pass your output back with the step name:
 
 \`\`\`bash
-echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
-<skill>/scripts/run advance --session abc123
+<skill>/scripts/run advance --step <step-name> --output '<your-json>' --session abc123
 \`\`\`
 
 This returns a line number (e.g., \`4\`). Read that line from the session file for the next prompt.

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -78,8 +78,8 @@ This returns a small JSON pointer:
 {"sessionId":"abc123","file":"/tmp/skill-kit-abc123.jsonl","line":2}
 \`\`\`
 
-Before reading the file, tell the user they may be asked to allow reading a \`skill-kit-*.jsonl\`
-file from the temp directory — this is the skill's session file and they should allow it permanently.
+Before making the first call, tell the user they may be asked to allow \`scripts/run\` and to
+read a file called \`skill-kit-<id>.jsonl\` — they should allow both permanently.
 
 Read exactly that line from the session file. It contains the step prompt, schema, and preamble.
 

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -46,7 +46,7 @@ Session mode reduces output noise and manages conversation history automatically
 #### Step 1: Start with a session
 
 \`\`\`bash
-\${CLAUDE_SKILL_DIR}/scripts/run --context '{}' --host claude-code --session new
+scripts/run --context '{}' --host claude-code --session new
 \`\`\`
 
 This returns a small JSON pointer:
@@ -72,7 +72,7 @@ Append your output to the session file, then call advance:
 
 \`\`\`bash
 echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
-\${CLAUDE_SKILL_DIR}/scripts/run advance --session abc123
+scripts/run advance --session abc123
 \`\`\`
 
 This returns a line number (e.g., \`4\`). Read that line from the session file for the next prompt.
@@ -89,7 +89,7 @@ If session mode is unavailable, use stateless invocation:
 #### Step 1: Start
 
 \`\`\`bash
-\${CLAUDE_SKILL_DIR}/scripts/run --context '{}' --host claude-code
+scripts/run --context '{}' --host claude-code
 \`\`\`
 
 The output is JSON with: \`preamble\`, \`step\`, \`prompt\`, \`schema\`.
@@ -101,7 +101,7 @@ Read the \`prompt\` field. Do what it says, then produce a JSON object matching 
 #### Step 3: Advance
 
 \`\`\`bash
-\${CLAUDE_SKILL_DIR}/scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
+scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
 \`\`\`
 
 - \`--step\`: the step name from the previous response
@@ -153,14 +153,14 @@ function generateSubskillSection(skill: SkillDefinition): string {
   lines.push('### Direct sub-skill access', '');
   lines.push('Session mode:');
   lines.push('```bash');
-  lines.push("${CLAUDE_SKILL_DIR}/scripts/run <subskill> --context '{}' --session new");
-  lines.push('${CLAUDE_SKILL_DIR}/scripts/run <subskill> advance --session <id>');
+  lines.push("scripts/run <subskill> --context '{}' --session new");
+  lines.push('scripts/run <subskill> advance --session <id>');
   lines.push('```');
   lines.push('');
   lines.push('Stateless mode:');
   lines.push('```bash');
-  lines.push("${CLAUDE_SKILL_DIR}/scripts/run <subskill> --context '{}'");
-  lines.push("${CLAUDE_SKILL_DIR}/scripts/run <subskill> advance --step <step> --output '...' --history '[...]'");
+  lines.push("scripts/run <subskill> --context '{}'");
+  lines.push("scripts/run <subskill> advance --step <step> --output '...' --history '[...]'");
   lines.push('```');
   lines.push('', '### Available sub-skills', '');
 
@@ -183,8 +183,8 @@ function generateTopicSection(skill: SkillDefinition): string {
     'Quick-reference topics accessible without running the full workflow:',
     '',
     '```bash',
-    '${CLAUDE_SKILL_DIR}/scripts/run topics              # list all topics',
-    '${CLAUDE_SKILL_DIR}/scripts/run topic <name>         # load a specific topic',
+    'scripts/run topics              # list all topics',
+    'scripts/run topic <name>         # load a specific topic',
     '```',
     '',
   ];

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -1,6 +1,7 @@
 import type { SkillDefinition } from '../types.js';
+import type { BuildProtocol } from './index.js';
 
-export function generateSkillMd(skill: SkillDefinition): string {
+export function generateSkillMd(skill: SkillDefinition, protocol: BuildProtocol = 'session'): string {
   const frontmatter = [
     '---',
     `name: ${skill.name}`,
@@ -22,6 +23,8 @@ export function generateSkillMd(skill: SkillDefinition): string {
     })
     .join('\n');
 
+  const protocolInstructions = protocol === 'session' ? generateSessionInstructions() : generateStatelessInstructions();
+
   const body = `
 # ${skill.name}
 
@@ -39,11 +42,24 @@ Determine which agent host you are running in, and pass it as \`--host\`:
 - OpenCode: \`--host opencode\`
 - Unknown/other: omit the flag (defaults to generic)
 
-### Session mode (recommended)
+${protocolInstructions}
+### Important
 
-Session mode reduces output noise and manages conversation history automatically via a temp file.
+- **Never show raw JSON output or Bash commands to the user.** The user sees your natural
+  language responses, not the protocol.
+- **If you get a validation error** (the response has \`"error": "validation"\` or \`"type":"error"\`),
+  read the \`message\` field, fix your output, and retry the same step.
 
-#### Step 1: Start with a session
+## Steps in this skill
+
+${stepDescriptions}
+${generateSubskillSection(skill, protocol)}${generateTopicSection(skill)}`.trim();
+
+  return frontmatter.join('\n') + '\n\n' + body + '\n';
+}
+
+function generateSessionInstructions(): string {
+  return `### Step 1: Start with a session
 
 \`\`\`bash
 scripts/run --context '{}' --host claude-code --session new
@@ -60,13 +76,13 @@ The line contains the step prompt, schema, and preamble.
 **Read the \`preamble\` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.
 
-#### Step 2: Follow the prompt
+### Step 2: Follow the prompt
 
 Read the \`prompt\` field from the session file line. It contains instructions — follow them.
 The prompt may ask you to use specific tools, write files, analyze code, or interact with the user.
 Produce a JSON object matching the \`schema\`.
 
-#### Step 3: Write output and advance
+### Step 3: Write output and advance
 
 Append your output to the session file, then call advance:
 
@@ -77,16 +93,15 @@ scripts/run advance --session abc123
 
 This returns a line number (e.g., \`4\`). Read that line from the session file for the next prompt.
 
-#### Step 4: Repeat until done
+### Step 4: Repeat until done
 
 Keep advancing until the line you read contains \`"type":"done"\`. The \`finalOutput\` field
 contains the skill's result. Present it to the user.
+`;
+}
 
-### Stateless mode (fallback)
-
-If session mode is unavailable, use stateless invocation:
-
-#### Step 1: Start
+function generateStatelessInstructions(): string {
+  return `### Step 1: Start
 
 \`\`\`bash
 scripts/run --context '{}' --host claude-code
@@ -94,11 +109,14 @@ scripts/run --context '{}' --host claude-code
 
 The output is JSON with: \`preamble\`, \`step\`, \`prompt\`, \`schema\`.
 
-#### Step 2: Follow the prompt
+**Read the \`preamble\` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
+that prompts use throughout the skill. Follow these mappings for every step.
+
+### Step 2: Follow the prompt
 
 Read the \`prompt\` field. Do what it says, then produce a JSON object matching \`schema\`.
 
-#### Step 3: Advance
+### Step 3: Advance
 
 \`\`\`bash
 scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
@@ -109,26 +127,14 @@ scripts/run advance --step <step-name> --output '<your-json>' --history '<histor
 - \`--history\`: a JSON array tracking the conversation. Start with \`[]\`. After each advance,
   the response includes a \`completed\` field — append it to the array for the next call.
 
-#### Step 4: Repeat until done
+### Step 4: Repeat until done
 
-Keep advancing until the response contains \`"done": true\`.
-
-### Important
-
-- **Never show raw JSON output or Bash commands to the user.** The user sees your natural
-  language responses, not the protocol.
-- **If you get a validation error** (the response has \`"error": "validation"\` or \`"type":"error"\`),
-  read the \`message\` field, fix your output, and retry the same step.
-
-## Steps in this skill
-
-${stepDescriptions}
-${generateSubskillSection(skill)}${generateTopicSection(skill)}`.trim();
-
-  return frontmatter.join('\n') + '\n\n' + body + '\n';
+Keep advancing until the response contains \`"done": true\`. The \`finalOutput\` field
+contains the skill's result. Present it to the user.
+`;
 }
 
-function generateSubskillSection(skill: SkillDefinition): string {
+function generateSubskillSection(skill: SkillDefinition, protocol: BuildProtocol): string {
   if (!skill.subskills || Object.keys(skill.subskills).length === 0) return '';
 
   const hasDispatcher = Object.keys(skill.steps).length > 0;
@@ -151,16 +157,14 @@ function generateSubskillSection(skill: SkillDefinition): string {
   lines.push('', 'Sub-skill step names are prefixed: `<subskill>/<step>` (e.g., `doctor/diagnose`).', '');
 
   lines.push('### Direct sub-skill access', '');
-  lines.push('Session mode:');
   lines.push('```bash');
-  lines.push("scripts/run <subskill> --context '{}' --session new");
-  lines.push('scripts/run <subskill> advance --session <id>');
-  lines.push('```');
-  lines.push('');
-  lines.push('Stateless mode:');
-  lines.push('```bash');
-  lines.push("scripts/run <subskill> --context '{}'");
-  lines.push("scripts/run <subskill> advance --step <step> --output '...' --history '[...]'");
+  if (protocol === 'session') {
+    lines.push("scripts/run <subskill> --context '{}' --session new");
+    lines.push('scripts/run <subskill> advance --session <id>');
+  } else {
+    lines.push("scripts/run <subskill> --context '{}'");
+    lines.push("scripts/run <subskill> advance --step <step> --output '...' --history '[...]'");
+  }
   lines.push('```');
   lines.push('', '### Available sub-skills', '');
 

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -76,12 +76,10 @@ function generateSessionInstructions(): string {
 <skill>/scripts/run --context '{}' --host claude-code --session new 2>/dev/null
 \`\`\`
 
-This returns a small JSON pointer:
-\`\`\`json
-{"sessionId":"abc123","file":"/tmp/skill-kit-abc123.jsonl","line":2}
-\`\`\`
+This returns a JSON pointer with \`sessionId\`, \`file\`, and \`line\`. The \`line\` field tells you
+which line to read — it will be \`2\`, not \`1\` (line 1 is an internal header, never read it).
 
-Read **exactly and only** the line indicated by \`line\` from the session file. It contains the step prompt, schema, and preamble. Do not read any other lines.
+Read **only** line \`line\` from \`file\`. It contains the step prompt, schema, and preamble.
 
 **Read the \`preamble\` first.** It defines verb-to-tool mappings (e.g., ASK_STRUCTURED, ASK_FREEFORM)
 that prompts use throughout the skill. Follow these mappings for every step.

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -1,6 +1,12 @@
 import type { SkillDefinition } from '../types.js';
 import type { BuildProtocol } from './index.js';
 
+const SKILL_DIR_INSTRUCTION = `This SKILL.md file is inside the skill directory. Resolve the **absolute path** to \`scripts/run\`
+from this file's location (e.g., \`/path/to/skill/scripts/run\`). Use the absolute path in all
+Bash commands — do not \`cd\` into the skill directory.
+
+In the examples below, \`<skill>/scripts/run\` is a placeholder for this absolute path.`;
+
 export function generateSkillMd(skill: SkillDefinition, protocol: BuildProtocol = 'session'): string {
   const frontmatter = [
     '---',
@@ -34,6 +40,8 @@ field, and passing your response back. **Do not show the raw JSON or Bash comman
 
 ## How to run this skill
 
+${SKILL_DIR_INSTRUCTION}
+
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as \`--host\`:
@@ -62,7 +70,7 @@ function generateSessionInstructions(): string {
   return `### Step 1: Start with a session
 
 \`\`\`bash
-scripts/run --context '{}' --host claude-code --session new
+<skill>/scripts/run --context '{}' --host claude-code --session new
 \`\`\`
 
 This returns a small JSON pointer:
@@ -88,7 +96,7 @@ Append your output to the session file, then call advance:
 
 \`\`\`bash
 echo '{"type":"output","step":"<step-name>","output":<your-json>}' >> /tmp/skill-kit-abc123.jsonl
-scripts/run advance --session abc123
+<skill>/scripts/run advance --session abc123
 \`\`\`
 
 This returns a line number (e.g., \`4\`). Read that line from the session file for the next prompt.
@@ -104,7 +112,7 @@ function generateStatelessInstructions(): string {
   return `### Step 1: Start
 
 \`\`\`bash
-scripts/run --context '{}' --host claude-code
+<skill>/scripts/run --context '{}' --host claude-code
 \`\`\`
 
 The output is JSON with: \`preamble\`, \`step\`, \`prompt\`, \`schema\`.
@@ -119,7 +127,7 @@ Read the \`prompt\` field. Do what it says, then produce a JSON object matching 
 ### Step 3: Advance
 
 \`\`\`bash
-scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
+<skill>/scripts/run advance --step <step-name> --output '<your-json>' --history '<history>' --host claude-code
 \`\`\`
 
 - \`--step\`: the step name from the previous response
@@ -159,11 +167,11 @@ function generateSubskillSection(skill: SkillDefinition, protocol: BuildProtocol
   lines.push('### Direct sub-skill access', '');
   lines.push('```bash');
   if (protocol === 'session') {
-    lines.push("scripts/run <subskill> --context '{}' --session new");
-    lines.push('scripts/run <subskill> advance --session <id>');
+    lines.push("<skill>/scripts/run <subskill> --context '{}' --session new");
+    lines.push('<skill>/scripts/run <subskill> advance --session <id>');
   } else {
-    lines.push("scripts/run <subskill> --context '{}'");
-    lines.push("scripts/run <subskill> advance --step <step> --output '...' --history '[...]'");
+    lines.push("<skill>/scripts/run <subskill> --context '{}'");
+    lines.push("<skill>/scripts/run <subskill> advance --step <step> --output '...' --history '[...]'");
   }
   lines.push('```');
   lines.push('', '### Available sub-skills', '');
@@ -187,8 +195,8 @@ function generateTopicSection(skill: SkillDefinition): string {
     'Quick-reference topics accessible without running the full workflow:',
     '',
     '```bash',
-    'scripts/run topics              # list all topics',
-    'scripts/run topic <name>         # load a specific topic',
+    '<skill>/scripts/run topics              # list all topics',
+    '<skill>/scripts/run topic <name>         # load a specific topic',
     '```',
     '',
   ];

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -78,6 +78,9 @@ This returns a small JSON pointer:
 {"sessionId":"abc123","file":"/tmp/skill-kit-abc123.jsonl","line":2}
 \`\`\`
 
+Before reading the file, tell the user they may be asked to allow reading a \`skill-kit-*.jsonl\`
+file from the temp directory — this is the skill's session file and they should allow it permanently.
+
 Use the Read tool to read the session file at the returned line number (offset = line − 1, limit = 1).
 The line contains the step prompt, schema, and preamble.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,4 +54,9 @@ export type {
   SubskillRegistration,
   RedirectResult,
   Buildable,
+  SessionPointer,
+  SessionHeader,
+  SessionOutputLine,
+  SessionOutputMode,
+  SessionLine,
 } from './types.js';

--- a/src/protocol/cli-entry.test.ts
+++ b/src/protocol/cli-entry.test.ts
@@ -105,11 +105,17 @@ test('CLI session advance in flag mode returns line number', async () => {
   const { stdout: advanceOut } = await exec(
     'npx',
     [
-      'tsx', fixturePath, 'advance',
-      '--step', 'greet',
-      '--output', '{"message":"hello"}',
-      '--session', pointer.sessionId,
-      '--session-dir', dir,
+      'tsx',
+      fixturePath,
+      'advance',
+      '--step',
+      'greet',
+      '--output',
+      '{"message":"hello"}',
+      '--session',
+      pointer.sessionId,
+      '--session-dir',
+      dir,
     ],
     { cwd: join(__dirname, '..', '..') },
   );

--- a/src/protocol/cli-entry.test.ts
+++ b/src/protocol/cli-entry.test.ts
@@ -4,10 +4,13 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { mkdtempSync, readFileSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 const exec = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturePath = join(__dirname, 'fixtures', 'simple-skill.ts');
+const multiStepFixturePath = join(__dirname, 'fixtures', 'multi-step-skill.ts');
 
 test('CLI start returns first step prompt as JSON', async () => {
   const { stdout } = await exec('npx', ['tsx', fixturePath, 'start', '--context', '{}'], {
@@ -53,4 +56,164 @@ test('CLI --help prints usage to stderr', async () => {
   assert.ok(stderr.includes('start'));
   assert.ok(stderr.includes('advance'));
   assert.ok(stderr.includes('--context'));
+});
+
+// --- Session mode tests ---
+
+function createTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'skill-kit-cli-test-'));
+}
+
+test('CLI session start returns session pointer', async () => {
+  const dir = createTempDir();
+  const { stdout } = await exec(
+    'npx',
+    ['tsx', fixturePath, 'start', '--context', '{}', '--host', 'claude-code', '--session', 'new', '--session-dir', dir],
+    { cwd: join(__dirname, '..', '..') },
+  );
+
+  const pointer = JSON.parse(stdout.trim());
+  assert.ok(pointer.sessionId);
+  assert.ok(pointer.file);
+  assert.equal(pointer.line, 2);
+
+  const fileContent = readFileSync(pointer.file, 'utf-8');
+  const lines = fileContent.trimEnd().split('\n');
+  assert.equal(lines.length, 2);
+
+  const header = JSON.parse(lines[0]!);
+  assert.equal(header.type, 'header');
+  assert.equal(header.skill, 'simple');
+  assert.equal(header.host, 'claude-code');
+
+  const prompt = JSON.parse(lines[1]!);
+  assert.equal(prompt.type, 'prompt');
+  assert.equal(prompt.step, 'greet');
+  assert.equal(prompt.prompt, 'Say hello.');
+});
+
+test('CLI session advance in flag mode returns line number', async () => {
+  const dir = createTempDir();
+
+  const { stdout: startOut } = await exec(
+    'npx',
+    ['tsx', fixturePath, 'start', '--context', '{}', '--session', 'new', '--session-dir', dir, '--output-mode', 'flag'],
+    { cwd: join(__dirname, '..', '..') },
+  );
+  const pointer = JSON.parse(startOut.trim());
+
+  const { stdout: advanceOut } = await exec(
+    'npx',
+    [
+      'tsx', fixturePath, 'advance',
+      '--step', 'greet',
+      '--output', '{"message":"hello"}',
+      '--session', pointer.sessionId,
+      '--session-dir', dir,
+    ],
+    { cwd: join(__dirname, '..', '..') },
+  );
+
+  const line = parseInt(advanceOut.trim(), 10);
+  assert.equal(line, 4);
+
+  const fileContent = readFileSync(pointer.file, 'utf-8');
+  const lines = fileContent.trimEnd().split('\n');
+  assert.equal(lines.length, 4);
+
+  const outputLine = JSON.parse(lines[2]!);
+  assert.equal(outputLine.type, 'output');
+  assert.equal(outputLine.step, 'greet');
+
+  const doneLine = JSON.parse(lines[3]!);
+  assert.equal(doneLine.type, 'done');
+  assert.equal(doneLine.done, true);
+});
+
+test('CLI session advance in file mode reads output from session file', async () => {
+  const dir = createTempDir();
+
+  const { stdout: startOut } = await exec(
+    'npx',
+    ['tsx', fixturePath, 'start', '--context', '{}', '--session', 'new', '--session-dir', dir],
+    { cwd: join(__dirname, '..', '..') },
+  );
+  const pointer = JSON.parse(startOut.trim());
+
+  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'greet', output: { message: 'hello' } }) + '\n');
+
+  const { stdout: advanceOut } = await exec(
+    'npx',
+    ['tsx', fixturePath, 'advance', '--session', pointer.sessionId, '--session-dir', dir],
+    { cwd: join(__dirname, '..', '..') },
+  );
+
+  const line = parseInt(advanceOut.trim(), 10);
+  assert.equal(line, 4);
+
+  const fileContent = readFileSync(pointer.file, 'utf-8');
+  const lines = fileContent.trimEnd().split('\n');
+
+  const doneLine = JSON.parse(lines[3]!);
+  assert.equal(doneLine.type, 'done');
+  assert.equal(doneLine.done, true);
+  assert.deepEqual(doneLine.finalOutput, { message: 'hello' });
+});
+
+test('CLI session full lifecycle with multi-step skill (file mode)', async () => {
+  const dir = createTempDir();
+
+  const { stdout: startOut } = await exec(
+    'npx',
+    ['tsx', multiStepFixturePath, 'start', '--context', '{}', '--session', 'new', '--session-dir', dir],
+    { cwd: join(__dirname, '..', '..') },
+  );
+  const pointer = JSON.parse(startOut.trim());
+  assert.equal(pointer.line, 2);
+
+  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'greet', output: { message: 'hi' } }) + '\n');
+
+  const { stdout: adv1Out } = await exec(
+    'npx',
+    ['tsx', multiStepFixturePath, 'advance', '--session', pointer.sessionId, '--session-dir', dir],
+    { cwd: join(__dirname, '..', '..') },
+  );
+  const line1 = parseInt(adv1Out.trim(), 10);
+  assert.equal(line1, 4);
+
+  const fileContent1 = readFileSync(pointer.file, 'utf-8');
+  const promptLine = JSON.parse(fileContent1.trimEnd().split('\n')[3]!);
+  assert.equal(promptLine.type, 'prompt');
+  assert.equal(promptLine.step, 'ask');
+  assert.ok(promptLine.completed);
+  assert.equal(promptLine.completed.step, 'greet');
+
+  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'ask', output: { answer: 'stuff' } }) + '\n');
+
+  const { stdout: adv2Out } = await exec(
+    'npx',
+    ['tsx', multiStepFixturePath, 'advance', '--session', pointer.sessionId, '--session-dir', dir],
+    { cwd: join(__dirname, '..', '..') },
+  );
+  const line2 = parseInt(adv2Out.trim(), 10);
+  assert.equal(line2, 6);
+
+  const fileContent2 = readFileSync(pointer.file, 'utf-8');
+  const doneLine = JSON.parse(fileContent2.trimEnd().split('\n')[5]!);
+  assert.equal(doneLine.type, 'done');
+  assert.equal(doneLine.done, true);
+  assert.deepEqual(doneLine.finalOutput, { answer: 'stuff' });
+  assert.equal(doneLine.completed.step, 'ask');
+});
+
+test('CLI session stateless mode still works without --session', async () => {
+  const { stdout } = await exec(
+    'npx',
+    ['tsx', fixturePath, 'advance', '--step', 'greet', '--output', '{"message":"hello"}', '--history', '[]'],
+    { cwd: join(__dirname, '..', '..') },
+  );
+
+  const result = JSON.parse(stdout.trim());
+  assert.equal(result.done, true);
+  assert.deepEqual(result.finalOutput, { message: 'hello' });
 });

--- a/src/protocol/cli-entry.ts
+++ b/src/protocol/cli-entry.ts
@@ -1,5 +1,7 @@
 import type { SkillDefinition } from '../types.js';
+import type { SessionOutputMode } from '../types.js';
 import { parseArgs, handleStart, handleAdvance, printHelp } from './single-invocation.js';
+import { SessionManager } from './session.js';
 
 export async function main(skill: SkillDefinition): Promise<void> {
   const { command, flags } = parseArgs(process.argv);
@@ -12,27 +14,78 @@ export async function main(skill: SkillDefinition): Promise<void> {
 
       case 'start': {
         const context = flags['context'] ? (JSON.parse(flags['context']) as unknown) : {};
-        await handleStart(skill, context, flags['host']);
+        const sessionFlag = flags['session'];
+
+        if (sessionFlag === 'new') {
+          const outputMode = (flags['output-mode'] as SessionOutputMode) ?? 'file';
+          const session = SessionManager.create({
+            sessionDir: flags['session-dir'],
+            skill: skill.name,
+            host: flags['host'] ?? 'generic',
+            context,
+            outputMode,
+          });
+          await handleStart(skill, context, flags['host'], session);
+        } else {
+          await handleStart(skill, context, flags['host']);
+        }
         break;
       }
 
       case 'advance': {
-        const step = flags['step'];
-        const output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
-        const history = flags['history']
-          ? (JSON.parse(flags['history']) as Array<{ step: string; output: unknown; action?: unknown }>)
-          : [];
+        const sessionFlag = flags['session'];
 
-        if (!step) {
-          process.stderr.write('error: --step is required for advance\n');
-          process.exit(1);
-        }
-        if (output === undefined) {
-          process.stderr.write('error: --output is required for advance\n');
-          process.exit(1);
-        }
+        if (sessionFlag && sessionFlag !== 'new') {
+          const session = SessionManager.open(sessionFlag, flags['session-dir']);
+          let stepName: string;
+          let output: unknown;
+          let history: Array<{ step: string; output: unknown; action?: unknown }>;
 
-        await handleAdvance(skill, step, output, history, flags['host']);
+          history = session.reconstructHistory();
+
+          if (session.header.outputMode === 'file' && !flags['output']) {
+            const lastOutput = session.readLastOutput();
+            if (!lastOutput) {
+              process.stderr.write('error: no output found in session file. Write your output to the session file before advancing.\n');
+              process.exit(1);
+            }
+            stepName = lastOutput.step;
+            output = lastOutput.output;
+          } else {
+            stepName = flags['step']!;
+            output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
+
+            if (!stepName) {
+              process.stderr.write('error: --step is required for advance in flag mode\n');
+              process.exit(1);
+            }
+            if (output === undefined) {
+              process.stderr.write('error: --output is required for advance in flag mode\n');
+              process.exit(1);
+            }
+
+            session.append({ type: 'output', step: stepName, output });
+          }
+
+          await handleAdvance(skill, stepName, output, history, session.header.host, session);
+        } else {
+          const step = flags['step'];
+          const output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
+          const history = flags['history']
+            ? (JSON.parse(flags['history']) as Array<{ step: string; output: unknown; action?: unknown }>)
+            : [];
+
+          if (!step) {
+            process.stderr.write('error: --step is required for advance\n');
+            process.exit(1);
+          }
+          if (output === undefined) {
+            process.stderr.write('error: --output is required for advance\n');
+            process.exit(1);
+          }
+
+          await handleAdvance(skill, step, output, history, flags['host']);
+        }
         break;
       }
     }

--- a/src/protocol/cli-entry.ts
+++ b/src/protocol/cli-entry.ts
@@ -46,7 +46,9 @@ export async function main(skill: SkillDefinition): Promise<void> {
           if (session.header.outputMode === 'file' && !flags['output']) {
             const lastOutput = session.readLastOutput();
             if (!lastOutput) {
-              process.stderr.write('error: no output found in session file. Write your output to the session file before advancing.\n');
+              process.stderr.write(
+                'error: no output found in session file. Write your output to the session file before advancing.\n',
+              );
               process.exit(1);
             }
             stepName = lastOutput.step;

--- a/src/protocol/composite-entry.test.ts
+++ b/src/protocol/composite-entry.test.ts
@@ -4,6 +4,8 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { mkdtempSync, readFileSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { parseCompositeArgs, type CompositeCommand } from './composite-entry.js';
 
 const exec = promisify(execFile);
@@ -13,6 +15,17 @@ const cwd = join(__dirname, '..', '..');
 
 async function run(...args: string[]): Promise<{ stdout: string; stderr: string }> {
   return exec('npx', ['tsx', fixturePath, ...args], { cwd });
+}
+
+function createTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'skill-kit-composite-test-'));
+}
+
+function readSessionLines(filePath: string): Array<Record<string, unknown>> {
+  return readFileSync(filePath, 'utf-8')
+    .trimEnd()
+    .split('\n')
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
 }
 
 // --- parseCompositeArgs ---
@@ -160,4 +173,111 @@ test('composite: --help lists subskills and topics', async () => {
   assert.ok(stderr.includes('basics'));
   assert.ok(stderr.includes('Sub-skills'));
   assert.ok(stderr.includes('Reference topics'));
+});
+
+// --- Session mode tests ---
+
+test('composite session: dispatcher start creates session file', async () => {
+  const dir = createTempDir();
+  const { stdout } = await run('--context', '{}', '--session', 'new', '--session-dir', dir);
+  const pointer = JSON.parse(stdout.trim());
+
+  assert.ok(pointer.sessionId);
+  assert.ok(pointer.file);
+  assert.equal(pointer.line, 2);
+
+  const lines = readSessionLines(pointer.file);
+  assert.equal(lines[0]!.type, 'header');
+  assert.equal(lines[1]!.type, 'prompt');
+  assert.equal(lines[1]!.step, 'classify');
+});
+
+test('composite session: dispatcher advance with subskill redirect (file mode)', async () => {
+  const dir = createTempDir();
+  const { stdout: startOut } = await run('--context', '{}', '--session', 'new', '--session-dir', dir);
+  const pointer = JSON.parse(startOut.trim());
+
+  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'classify', output: { intent: 'doctor' } }) + '\n');
+
+  const { stdout: advOut } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
+  const line = parseInt(advOut.trim(), 10);
+
+  const lines = readSessionLines(pointer.file);
+  const resultLine = lines[line - 1]!;
+  assert.equal(resultLine.type, 'prompt');
+  assert.equal(resultLine.step, 'doctor/diagnose');
+  assert.ok(resultLine.completed);
+});
+
+test('composite session: dispatcher advance with topic redirect (file mode)', async () => {
+  const dir = createTempDir();
+  const { stdout: startOut } = await run('--context', '{}', '--session', 'new', '--session-dir', dir);
+  const pointer = JSON.parse(startOut.trim());
+
+  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'classify', output: { intent: 'faq' } }) + '\n');
+
+  const { stdout: advOut } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
+  const line = parseInt(advOut.trim(), 10);
+
+  const lines = readSessionLines(pointer.file);
+  const resultLine = lines[line - 1]!;
+  assert.equal(resultLine.type, 'done');
+  assert.equal((resultLine as Record<string, unknown>).done, true);
+  assert.equal((resultLine.finalOutput as Record<string, unknown>).topic, 'basics');
+});
+
+test('composite session: full lifecycle dispatcher → subskill (file mode)', async () => {
+  const dir = createTempDir();
+
+  const { stdout: startOut } = await run('--context', '{}', '--session', 'new', '--session-dir', dir);
+  const pointer = JSON.parse(startOut.trim());
+
+  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'classify', output: { intent: 'doctor' } }) + '\n');
+  const { stdout: adv1 } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
+  const line1 = parseInt(adv1.trim(), 10);
+
+  const linesAfterRedirect = readSessionLines(pointer.file);
+  const subskillPrompt = linesAfterRedirect[line1 - 1]!;
+  assert.equal(subskillPrompt.step, 'doctor/diagnose');
+
+  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'doctor/diagnose', output: { issue: 'fixed' } }) + '\n');
+  const { stdout: adv2 } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
+  const line2 = parseInt(adv2.trim(), 10);
+
+  const finalLines = readSessionLines(pointer.file);
+  const doneLine = finalLines[line2 - 1]!;
+  assert.equal(doneLine.type, 'done');
+  assert.deepEqual(doneLine.finalOutput, { issue: 'fixed' });
+});
+
+test('composite session: direct subskill start (file mode)', async () => {
+  const dir = createTempDir();
+  const { stdout } = await run('doctor', '--context', '{}', '--session', 'new', '--session-dir', dir);
+  const pointer = JSON.parse(stdout.trim());
+
+  const lines = readSessionLines(pointer.file);
+  assert.equal(lines[1]!.type, 'prompt');
+  assert.equal(lines[1]!.step, 'doctor/diagnose');
+});
+
+test('composite session: flag mode advance', async () => {
+  const dir = createTempDir();
+  const { stdout: startOut } = await run(
+    '--context', '{}', '--session', 'new', '--session-dir', dir, '--output-mode', 'flag',
+  );
+  const pointer = JSON.parse(startOut.trim());
+
+  const { stdout: advOut } = await run(
+    'advance',
+    '--step', 'classify',
+    '--output', '{"intent":"faq"}',
+    '--session', pointer.sessionId,
+    '--session-dir', dir,
+  );
+  const line = parseInt(advOut.trim(), 10);
+
+  const lines = readSessionLines(pointer.file);
+  const doneLine = lines[line - 1]!;
+  assert.equal(doneLine.type, 'done');
+  assert.equal((doneLine.finalOutput as Record<string, unknown>).topic, 'basics');
 });

--- a/src/protocol/composite-entry.test.ts
+++ b/src/protocol/composite-entry.test.ts
@@ -197,7 +197,10 @@ test('composite session: dispatcher advance with subskill redirect (file mode)',
   const { stdout: startOut } = await run('--context', '{}', '--session', 'new', '--session-dir', dir);
   const pointer = JSON.parse(startOut.trim());
 
-  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'classify', output: { intent: 'doctor' } }) + '\n');
+  appendFileSync(
+    pointer.file,
+    JSON.stringify({ type: 'output', step: 'classify', output: { intent: 'doctor' } }) + '\n',
+  );
 
   const { stdout: advOut } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
   const line = parseInt(advOut.trim(), 10);
@@ -232,7 +235,10 @@ test('composite session: full lifecycle dispatcher → subskill (file mode)', as
   const { stdout: startOut } = await run('--context', '{}', '--session', 'new', '--session-dir', dir);
   const pointer = JSON.parse(startOut.trim());
 
-  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'classify', output: { intent: 'doctor' } }) + '\n');
+  appendFileSync(
+    pointer.file,
+    JSON.stringify({ type: 'output', step: 'classify', output: { intent: 'doctor' } }) + '\n',
+  );
   const { stdout: adv1 } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
   const line1 = parseInt(adv1.trim(), 10);
 
@@ -240,7 +246,10 @@ test('composite session: full lifecycle dispatcher → subskill (file mode)', as
   const subskillPrompt = linesAfterRedirect[line1 - 1]!;
   assert.equal(subskillPrompt.step, 'doctor/diagnose');
 
-  appendFileSync(pointer.file, JSON.stringify({ type: 'output', step: 'doctor/diagnose', output: { issue: 'fixed' } }) + '\n');
+  appendFileSync(
+    pointer.file,
+    JSON.stringify({ type: 'output', step: 'doctor/diagnose', output: { issue: 'fixed' } }) + '\n',
+  );
   const { stdout: adv2 } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
   const line2 = parseInt(adv2.trim(), 10);
 
@@ -263,16 +272,27 @@ test('composite session: direct subskill start (file mode)', async () => {
 test('composite session: flag mode advance', async () => {
   const dir = createTempDir();
   const { stdout: startOut } = await run(
-    '--context', '{}', '--session', 'new', '--session-dir', dir, '--output-mode', 'flag',
+    '--context',
+    '{}',
+    '--session',
+    'new',
+    '--session-dir',
+    dir,
+    '--output-mode',
+    'flag',
   );
   const pointer = JSON.parse(startOut.trim());
 
   const { stdout: advOut } = await run(
     'advance',
-    '--step', 'classify',
-    '--output', '{"intent":"faq"}',
-    '--session', pointer.sessionId,
-    '--session-dir', dir,
+    '--step',
+    'classify',
+    '--output',
+    '{"intent":"faq"}',
+    '--session',
+    pointer.sessionId,
+    '--session-dir',
+    dir,
   );
   const line = parseInt(advOut.trim(), 10);
 

--- a/src/protocol/composite-entry.ts
+++ b/src/protocol/composite-entry.ts
@@ -1,9 +1,10 @@
 import { dirname, resolve } from 'node:path';
-import type { SkillDefinition, RedirectResult, CliResult, ReferenceLoader } from '../types.js';
+import type { SkillDefinition, RedirectResult, CliResult, ReferenceLoader, SessionOutputMode } from '../types.js';
 import { WorkflowEngine } from '../runtime/engine.js';
 import { createReferenceLoader } from '../runtime/reference-loader.js';
 import { resolveHost } from './host.js';
 import { generatePreamble } from '../runtime/preamble.js';
+import { SessionManager, type SessionFile } from './session.js';
 
 function resolveSkillDir(): string {
   const binPath = process.execPath;
@@ -110,8 +111,27 @@ function prefixResult(result: CliResult, subskillName: string): CliResult {
   return result;
 }
 
-function stdout(data: unknown): void {
-  process.stdout.write(JSON.stringify(data) + '\n');
+function writeOutput(data: unknown, session: SessionFile | undefined): void {
+  if (session) {
+    const line = session.appendResult(data as CliResult);
+    session.writePointer(line);
+  } else {
+    process.stdout.write(JSON.stringify(data) + '\n');
+  }
+}
+
+function writeStartOutput(data: unknown, session: SessionFile | undefined): void {
+  if (session) {
+    const line = session.appendResult(data as CliResult);
+    session.writeStartPointer(line);
+  } else {
+    process.stdout.write(JSON.stringify(data) + '\n');
+  }
+}
+
+interface SessionContext {
+  session: SessionFile | undefined;
+  isStart: boolean;
 }
 
 export async function compositeMain(def: SkillDefinition, refsBasePath?: string): Promise<void> {
@@ -169,27 +189,64 @@ function handleTopic(def: SkillDefinition, topicName: string, refs: ReferenceLoa
   if (!content.endsWith('\n')) process.stdout.write('\n');
 }
 
-async function handleDispatcher(
-  def: SkillDefinition,
-  parsed: { command: 'start' | 'advance'; flags: Record<string, string> },
-  refs: ReferenceLoader,
-): Promise<void> {
-  const handshake = resolveHost(parsed.flags['host']);
+function resolveSessionForCommand(
+  flags: Record<string, string>,
+  command: 'start' | 'advance',
+  skillName: string,
+): SessionContext {
+  const sessionFlag = flags['session'];
 
-  if (parsed.command === 'start') {
-    const context = parsed.flags['context'] ? (JSON.parse(parsed.flags['context']) as unknown) : {};
-    const engine = new WorkflowEngine(def, handshake, context, refs);
-    const result = engine.start();
-    result.preamble = generatePreamble(handshake);
-    stdout(result);
-    return;
+  if (command === 'start' && sessionFlag === 'new') {
+    const outputMode = (flags['output-mode'] as SessionOutputMode) ?? 'file';
+    const session = SessionManager.create({
+      sessionDir: flags['session-dir'],
+      skill: skillName,
+      host: flags['host'] ?? 'generic',
+      context: flags['context'] ? (JSON.parse(flags['context']) as unknown) : {},
+      outputMode,
+    });
+    return { session, isStart: true };
   }
 
-  const stepName = parsed.flags['step'];
-  const output = parsed.flags['output'] ? (JSON.parse(parsed.flags['output']) as unknown) : undefined;
-  const history: HistoryEntry[] = parsed.flags['history']
-    ? (JSON.parse(parsed.flags['history']) as HistoryEntry[])
-    : [];
+  if (command === 'advance' && sessionFlag && sessionFlag !== 'new') {
+    const session = SessionManager.open(sessionFlag, flags['session-dir']);
+    return { session, isStart: false };
+  }
+
+  return { session: undefined, isStart: command === 'start' };
+}
+
+function resolveAdvanceInput(
+  flags: Record<string, string>,
+  session: SessionFile | undefined,
+): { stepName: string; output: unknown; history: HistoryEntry[] } {
+  if (session) {
+    const history = session.reconstructHistory();
+
+    if (session.header.outputMode === 'file' && !flags['output']) {
+      const lastOutput = session.readLastOutput();
+      if (!lastOutput) {
+        process.stderr.write(
+          'error: no output found in session file. Write your output to the session file before advancing.\n',
+        );
+        process.exit(1);
+      }
+      return { stepName: lastOutput.step, output: lastOutput.output, history };
+    }
+
+    const stepName = flags['step']!;
+    const output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
+    if (!stepName || output === undefined) {
+      process.stderr.write('error: --step and --output are required for advance in flag mode\n');
+      process.exit(1);
+    }
+    session.append({ type: 'output', step: stepName, output });
+    return { stepName, output, history };
+  }
+
+  const stepName = flags['step']!;
+  const output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
+  const history: HistoryEntry[] = flags['history'] ? (JSON.parse(flags['history']) as HistoryEntry[]) : [];
 
   if (!stepName) {
     process.stderr.write('error: --step is required for advance\n');
@@ -200,10 +257,31 @@ async function handleDispatcher(
     process.exit(1);
   }
 
+  return { stepName, output, history };
+}
+
+async function handleDispatcher(
+  def: SkillDefinition,
+  parsed: { command: 'start' | 'advance'; flags: Record<string, string> },
+  refs: ReferenceLoader,
+): Promise<void> {
+  const { session, isStart } = resolveSessionForCommand(parsed.flags, parsed.command, def.name);
+  const handshake = resolveHost(session?.header.host ?? parsed.flags['host']);
+
+  if (isStart) {
+    const context = parsed.flags['context'] ? (JSON.parse(parsed.flags['context']) as unknown) : {};
+    const engine = new WorkflowEngine(def, handshake, context, refs);
+    const result = engine.start();
+    result.preamble = generatePreamble(handshake);
+    writeStartOutput(result, session);
+    return;
+  }
+
+  const { stepName, output, history } = resolveAdvanceInput(parsed.flags, session);
+
   const parsed_ = unprefixStep(stepName);
   if (parsed_) {
-    // Step is namespaced (e.g. 'doctor/diagnose') — route to sub-skill advance
-    await handleSubskillAdvance(def, parsed_.subskill, parsed_.step, output, history, handshake, refs);
+    await handleSubskillAdvance(def, parsed_.subskill, parsed_.step, output, history, handshake, refs, session);
     return;
   }
 
@@ -217,11 +295,11 @@ async function handleDispatcher(
   const result = await engine.advance(stepName, output);
 
   if ('redirect' in result) {
-    await handleRedirect(def, result as RedirectResult, handshake, refs);
+    await handleRedirect(def, result as RedirectResult, handshake, refs, session);
     return;
   }
 
-  stdout(result);
+  writeOutput(result, session);
 }
 
 async function handleSubskill(
@@ -235,33 +313,20 @@ async function handleSubskill(
     process.exit(1);
   }
 
-  const handshake = resolveHost(parsed.flags['host']);
+  const { session, isStart } = resolveSessionForCommand(parsed.flags, parsed.command, def.name);
+  const handshake = resolveHost(session?.header.host ?? parsed.flags['host']);
 
-  if (parsed.command === 'start') {
+  if (isStart) {
     const context = parsed.flags['context'] ? (JSON.parse(parsed.flags['context']) as unknown) : {};
     const engine = new WorkflowEngine(sub.definition, handshake, context, refs);
     const result = engine.start();
     result.preamble = generatePreamble(handshake);
-    stdout(prefixResult(result, parsed.name));
+    writeStartOutput(prefixResult(result, parsed.name), session);
     return;
   }
 
-  const stepName = parsed.flags['step'];
-  const output = parsed.flags['output'] ? (JSON.parse(parsed.flags['output']) as unknown) : undefined;
-  const history: HistoryEntry[] = parsed.flags['history']
-    ? (JSON.parse(parsed.flags['history']) as HistoryEntry[])
-    : [];
-
-  if (!stepName) {
-    process.stderr.write('error: --step is required for advance\n');
-    process.exit(1);
-  }
-  if (output === undefined) {
-    process.stderr.write('error: --output is required for advance\n');
-    process.exit(1);
-  }
-
-  await handleSubskillAdvance(def, parsed.name, stepName, output, history, handshake, refs);
+  const { stepName, output, history } = resolveAdvanceInput(parsed.flags, session);
+  await handleSubskillAdvance(def, parsed.name, stepName, output, history, handshake, refs, session);
 }
 
 async function handleSubskillAdvance(
@@ -272,6 +337,7 @@ async function handleSubskillAdvance(
   history: HistoryEntry[],
   handshake: ReturnType<typeof resolveHost>,
   refs: ReferenceLoader,
+  session: SessionFile | undefined,
 ): Promise<void> {
   const sub = def.subskills?.[subskillName];
   if (!sub) {
@@ -287,7 +353,7 @@ async function handleSubskillAdvance(
   engine.start();
 
   const result = await engine.advance(stepName, output);
-  stdout(prefixResult(result, subskillName));
+  writeOutput(prefixResult(result, subskillName), session);
 }
 
 async function handleRedirect(
@@ -295,6 +361,7 @@ async function handleRedirect(
   redirect: RedirectResult,
   handshake: ReturnType<typeof resolveHost>,
   refs: ReferenceLoader,
+  session: SessionFile | undefined,
 ): Promise<void> {
   const target = redirect.redirect;
 
@@ -305,7 +372,7 @@ async function handleRedirect(
       throw new Error(`Redirect to unknown topic "${topicName}"`);
     }
     const content = topic.content({ refs });
-    stdout({ done: true, finalOutput: { topic: topicName, content }, completed: redirect.completed });
+    writeOutput({ done: true, finalOutput: { topic: topicName, content }, completed: redirect.completed }, session);
     return;
   }
 
@@ -319,7 +386,7 @@ async function handleRedirect(
     const context = sub.contextMap ? sub.contextMap(redirect.completed.output, redirect.stash) : {};
     const engine = new WorkflowEngine(sub.definition, handshake, context, refs);
     const result = engine.start();
-    stdout({ ...prefixResult(result, subName), completed: redirect.completed });
+    writeOutput({ ...prefixResult(result, subName), completed: redirect.completed }, session);
     return;
   }
 
@@ -334,7 +401,8 @@ function printCompositeHelp(def: SkillDefinition): void {
     `${def.name} — composite skill`,
     '',
     'Usage:',
-    `  ${def.name} --context '{"key":"value"}' [--host claude-code]`,
+    `  ${def.name} --context '{"key":"value"}' [--host claude-code] [--session new]`,
+    `  ${def.name} advance --session <id>`,
     `  ${def.name} advance --step <name> --output '{"..."}' --history '[...]'`,
   ];
 
@@ -363,12 +431,15 @@ function printCompositeHelp(def: SkillDefinition): void {
 
   lines.push('');
   lines.push('Flags:');
-  lines.push('  --context   JSON string. Validated against context schema. (start only)');
-  lines.push('  --step      Step name (advance only). Sub-skill steps are prefixed: <subskill>/<step>');
-  lines.push('  --output    JSON string. Agent response for the step. (advance only)');
-  lines.push('  --history   JSON array of {step, output, action?} objects. (advance only)');
-  lines.push('  --host      Host identifier for prose generation. Default: generic.');
-  lines.push('  --help      Print this message.');
+  lines.push('  --context      JSON string. Validated against context schema. (start only)');
+  lines.push('  --step         Step name (advance only). Sub-skill steps: <subskill>/<step>');
+  lines.push('  --output       JSON string. Agent response for the step. (advance only)');
+  lines.push('  --history      JSON array of {step, output, action?} objects. (advance only)');
+  lines.push('  --host         Host identifier for prose generation. Default: generic.');
+  lines.push('  --session      "new" to create a session (start), or session ID (advance).');
+  lines.push('  --session-dir  Directory for session files. Default: OS temp directory.');
+  lines.push('  --output-mode  "file" (default) or "flag". How agent passes step output.');
+  lines.push('  --help         Print this message.');
 
   process.stderr.write(lines.join('\n') + '\n');
 }

--- a/src/protocol/fixtures/multi-step-skill.ts
+++ b/src/protocol/fixtures/multi-step-skill.ts
@@ -1,0 +1,17 @@
+import { skill, z } from '../../index.js';
+import { main } from '../../cli.js';
+
+const s = skill({ name: 'multi-step', entry: 'greet' })
+  .step('greet', {
+    prompt: 'Say hello.',
+    output: z.object({ message: z.string() }),
+    next: 'ask',
+  })
+  .step('ask', {
+    prompt: 'Ask a question.',
+    output: z.object({ answer: z.string() }),
+    next: { terminal: true },
+  })
+  .build();
+
+main(s);

--- a/src/protocol/session.test.ts
+++ b/src/protocol/session.test.ts
@@ -1,0 +1,286 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SessionManager } from './session.js';
+import type { PromptResult, DoneResult, ValidationErrorResult } from '../types.js';
+
+function createTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'skill-kit-test-'));
+}
+
+test('SessionManager.create writes header and returns SessionFile', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: { path: '.' },
+  });
+
+  assert.match(session.sessionId, /^[a-f0-9]{8}$/);
+  assert.equal(session.header.type, 'header');
+  assert.equal(session.header.skill, 'test-skill');
+  assert.equal(session.header.host, 'claude-code');
+  assert.deepEqual(session.header.context, { path: '.' });
+  assert.equal(session.header.outputMode, 'file');
+
+  const content = readFileSync(session.filePath, 'utf-8');
+  const header = JSON.parse(content.trimEnd());
+  assert.equal(header.type, 'header');
+  assert.equal(header.sessionId, session.sessionId);
+});
+
+test('SessionManager.create respects outputMode flag', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+    outputMode: 'flag',
+  });
+
+  assert.equal(session.header.outputMode, 'flag');
+});
+
+test('SessionManager.open reads existing session', () => {
+  const dir = createTempDir();
+  const created = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: { key: 'value' },
+  });
+
+  const opened = SessionManager.open(created.sessionId, dir);
+  assert.equal(opened.sessionId, created.sessionId);
+  assert.equal(opened.filePath, created.filePath);
+  assert.equal(opened.header.skill, 'test-skill');
+  assert.deepEqual(opened.header.context, { key: 'value' });
+});
+
+test('SessionManager.open throws for nonexistent session', () => {
+  const dir = createTempDir();
+  assert.throws(() => SessionManager.open('deadbeef', dir), /session "deadbeef" not found/);
+});
+
+test('SessionFile.append returns incrementing line numbers', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  const line2 = session.append({ type: 'prompt', step: 'greet', prompt: 'Hello', schema: {} });
+  assert.equal(line2, 2);
+
+  const line3 = session.append({ type: 'output', step: 'greet', output: { message: 'hi' } });
+  assert.equal(line3, 3);
+
+  const line4 = session.append({ type: 'prompt', step: 'ask', prompt: 'What?', schema: {} });
+  assert.equal(line4, 4);
+});
+
+test('SessionFile.lineCount returns correct count', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  assert.equal(session.lineCount(), 1);
+  session.append({ type: 'prompt', step: 'greet', prompt: 'Hello', schema: {} });
+  assert.equal(session.lineCount(), 2);
+});
+
+test('SessionFile.reconstructHistory builds history from completed fields', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  session.append({ type: 'prompt', step: 'greet', prompt: 'Hello', schema: {} });
+  session.append({ type: 'output', step: 'greet', output: { message: 'hi' } });
+  session.append({
+    type: 'prompt',
+    step: 'ask',
+    prompt: 'What?',
+    schema: {},
+    completed: { step: 'greet', output: { message: 'hi' } },
+  });
+  session.append({ type: 'output', step: 'ask', output: { answer: 'stuff' } });
+  session.append({
+    type: 'done',
+    done: true,
+    finalOutput: { result: 'ok' },
+    completed: { step: 'ask', output: { answer: 'stuff' }, action: { status: 200 } },
+  });
+
+  const history = session.reconstructHistory();
+  assert.equal(history.length, 2);
+  assert.deepEqual(history[0], { step: 'greet', output: { message: 'hi' } });
+  assert.deepEqual(history[1], { step: 'ask', output: { answer: 'stuff' }, action: { status: 200 } });
+});
+
+test('SessionFile.reconstructHistory returns empty for fresh session', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  session.append({ type: 'prompt', step: 'greet', prompt: 'Hello', schema: {} });
+
+  const history = session.reconstructHistory();
+  assert.equal(history.length, 0);
+});
+
+test('SessionFile.readLastOutput finds the last output line', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  session.append({ type: 'prompt', step: 'greet', prompt: 'Hello', schema: {} });
+  session.append({ type: 'output', step: 'greet', output: { message: 'hi' } });
+  session.append({
+    type: 'prompt',
+    step: 'ask',
+    prompt: 'What?',
+    schema: {},
+    completed: { step: 'greet', output: { message: 'hi' } },
+  });
+  session.append({ type: 'output', step: 'ask', output: { answer: 'stuff' } });
+
+  const last = session.readLastOutput();
+  assert.deepEqual(last, { step: 'ask', output: { answer: 'stuff' } });
+});
+
+test('SessionFile.readLastOutput returns null when no output lines exist', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  session.append({ type: 'prompt', step: 'greet', prompt: 'Hello', schema: {} });
+
+  assert.equal(session.readLastOutput(), null);
+});
+
+test('SessionFile.appendResult adds type field to PromptResult', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  const result: PromptResult = { step: 'greet', prompt: 'Hello', schema: { type: 'object' } };
+  const line = session.appendResult(result);
+  assert.equal(line, 2);
+
+  const content = readFileSync(session.filePath, 'utf-8');
+  const lines = content.trimEnd().split('\n');
+  const parsed = JSON.parse(lines[1]!);
+  assert.equal(parsed.type, 'prompt');
+  assert.equal(parsed.step, 'greet');
+});
+
+test('SessionFile.appendResult adds type field to DoneResult', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  const result: DoneResult = { done: true, finalOutput: { summary: 'done' } };
+  session.appendResult(result);
+
+  const content = readFileSync(session.filePath, 'utf-8');
+  const lines = content.trimEnd().split('\n');
+  const parsed = JSON.parse(lines[1]!);
+  assert.equal(parsed.type, 'done');
+  assert.equal(parsed.done, true);
+});
+
+test('SessionFile.appendResult adds type field to ValidationErrorResult', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  const result: ValidationErrorResult = { error: 'validation', step: 'greet', message: 'bad', retry: true };
+  session.appendResult(result);
+
+  const content = readFileSync(session.filePath, 'utf-8');
+  const lines = content.trimEnd().split('\n');
+  const parsed = JSON.parse(lines[1]!);
+  assert.equal(parsed.type, 'error');
+  assert.equal(parsed.error, 'validation');
+});
+
+test('SessionFile.cleanup removes the session file', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  session.cleanup();
+  assert.throws(() => SessionManager.open(session.sessionId, dir), /not found/);
+});
+
+test('SessionManager.cleanup removes session file by id', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  SessionManager.cleanup(session.sessionId, dir);
+  assert.throws(() => SessionManager.open(session.sessionId, dir), /not found/);
+});
+
+test('SessionFile handles malformed lines gracefully', () => {
+  const dir = createTempDir();
+  const session = SessionManager.create({
+    sessionDir: dir,
+    skill: 'test-skill',
+    host: 'claude-code',
+    context: {},
+  });
+
+  appendFileSync(session.filePath, '{"type":"prompt","step":"greet","prompt":"Hello","schema":{}}\n');
+  appendFileSync(session.filePath, 'not valid json\n');
+  appendFileSync(session.filePath, '{"type":"output","step":"greet","output":{"message":"hi"}}\n');
+
+  const last = session.readLastOutput();
+  assert.deepEqual(last, { step: 'greet', output: { message: 'hi' } });
+});

--- a/src/protocol/session.ts
+++ b/src/protocol/session.ts
@@ -2,13 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { readFileSync, appendFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type {
-  SessionHeader,
-  SessionOutputMode,
-  SessionPointer,
-  CliResult,
-  StepResult,
-} from '../types.js';
+import type { SessionHeader, SessionOutputMode, SessionPointer, CliResult, StepResult } from '../types.js';
 
 const SESSION_ID_LENGTH = 4;
 const SESSION_FILE_PREFIX = 'skill-kit-';

--- a/src/protocol/session.ts
+++ b/src/protocol/session.ts
@@ -1,0 +1,178 @@
+import { randomBytes } from 'node:crypto';
+import { readFileSync, appendFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  SessionHeader,
+  SessionOutputMode,
+  SessionPointer,
+  CliResult,
+  StepResult,
+} from '../types.js';
+
+const SESSION_ID_LENGTH = 4;
+const SESSION_FILE_PREFIX = 'skill-kit-';
+const SESSION_FILE_SUFFIX = '.jsonl';
+
+function generateSessionId(): string {
+  return randomBytes(SESSION_ID_LENGTH).toString('hex');
+}
+
+function sessionFilePath(sessionDir: string, sessionId: string): string {
+  return join(sessionDir, `${SESSION_FILE_PREFIX}${sessionId}${SESSION_FILE_SUFFIX}`);
+}
+
+export interface CreateSessionOptions {
+  sessionDir?: string;
+  skill: string;
+  host: string;
+  context: unknown;
+  outputMode?: SessionOutputMode;
+}
+
+export class SessionFile {
+  readonly sessionId: string;
+  readonly filePath: string;
+  readonly header: SessionHeader;
+
+  constructor(sessionId: string, filePath: string, header: SessionHeader) {
+    this.sessionId = sessionId;
+    this.filePath = filePath;
+    this.header = header;
+  }
+
+  append(line: Record<string, unknown>): number {
+    appendFileSync(this.filePath, JSON.stringify(line) + '\n');
+    return this.lineCount();
+  }
+
+  lineCount(): number {
+    const content = readFileSync(this.filePath, 'utf-8');
+    return content.trimEnd().split('\n').length;
+  }
+
+  reconstructHistory(): Array<{ step: string; output: unknown; action?: unknown }> {
+    const lines = this.readLines();
+    const history: Array<{ step: string; output: unknown; action?: unknown }> = [];
+
+    for (const line of lines) {
+      if (line.type === 'prompt' || line.type === 'done') {
+        const completed = (line as Record<string, unknown>).completed as StepResult | undefined;
+        if (completed) {
+          history.push({
+            step: completed.step,
+            output: completed.output,
+            ...(completed.action !== undefined ? { action: completed.action } : {}),
+          });
+        }
+      }
+    }
+
+    return history;
+  }
+
+  readLastOutput(): { step: string; output: unknown } | null {
+    const lines = this.readLines();
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i]!;
+      if (line.type === 'output') {
+        return { step: line.step as string, output: line.output };
+      }
+    }
+    return null;
+  }
+
+  appendResult(result: CliResult): number {
+    const typed = addTypeField(result);
+    return this.append(typed);
+  }
+
+  writePointer(line: number): void {
+    process.stdout.write(`${line}\n`);
+  }
+
+  writeStartPointer(line: number): void {
+    const pointer: SessionPointer = { sessionId: this.sessionId, file: this.filePath, line };
+    process.stdout.write(JSON.stringify(pointer) + '\n');
+  }
+
+  cleanup(): void {
+    if (existsSync(this.filePath)) {
+      unlinkSync(this.filePath);
+    }
+  }
+
+  private readLines(): Array<Record<string, unknown>> {
+    const content = readFileSync(this.filePath, 'utf-8');
+    const rawLines = content.trimEnd().split('\n');
+    const parsed: Array<Record<string, unknown>> = [];
+
+    for (const raw of rawLines) {
+      try {
+        parsed.push(JSON.parse(raw) as Record<string, unknown>);
+      } catch {
+        // skip malformed lines (crash resilience)
+      }
+    }
+
+    return parsed;
+  }
+}
+
+export class SessionManager {
+  static create(options: CreateSessionOptions): SessionFile {
+    const sessionDir = options.sessionDir ?? tmpdir();
+    const sessionId = generateSessionId();
+    const filePath = sessionFilePath(sessionDir, sessionId);
+
+    const header: SessionHeader = {
+      type: 'header',
+      sessionId,
+      skill: options.skill,
+      host: options.host,
+      context: options.context,
+      createdAt: new Date().toISOString(),
+      outputMode: options.outputMode ?? 'file',
+    };
+
+    writeFileSync(filePath, JSON.stringify(header) + '\n');
+    return new SessionFile(sessionId, filePath, header);
+  }
+
+  static open(sessionId: string, sessionDir?: string): SessionFile {
+    const dir = sessionDir ?? tmpdir();
+    const filePath = sessionFilePath(dir, sessionId);
+
+    if (!existsSync(filePath)) {
+      throw new Error(`session "${sessionId}" not found at ${filePath}. Start a new session with --session new.`);
+    }
+
+    const content = readFileSync(filePath, 'utf-8');
+    const firstLine = content.split('\n')[0];
+    if (!firstLine) {
+      throw new Error(`session "${sessionId}" has an empty file at ${filePath}.`);
+    }
+
+    const header = JSON.parse(firstLine) as SessionHeader;
+    if (header.type !== 'header' || header.sessionId !== sessionId) {
+      throw new Error(`session "${sessionId}" has an invalid header.`);
+    }
+
+    return new SessionFile(sessionId, filePath, header);
+  }
+
+  static cleanup(sessionId: string, sessionDir?: string): void {
+    const dir = sessionDir ?? tmpdir();
+    const filePath = sessionFilePath(dir, sessionId);
+    if (existsSync(filePath)) {
+      unlinkSync(filePath);
+    }
+  }
+}
+
+function addTypeField(result: CliResult): Record<string, unknown> {
+  if ('done' in result) return { type: 'done', ...result };
+  if ('error' in result) return { type: 'error', ...result };
+  if ('redirect' in result) return { type: 'redirect', ...result };
+  return { type: 'prompt', ...result };
+}

--- a/src/protocol/single-invocation.ts
+++ b/src/protocol/single-invocation.ts
@@ -1,12 +1,24 @@
 import type { SkillDefinition } from '../types.js';
 import { WorkflowEngine } from '../runtime/engine.js';
 import { resolveHost } from './host.js';
+import type { SessionFile } from './session.js';
 
-export async function handleStart(skill: SkillDefinition, context: unknown, hostName?: string): Promise<void> {
+export async function handleStart(
+  skill: SkillDefinition,
+  context: unknown,
+  hostName?: string,
+  session?: SessionFile,
+): Promise<void> {
   const handshake = resolveHost(hostName);
   const engine = new WorkflowEngine(skill, handshake, context);
   const result = engine.start();
-  process.stdout.write(JSON.stringify(result) + '\n');
+
+  if (session) {
+    const line = session.appendResult(result);
+    session.writeStartPointer(line);
+  } else {
+    process.stdout.write(JSON.stringify(result) + '\n');
+  }
 }
 
 export async function handleAdvance(
@@ -15,6 +27,7 @@ export async function handleAdvance(
   output: unknown,
   history: Array<{ step: string; output: unknown; action?: unknown }>,
   hostName?: string,
+  session?: SessionFile,
 ): Promise<void> {
   const handshake = resolveHost(hostName);
   const engine = new WorkflowEngine(skill, handshake, {});
@@ -25,7 +38,13 @@ export async function handleAdvance(
 
   engine.start();
   const result = await engine.advance(stepName, output);
-  process.stdout.write(JSON.stringify(result) + '\n');
+
+  if (session) {
+    const line = session.appendResult(result);
+    session.writePointer(line);
+  } else {
+    process.stdout.write(JSON.stringify(result) + '\n');
+  }
 }
 
 function printHelp(skillName: string): void {
@@ -33,7 +52,8 @@ function printHelp(skillName: string): void {
     `${skillName} — skill-kit CLI`,
     '',
     'Usage:',
-    `  ${skillName} --context '{"key":"value"}' [--host claude-code]`,
+    `  ${skillName} --context '{"key":"value"}' [--host claude-code] [--session new]`,
+    `  ${skillName} advance --session <id>`,
     `  ${skillName} advance --step <name> --output '{"key":"value"}' --history '[...]' [--host claude-code]`,
     '',
     'Subcommands:',
@@ -42,12 +62,15 @@ function printHelp(skillName: string): void {
     '  advance     Submit step output. Returns next prompt or done signal.',
     '',
     'Flags:',
-    '  --context   JSON string. Validated against skill context schema. (start only)',
-    '  --step      Name of the step whose output is being submitted. (advance only)',
-    '  --output    JSON string. The agent response for the step. (advance only)',
-    '  --history   JSON array of {step, output, action?} objects. (advance only)',
-    '  --host      Host identifier for prose generation. Default: generic.',
-    '  --help      Print this message.',
+    '  --context      JSON string. Validated against skill context schema. (start only)',
+    '  --step         Name of the step whose output is being submitted. (advance only)',
+    '  --output       JSON string. The agent response for the step. (advance only)',
+    '  --history      JSON array of {step, output, action?} objects. (advance only)',
+    '  --host         Host identifier for prose generation. Default: generic.',
+    '  --session      "new" to create a session (start), or session ID (advance).',
+    '  --session-dir  Directory for session files. Default: OS temp directory.',
+    '  --output-mode  "file" (default) or "flag". How the agent passes step output.',
+    '  --help         Print this message.',
   ];
   process.stderr.write(help.join('\n') + '\n');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,6 +280,34 @@ export interface RedirectResult {
 
 export type CliResult = PromptResult | DoneResult | ValidationErrorResult | RedirectResult;
 
+// --- Session Protocol ---
+
+export type SessionOutputMode = 'file' | 'flag';
+
+export interface SessionHeader {
+  type: 'header';
+  sessionId: string;
+  skill: string;
+  host: string;
+  context: unknown;
+  createdAt: string;
+  outputMode: SessionOutputMode;
+}
+
+export interface SessionOutputLine {
+  type: 'output';
+  step: string;
+  output: unknown;
+}
+
+export type SessionLine = SessionHeader | SessionOutputLine | (CliResult & { type: string });
+
+export interface SessionPointer {
+  sessionId: string;
+  file: string;
+  line: number;
+}
+
 // --- Testing ---
 
 export interface SkillRunResult {

--- a/tasks/2026-04-22_1930_file-based-session-protocol/TASK.md
+++ b/tasks/2026-04-22_1930_file-based-session-protocol/TASK.md
@@ -1,0 +1,94 @@
+# File-Based Session Protocol
+
+## Scope
+
+**In:** File-based session protocol for skill-kit skills. Session JSONL files, two output modes (file-write default, flag fallback), history reconstruction from session files, backward-compatible with existing stateless protocol. All three skill types (single, composite, reference). Generated SKILL.md updates. Documentation across SPEC.md, docs/, docs-site/.
+
+**Out:** Session TTL enforcement. Background cleanup processes. Reference skills (no state to manage — they're already single-call). Changes to the engine itself (WorkflowEngine, StashStore, History).
+
+## Context
+
+When agents run skill-kit skills, every invocation passes the entire conversation history as CLI args and returns verbose JSON to stdout. This causes noisy UX (ugly JSON blobs in Bash tool output visible to users) and growing CLI args (--history re-sends ALL prior step outputs). The goal is a file-based session protocol where the CLI writes to a JSONL session file and the agent reads/writes via host tools (Read/Write), making stdout minimal.
+
+User feedback: Default should be file-write mode (agent appends output to JSONL file), with --output flag as configurable fallback for agents that can't write files reliably.
+
+## Plan
+
+### Design: JSONL Session File
+
+Session file: `/tmp/skill-kit-<sessionId>.jsonl` (8-char hex ID from `crypto.randomBytes(4)`).
+
+```
+Line 1: {"type":"header","sessionId":"abc123","skill":"name","host":"claude-code","context":{},"createdAt":"...","outputMode":"file"}
+Line 2: {"type":"prompt","step":"choose","prompt":"...","schema":{...},"preamble":"..."}
+Line 3: {"type":"output","step":"choose","output":{"choice":"setup"}}            ← written by agent (file mode) or CLI (flag mode)
+Line 4: {"type":"prompt","step":"setup/check","prompt":"...","schema":{...},"completed":{"step":"choose","output":{"choice":"setup"}}}
+...
+Line N: {"type":"done","finalOutput":{...},"completed":{"step":"last","output":{...},"action":{...}}}
+```
+
+Each line has a `type` discriminator. Agent output lines are `type: "output"`. Protocol responses are `type: "prompt"`, `type: "done"`, `type: "error"`.
+
+### Design: Output Modes
+
+- **`"file"` (default)**: Agent appends `{"type":"output","step":"<name>","output":{...}}` to JSONL, then calls `advance --session <id>` with no --step/--output. CLI reads last output line from file.
+- **`"flag"` (fallback)**: Agent passes `--step <name> --output '{...}'` on advance call. CLI writes the output line itself.
+
+Set via `--output-mode file|flag` at session creation, stored in header.
+
+### Design: CLI Interface
+
+```bash
+# Start with session
+scripts/run --context '{}' --host claude-code --session new [--output-mode file|flag]
+# stdout: {"sessionId":"abc123","file":"/tmp/skill-kit-abc123.jsonl","line":2}
+
+# Advance (file mode — agent already wrote output to file)
+scripts/run advance --session abc123
+# stdout: 4
+
+# Advance (flag mode)
+scripts/run advance --step choose --output '{"choice":"setup"}' --session abc123
+# stdout: 4
+
+# Without --session: identical to today (backward compatible)
+```
+
+### Design: History Reconstruction
+
+History is built from `completed` fields in `prompt` and `done` lines — these contain `{step, output, action?}` tuples matching what `replayHistory()` expects. The last `output` line (current step's response) is consumed for the current advance but not added to replayed history.
+
+### Design: SessionPointer Type
+
+```typescript
+export interface SessionPointer {
+  sessionId: string;
+  file: string;
+  line: number;
+}
+```
+
+### Rejected Alternatives
+
+1. **Separate history lines in file**: Redundant data, breaks append-only simplicity.
+2. **Agent always uses --output flag**: More visible noise in Bash output — user explicitly wanted file-write as default.
+3. **stdin pipe protocol**: Requires persistent process management, not supported by all hosts.
+
+## Steps
+
+- [ ] Create `src/protocol/session.ts` — SessionManager, SessionFile classes
+- [ ] Create `src/protocol/session.test.ts` — unit tests
+- [ ] Add `SessionPointer` to `src/types.ts`, export from `src/index.ts`
+- [ ] Modify `src/protocol/single-invocation.ts` — session support in start/advance/parseArgs
+- [ ] Modify `src/protocol/cli-entry.ts` — wire session flags
+- [ ] Modify `src/protocol/composite-entry.ts` — session support in composite handlers
+- [ ] Update `src/build/skillmd-template.ts` — session-mode instructions in generated SKILL.md
+- [ ] Update SPEC.md — session protocol specification
+- [ ] Update docs/architecture.md — expand protocol section
+- [ ] Update docs/api.md — SessionPointer type, new flags
+- [ ] Update docs-site pages — architecture, workflow-skills, composite-skills, api, building
+- [ ] Verify: typecheck + tests + format + docs consistency
+
+## Notes
+
+(Running log — decisions made during implementation)

--- a/tasks/2026-04-22_1930_file-based-session-protocol/TASK.md
+++ b/tasks/2026-04-22_1930_file-based-session-protocol/TASK.md
@@ -76,19 +76,25 @@ export interface SessionPointer {
 
 ## Steps
 
-- [ ] Create `src/protocol/session.ts` — SessionManager, SessionFile classes
-- [ ] Create `src/protocol/session.test.ts` — unit tests
-- [ ] Add `SessionPointer` to `src/types.ts`, export from `src/index.ts`
-- [ ] Modify `src/protocol/single-invocation.ts` — session support in start/advance/parseArgs
-- [ ] Modify `src/protocol/cli-entry.ts` — wire session flags
-- [ ] Modify `src/protocol/composite-entry.ts` — session support in composite handlers
-- [ ] Update `src/build/skillmd-template.ts` — session-mode instructions in generated SKILL.md
-- [ ] Update SPEC.md — session protocol specification
-- [ ] Update docs/architecture.md — expand protocol section
-- [ ] Update docs/api.md — SessionPointer type, new flags
-- [ ] Update docs-site pages — architecture, workflow-skills, composite-skills, api, building
-- [ ] Verify: typecheck + tests + format + docs consistency
+- [x] Create `src/protocol/session.ts` — SessionManager, SessionFile classes
+- [x] Create `src/protocol/session.test.ts` — unit tests (16 tests)
+- [x] Add `SessionPointer` to `src/types.ts`, export from `src/index.ts`
+- [x] Modify `src/protocol/single-invocation.ts` — session support in start/advance/parseArgs
+- [x] Modify `src/protocol/cli-entry.ts` — wire session flags (5 new tests)
+- [x] Modify `src/protocol/composite-entry.ts` — session support in composite handlers (6 new tests)
+- [x] Update `src/build/skillmd-template.ts` — session-mode instructions in generated SKILL.md
+- [x] Update SPEC.md — session protocol specification
+- [x] Update docs/architecture.md — expand protocol section
+- [x] Update docs/api.md — SessionPointer type, new flags
+- [x] Update docs-site pages — architecture, composite-skills, building, api
+- [x] Verify: typecheck + tests + format + docs consistency (194 tests, all passing)
 
 ## Notes
+
+- History reconstruction reads `completed` fields from prompt/done lines, not output lines. This avoids needing to break append-only semantics when actions produce results.
+- Extracted `resolveSessionForCommand` and `resolveAdvanceInput` helpers in composite-entry to share session logic across dispatcher/subskill handler paths.
+- Added multi-step-skill.ts fixture for testing full session lifecycle across step boundaries.
+- Session file cleanup is not automatic — relies on OS temp cleanup. Explicit cleanup available via `SessionFile.cleanup()` and `SessionManager.cleanup()`.
+- `workflow-skills.mdx` had no protocol invocation examples, so no changes needed there.
 
 (Running log — decisions made during implementation)


### PR DESCRIPTION
## Summary

- Adds a file-based session protocol that moves skill communication to a JSONL temp file, eliminating verbose JSON in Bash output and the growing `--history` flag
- New `--session new` / `--session <id>` flags on `scripts/run` for session lifecycle; stateless mode (`--history`) continues to work unchanged
- New `--protocol session|stateless` build flag controls which invocation instructions the generated SKILL.md emits (default: `session`)
- Replaces all `${CLAUDE_SKILL_DIR}` references with host-agnostic `<skill>/scripts/run` absolute path instructions
- 27 new tests (16 session module, 5 single-skill CLI, 6 composite CLI) — 197 total, all passing

## How it works

**Start:** `scripts/run --context '{}' --host claude-code --session new` → returns `{sessionId, file, line}`

**Advance:** `scripts/run advance --step <name> --output '<json>' --session <id>` → returns line number

**Read:** Agent reads the returned line from the JSONL session file to get prompts/schemas

The CLI manages history in the session file — no `--history` flag needed. The binary always supports both protocols; the build flag only controls what the SKILL.md teaches.

## Test plan

- [ ] `pnpm exec tsc --noEmit` — typecheck passes
- [ ] `node --test --import tsx/esm 'src/**/*.test.ts'` — 197 tests pass
- [ ] `pnpm exec prettier --check .` — formatting clean
- [ ] Run `get-to-know-you` skill via Claude Code to verify session UX end-to-end
- [ ] Build an example with `--protocol stateless` to verify fallback instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)