### PR TITLE
fix(build): quote SKILL.md description frontmatter []

### DIFF
--- a/src/build/index.test.ts
+++ b/src/build/index.test.ts
@@ -6,9 +6,11 @@ import { generateNodeWrapper } from './node-wrapper-template.js';
 import { generateScriptsRun } from './scripts-run-template.js';
 import { generateNodeScriptsRun } from './node-scripts-run-template.js';
 import { generateSkillMd } from './skillmd-template.js';
+import { generateReferenceMd } from './reference-md-template.js';
 import { generatePackageJson } from './package-json-template.js';
 import { resolveTargets } from './targets.js';
 import { skill } from '../skill.js';
+import { reference } from '../reference.js';
 
 test('generateBunWrapper produces valid import for skill', () => {
   const result = generateBunWrapper('/abs/path/skill.ts', 'skill');
@@ -51,7 +53,7 @@ test('generateSkillMd produces valid frontmatter and invocation instructions', (
   const result = generateSkillMd(s);
 
   assert.ok(result.startsWith('---\nname: test-skill'));
-  assert.ok(result.includes('description: A test skill for unit testing.'));
+  assert.ok(result.includes('description: "A test skill for unit testing."'));
   assert.ok(result.includes('version: "1.0.0"'));
   assert.ok(result.includes('scripts/run --context'));
   assert.ok(result.includes('scripts/run advance'));
@@ -65,7 +67,36 @@ test('generateSkillMd uses default description when none provided', () => {
     .build();
 
   const result = generateSkillMd(s);
-  assert.ok(result.includes('minimal skill powered by @contentful/skill-kit'));
+  assert.ok(result.includes('description: "minimal skill powered by @contentful/skill-kit."'));
+});
+
+test('generateSkillMd double-quotes YAML description content', () => {
+  const s = skill({
+    name: 'quoted',
+    description: 'Trigger keywords: debug, fix and "repair".',
+    entry: 'start',
+  })
+    .step('start', {
+      prompt: 'Begin.',
+      output: z.object({ done: z.boolean() }),
+      next: { terminal: true },
+    })
+    .build();
+
+  const result = generateSkillMd(s);
+  assert.ok(result.includes('description: "Trigger keywords: debug, fix and \\\"repair\\\"."'));
+});
+
+test('generateReferenceMd double-quotes YAML description content', () => {
+  const ref = reference({
+    name: 'docs-ref',
+    description: 'Reference topics: setup and "debug".',
+  })
+    .topic('setup', { label: 'Setup', content: () => 'Use setup docs.' })
+    .build();
+
+  const result = generateReferenceMd(ref);
+  assert.ok(result.includes('description: "Reference topics: setup and \\\"debug\\\"."'));
 });
 
 test('generateSkillMd with protocol=session omits stateless instructions', () => {

--- a/src/build/index.test.ts
+++ b/src/build/index.test.ts
@@ -61,13 +61,13 @@ test('generateSkillMd produces valid frontmatter and invocation instructions', (
   assert.ok(result.includes('**start**: Begin the process.'));
 });
 
-test('generateSkillMd uses default description when none provided', () => {
+test('generateSkillMd uses empty description when none provided', () => {
   const s = skill({ name: 'minimal', entry: 'a' })
     .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
     .build();
 
   const result = generateSkillMd(s);
-  assert.ok(result.includes('description: "minimal skill powered by @contentful/skill-kit."'));
+  assert.ok(result.includes('description: ""'));
 });
 
 test('generateSkillMd double-quotes YAML description content', () => {

--- a/src/build/reference-md-template.ts
+++ b/src/build/reference-md-template.ts
@@ -1,7 +1,7 @@
 import type { ReferenceDefinition } from '../types.js';
 
 export function generateReferenceMd(def: ReferenceDefinition): string {
-  const frontmatter = ['---', `name: ${def.name}`, `description: ${def.description}`];
+  const frontmatter = ['---', `name: ${def.name}`, `description: ${yamlDoubleQuoted(def.description)}`];
 
   if (def.version !== '0.0.0') {
     frontmatter.push(`metadata:`);
@@ -27,4 +27,8 @@ To list all available topics: \`<skill>/scripts/run\`
 `.trim();
 
   return frontmatter.join('\n') + '\n\n' + body + '\n';
+}
+
+function yamlDoubleQuoted(value: string): string {
+  return JSON.stringify(value);
 }

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -8,10 +8,11 @@ Bash commands — do not \`cd\` into the skill directory.
 In the examples below, \`<skill>/scripts/run\` is a placeholder for this absolute path.`;
 
 export function generateSkillMd(skill: SkillDefinition, protocol: BuildProtocol = 'session'): string {
+  const description = skill.description || `${skill.name} skill powered by @contentful/skill-kit.`;
   const frontmatter = [
     '---',
     `name: ${skill.name}`,
-    `description: ${skill.description || `${skill.name} skill powered by @contentful/skill-kit.`}`,
+    `description: ${yamlDoubleQuoted(description)}`,
   ];
 
   if (skill.version !== '0.0.0') {
@@ -67,6 +68,10 @@ ${stepDescriptions}
 ${generateSubskillSection(skill, protocol)}${generateTopicSection(skill)}`.trim();
 
   return frontmatter.join('\n') + '\n\n' + body + '\n';
+}
+
+function yamlDoubleQuoted(value: string): string {
+  return JSON.stringify(value);
 }
 
 function generateSessionInstructions(): string {

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -8,11 +8,7 @@ Bash commands — do not \`cd\` into the skill directory.
 In the examples below, \`<skill>/scripts/run\` is a placeholder for this absolute path.`;
 
 export function generateSkillMd(skill: SkillDefinition, protocol: BuildProtocol = 'session'): string {
-  const frontmatter = [
-    '---',
-    `name: ${skill.name}`,
-    `description: ${yamlDoubleQuoted(skill.description)}`,
-  ];
+  const frontmatter = ['---', `name: ${skill.name}`, `description: ${yamlDoubleQuoted(skill.description)}`];
 
   if (skill.version !== '0.0.0') {
     frontmatter.push(`metadata:`);

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -8,11 +8,10 @@ Bash commands — do not \`cd\` into the skill directory.
 In the examples below, \`<skill>/scripts/run\` is a placeholder for this absolute path.`;
 
 export function generateSkillMd(skill: SkillDefinition, protocol: BuildProtocol = 'session'): string {
-  const description = skill.description || `${skill.name} skill powered by @contentful/skill-kit.`;
   const frontmatter = [
     '---',
     `name: ${skill.name}`,
-    `description: ${yamlDoubleQuoted(description)}`,
+    `description: ${yamlDoubleQuoted(skill.description)}`,
   ];
 
   if (skill.version !== '0.0.0') {


### PR DESCRIPTION
## Summary
- always render generated SKILL.md frontmatter `description` as a double-quoted YAML string in both skill and reference templates
- add a shared quoting helper (`JSON.stringify`) to ensure characters like `:` and embedded quotes stay YAML-safe
- update build template tests to assert quoted output and add coverage for descriptions containing colons and quotes

## Validation
- `pnpm exec tsc --noEmit`
- `node --test --import tsx/esm src/build/index.test.ts`