### PR TITLE
NT-3052: feat: improved package.json generation with PackageConfig and resolveVersion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,16 @@ pnpm exec tsc --noEmit && node --test --import tsx/esm 'src/**/*.test.ts' && pnp
 
 The docs site (`docs-site/`) is an Astro static site deployed to GitHub Pages. Its content pages are adapted from `docs/api.md`, `docs/architecture.md`, and the README. These are **not** auto-synced — when you change the markdown docs, update the corresponding MDX pages in `docs-site/src/pages/` and vice versa.
 
+**Documentation is part of the feature, not a follow-up.** Every change touching public API or build behavior must update all affected docs before the branch is considered complete:
+
+1. `SPEC.md` — the source of truth for the SDK design
+2. `docs/api.md` — config tables, builder signatures, CLI reference
+3. `docs/architecture.md` — pipeline steps, output structure
+4. `docs-site/src/pages/` — the corresponding MDX pages that mirror the above
+5. `README.md` — API signatures in the overview section
+
+The five locations are not auto-synced. When you add a field to a config table in `docs/api.md`, the same field must appear in `docs-site/src/pages/api/index.mdx`. When you change a build pipeline step in `docs/architecture.md`, the same change goes in `docs-site/src/pages/architecture/index.mdx`. Grep for the old text across all five locations to make sure nothing is missed.
+
 **Known issue:** Pages is private, so GitHub assigns a random `*.pages.github.io` domain and serves at root (no base path). The `contentful.github.io/skill-kit/` URL 301-redirects there. Fix by either making Pages public (serves at `contentful.github.io/skill-kit/`, re-add `base: '/skill-kit/'` to `astro.config.mjs`) or configuring a custom domain.
 
 ## Key references

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ A composite skill that dispatches to doctor and setup sub-skills, or resolves FA
 ### Workflow Builder
 
 ```typescript
-skill({ name, entry, description?, triggers?, context?, stash?, observers?, finalOutput? })
+skill({ name, entry, version?, resolveVersion?, package?, description?, triggers?, context?, stash?, observers?, finalOutput? })
   .step(name, config)              // inline step — context/stash types inferred
   .extend(name, sharedStep, overrides)  // shared step with typed overrides
   .register(module, { next })      // merge module steps, widen stash type
@@ -284,7 +284,7 @@ skill({ name, entry, description?, triggers?, context?, stash?, observers?, fina
 ### Reference Builder
 
 ```typescript
-reference({ name, description, version? })
+reference({ name, description, version?, resolveVersion?, package? })
   .topic(name, { label, content: (ctx) => string })  // content receives { refs }
   .build()                                            // → ReferenceDefinition
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -114,6 +114,10 @@ export default skill({
   entry: 'diagnose',
   context: z.object({ repoPath: z.string().default('.') }),
   stash: z.object({ failCount: z.number() }),
+  package: {
+    name: '@contentful/skill-repo-doctor',
+    license: 'MIT',
+  },
 })
   .step('diagnose', {
     /* ... */
@@ -980,7 +984,7 @@ This:
 2. Bundles the skill code (mode-dependent — see below)
 3. Generates `scripts/run` shell wrapper (public interface)
 4. Generates `SKILL.md` with invocation instructions
-5. Generates `package.json` with name and version
+5. Generates `package.json` — name, version, and any fields from the `package` config. Merges with existing `package.json` in the output directory if present. When `resolveVersion: true` is set, reads the version from the nearest ancestor `package.json` instead of using the hardcoded `version` field.
 6. Copies `references/` from the source directory
 
 ### Build modes

--- a/docs-site/src/pages/api/index.mdx
+++ b/docs-site/src/pages/api/index.mdx
@@ -21,18 +21,20 @@ skill({ name, entry, context?, stash?, observers?, finalOutput?, skillMd? })
 
 ### `skill()` config
 
-| Field         | Type                                           | Required | Description                                                |
-| ------------- | ---------------------------------------------- | -------- | ---------------------------------------------------------- |
-| `name`        | `string`                                       | yes      | Skill identifier                                           |
-| `entry`       | `string`                                       | yes      | Name of the first step                                     |
-| `version`     | `string`                                       | no       | Defaults to `'0.0.0'`                                      |
-| `description` | `string`                                       | no       | Used in generated SKILL.md                                 |
-| `triggers`    | `string[]`                                     | no       | Keywords appended to description for agent discoverability |
-| `context`     | `z.ZodType`                                    | no       | Zod schema for immutable skill-wide context                |
-| `stash`       | `z.ZodType`                                    | no       | Zod schema for mutable cross-step state                    |
-| `finalOutput` | `z.ZodType`                                    | no       | Schema for the terminal step's output                      |
-| `observers`   | `ObserverMap`                                  | no       | Lifecycle hooks (see [Observers](#observers))              |
-| `skillMd`     | `string \| (skill: SkillDefinition) => string` | no       | Custom SKILL.md template override                          |
+| Field            | Type                                           | Required | Description                                                                             |
+| ---------------- | ---------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `name`           | `string`                                       | yes      | Skill identifier                                                                        |
+| `entry`          | `string`                                       | yes      | Name of the first step                                                                  |
+| `version`        | `string`                                       | no       | Defaults to `'0.0.0'`. Mutually exclusive with `resolveVersion`                         |
+| `resolveVersion` | `true`                                         | no       | Resolve version from nearest ancestor `package.json`. Mutually exclusive with `version` |
+| `description`    | `string`                                       | no       | Used in generated SKILL.md                                                              |
+| `triggers`       | `string[]`                                     | no       | Keywords appended to description for agent discoverability                              |
+| `context`        | `z.ZodType`                                    | no       | Zod schema for immutable skill-wide context                                             |
+| `stash`          | `z.ZodType`                                    | no       | Zod schema for mutable cross-step state                                                 |
+| `finalOutput`    | `z.ZodType`                                    | no       | Schema for the terminal step's output                                                   |
+| `observers`      | `ObserverMap`                                  | no       | Lifecycle hooks (see [Observers](#observers))                                           |
+| `skillMd`        | `string \| (skill: SkillDefinition) => string` | no       | Custom SKILL.md template override                                                       |
+| `package`        | `PackageConfig`                                | no       | Fields written to the output `package.json` (see [Package Config](#package-config))     |
 
 Context and stash types flow into step callbacks automatically via contextual inference — no annotations needed.
 
@@ -151,18 +153,20 @@ For skills that don't need a workflow — just progressive disclosure of content
 ```typescript
 import { reference } from '@contentful/skill-kit';
 
-reference({ name, description, version? })
+reference({ name, description, version?, resolveVersion?, package? })
   .topic(name, { label, content: (ctx) => string })
   .build()                                           // → ReferenceDefinition (frozen)
 ```
 
 ### `reference()` config
 
-| Field         | Type     | Required | Description                |
-| ------------- | -------- | -------- | -------------------------- |
-| `name`        | `string` | yes      | Reference skill identifier |
-| `description` | `string` | yes      | Used in generated SKILL.md |
-| `version`     | `string` | no       | Defaults to `'0.0.0'`      |
+| Field            | Type            | Required | Description                                                                             |
+| ---------------- | --------------- | -------- | --------------------------------------------------------------------------------------- |
+| `name`           | `string`        | yes      | Reference skill identifier                                                              |
+| `description`    | `string`        | yes      | Used in generated SKILL.md                                                              |
+| `version`        | `string`        | no       | Defaults to `'0.0.0'`. Mutually exclusive with `resolveVersion`                         |
+| `resolveVersion` | `true`          | no       | Resolve version from nearest ancestor `package.json`. Mutually exclusive with `version` |
+| `package`        | `PackageConfig` | no       | Fields written to the output `package.json` (see [Package Config](#package-config))     |
 
 ### `.topic(name, config)`
 
@@ -180,6 +184,46 @@ Registers a topic. `content` is a lazy function receiving `{ refs: ReferenceLoad
 ```
 
 At least one topic is required. `build()` throws if name, description, or topics are missing.
+
+---
+
+## Package Config
+
+Both `skill()` and `reference()` accept an optional `package` field that controls the generated `package.json`:
+
+```typescript
+export default skill({
+  name: 'my-skill',
+  resolveVersion: true,
+  entry: 'start',
+  package: {
+    name: '@org/skill-my-skill',
+    license: 'MIT',
+    files: ['SKILL.md', 'scripts/**', 'bin/**'],
+  },
+});
+```
+
+### `PackageConfig` fields
+
+| Field         | Type       | Description                                         |
+| ------------- | ---------- | --------------------------------------------------- |
+| `name`        | `string`   | Override package name (default: skill name)         |
+| `description` | `string`   | Written to `package.json`                           |
+| `license`     | `string`   | Written to `package.json`                           |
+| `files`       | `string[]` | Written to `package.json`                           |
+| `[key]`       | `unknown`  | Any other field is passed through to `package.json` |
+
+### Version strategy
+
+Version is set via one of two mutually exclusive fields (enforced at the type level):
+
+- **`version`** — Explicit version string (e.g., `version: '1.0.0'`). Defaults to `'0.0.0'` if omitted.
+- **`resolveVersion: true`** — The build walks up from the entry file's directory to find the nearest ancestor `package.json` with a `version` field and uses that. Useful when a version manager like `release-it` bumps the root `package.json`.
+
+### Merge behavior
+
+If a `package.json` already exists in the output directory, the build merges rather than overwrites: existing fields are preserved, `package` config fields override, and `name`/`version` are always authoritative.
 
 ---
 
@@ -747,7 +791,7 @@ Output (bun mode):
 ```
 <dir>/
   SKILL.md               ← Generated agent-facing docs
-  package.json           ← Name and version
+  package.json           ← Name, version, and package config fields
   scripts/run            ← Shell wrapper (platform dispatcher)
   bin/<name>-<platform>  ← Compiled Bun executables
   references/            ← Copied from source
@@ -758,7 +802,7 @@ Output (node mode):
 ```
 <dir>/
   SKILL.md               ← Generated agent-facing docs
-  package.json           ← Name and version
+  package.json           ← Name, version, and package config fields
   scripts/run            ← Shell wrapper (Node version check)
   bin/<name>.mjs         ← Single ESM bundle
   references/            ← Copied from source

--- a/docs-site/src/pages/architecture/index.mdx
+++ b/docs-site/src/pages/architecture/index.mdx
@@ -231,7 +231,7 @@ The `--mode` flag selects the bundling strategy:
    - **Node mode:** Run esbuild to produce a single `.mjs` bundle with all dependencies inlined.
 5. **Generate scripts/run** — Shell wrapper (mode-dependent: platform dispatcher for bun, Node version check for node).
 6. **Generate SKILL.md** — Agent-facing documentation with invocation instructions, step descriptions, and reference pointers.
-7. **Generate package.json** — Minimal metadata (name, version).
+7. **Generate package.json** — Name, version, and any fields from the skill's `package` config. Merges with existing `package.json` in the output directory. When `resolveVersion: true`, reads the version from the nearest ancestor `package.json`.
 8. **Copy references/** — Markdown files from the source `references/` directory.
 9. **Clean up** — Remove temporary wrapper files.
 

--- a/docs-site/src/pages/getting-started/building.mdx
+++ b/docs-site/src/pages/getting-started/building.mdx
@@ -38,7 +38,7 @@ Output structure:
 ```
 skill/
   SKILL.md                  # Generated agent-facing docs
-  package.json              # Name and version
+  package.json              # Name, version, and package config fields
   scripts/run               # Shell wrapper (platform dispatcher)
   bin/
     greet-darwin-arm64      # Compiled Bun executables
@@ -57,7 +57,7 @@ Output structure:
 ```
 skill/
   SKILL.md                  # Generated agent-facing docs
-  package.json              # Name and version
+  package.json              # Name, version, and package config fields
   scripts/run               # Shell wrapper (Node version check)
   bin/
     greet.mjs               # Single ESM bundle

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,18 +18,20 @@ skill({ name, entry, context?, stash?, observers?, finalOutput?, skillMd? })
 
 ### `skill()` config
 
-| Field         | Type                                           | Required | Description                                                |
-| ------------- | ---------------------------------------------- | -------- | ---------------------------------------------------------- |
-| `name`        | `string`                                       | yes      | Skill identifier                                           |
-| `entry`       | `string`                                       | yes      | Name of the first step                                     |
-| `version`     | `string`                                       | no       | Defaults to `'0.0.0'`                                      |
-| `description` | `string`                                       | no       | Used in generated SKILL.md                                 |
-| `triggers`    | `string[]`                                     | no       | Keywords appended to description for agent discoverability |
-| `context`     | `z.ZodType`                                    | no       | Zod schema for immutable skill-wide context                |
-| `stash`       | `z.ZodType`                                    | no       | Zod schema for mutable cross-step state                    |
-| `finalOutput` | `z.ZodType`                                    | no       | Schema for the terminal step's output                      |
-| `observers`   | `ObserverMap`                                  | no       | Lifecycle hooks (see [Observers](#observers))              |
-| `skillMd`     | `string \| (skill: SkillDefinition) => string` | no       | Custom SKILL.md template override                          |
+| Field            | Type                                           | Required | Description                                                                             |
+| ---------------- | ---------------------------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `name`           | `string`                                       | yes      | Skill identifier                                                                        |
+| `entry`          | `string`                                       | yes      | Name of the first step                                                                  |
+| `version`        | `string`                                       | no       | Defaults to `'0.0.0'`. Mutually exclusive with `resolveVersion`                         |
+| `resolveVersion` | `true`                                         | no       | Resolve version from nearest ancestor `package.json`. Mutually exclusive with `version` |
+| `description`    | `string`                                       | no       | Used in generated SKILL.md                                                              |
+| `triggers`       | `string[]`                                     | no       | Keywords appended to description for agent discoverability                              |
+| `context`        | `z.ZodType`                                    | no       | Zod schema for immutable skill-wide context                                             |
+| `stash`          | `z.ZodType`                                    | no       | Zod schema for mutable cross-step state                                                 |
+| `finalOutput`    | `z.ZodType`                                    | no       | Schema for the terminal step's output                                                   |
+| `observers`      | `ObserverMap`                                  | no       | Lifecycle hooks (see [Observers](#observers))                                           |
+| `skillMd`        | `string \| (skill: SkillDefinition) => string` | no       | Custom SKILL.md template override                                                       |
+| `package`        | `PackageConfig`                                | no       | Fields written to the output `package.json` (see [Package Config](#package-config))     |
 
 Context and stash types flow into step callbacks automatically via contextual inference — no annotations needed.
 
@@ -148,18 +150,20 @@ For skills that don't need a workflow — just progressive disclosure of content
 ```typescript
 import { reference } from '@contentful/skill-kit';
 
-reference({ name, description, version? })
+reference({ name, description, version?, resolveVersion?, package? })
   .topic(name, { label, content: (ctx) => string })
   .build()                                           // → ReferenceDefinition (frozen)
 ```
 
 ### `reference()` config
 
-| Field         | Type     | Required | Description                |
-| ------------- | -------- | -------- | -------------------------- |
-| `name`        | `string` | yes      | Reference skill identifier |
-| `description` | `string` | yes      | Used in generated SKILL.md |
-| `version`     | `string` | no       | Defaults to `'0.0.0'`      |
+| Field            | Type            | Required | Description                                                                             |
+| ---------------- | --------------- | -------- | --------------------------------------------------------------------------------------- |
+| `name`           | `string`        | yes      | Reference skill identifier                                                              |
+| `description`    | `string`        | yes      | Used in generated SKILL.md                                                              |
+| `version`        | `string`        | no       | Defaults to `'0.0.0'`. Mutually exclusive with `resolveVersion`                         |
+| `resolveVersion` | `true`          | no       | Resolve version from nearest ancestor `package.json`. Mutually exclusive with `version` |
+| `package`        | `PackageConfig` | no       | Fields written to the output `package.json` (see [Package Config](#package-config))     |
 
 ### `.topic(name, config)`
 
@@ -177,6 +181,46 @@ Registers a topic. `content` is a lazy function receiving `{ refs: ReferenceLoad
 ```
 
 At least one topic is required. `build()` throws if name, description, or topics are missing.
+
+---
+
+## Package Config
+
+Both `skill()` and `reference()` accept an optional `package` field that controls the generated `package.json`:
+
+```typescript
+export default skill({
+  name: 'my-skill',
+  resolveVersion: true,
+  entry: 'start',
+  package: {
+    name: '@org/skill-my-skill',
+    license: 'MIT',
+    files: ['SKILL.md', 'scripts/**', 'bin/**'],
+  },
+});
+```
+
+### `PackageConfig` fields
+
+| Field         | Type       | Description                                         |
+| ------------- | ---------- | --------------------------------------------------- |
+| `name`        | `string`   | Override package name (default: skill name)         |
+| `description` | `string`   | Written to `package.json`                           |
+| `license`     | `string`   | Written to `package.json`                           |
+| `files`       | `string[]` | Written to `package.json`                           |
+| `[key]`       | `unknown`  | Any other field is passed through to `package.json` |
+
+### Version strategy
+
+Version is set via one of two mutually exclusive fields (enforced at the type level):
+
+- **`version`** — Explicit version string (e.g., `version: '1.0.0'`). Defaults to `'0.0.0'` if omitted.
+- **`resolveVersion: true`** — The build walks up from the entry file's directory to find the nearest ancestor `package.json` with a `version` field and uses that. Useful when a version manager like `release-it` bumps the root `package.json`.
+
+### Merge behavior
+
+If a `package.json` already exists in the output directory, the build merges rather than overwrites: existing fields are preserved, `package` config fields override, and `name`/`version` are always authoritative.
 
 ---
 
@@ -739,7 +783,7 @@ Output (bun mode):
 ```
 <dir>/
   SKILL.md               ← Generated agent-facing docs
-  package.json           ← Name and version
+  package.json           ← Name, version, and package config fields
   scripts/run            ← Shell wrapper (platform dispatcher)
   bin/<name>-<platform>  ← Compiled Bun executables
   references/            ← Copied from source
@@ -750,7 +794,7 @@ Output (node mode):
 ```
 <dir>/
   SKILL.md               ← Generated agent-facing docs
-  package.json           ← Name and version
+  package.json           ← Name, version, and package config fields
   scripts/run            ← Shell wrapper (Node version check)
   bin/<name>.mjs         ← Single ESM bundle
   references/            ← Copied from source

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,7 @@ The `--mode` flag selects the bundling strategy:
    - **Node mode:** Run esbuild to produce a single `.mjs` bundle with all dependencies inlined.
 5. **Generate scripts/run** — Shell wrapper (mode-dependent: platform dispatcher for bun, Node version check for node).
 6. **Generate SKILL.md** — Agent-facing documentation with invocation instructions, step descriptions, and reference pointers.
-7. **Generate package.json** — Minimal metadata (name, version).
+7. **Generate package.json** — Name, version, and any fields from the skill's `package` config. Merges with existing `package.json` in the output directory. When `resolveVersion: true`, reads the version from the nearest ancestor `package.json`.
 8. **Copy references/** — Markdown files from the source `references/` directory.
 9. **Clean up** — Remove temporary wrapper files.
 

--- a/src/build/index.test.ts
+++ b/src/build/index.test.ts
@@ -1,5 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { z } from 'zod';
 import { generateBunWrapper } from './bun-wrapper-template.js';
 import { generateNodeWrapper } from './node-wrapper-template.js';
@@ -99,10 +102,72 @@ test('generateSkillMd default protocol is session', () => {
 });
 
 test('generatePackageJson produces valid JSON with name and version', () => {
-  const result = generatePackageJson('my-skill', '2.0.0');
+  const result = generatePackageJson('2.0.0', { name: 'my-skill' });
   const parsed = JSON.parse(result);
   assert.equal(parsed.name, 'my-skill');
   assert.equal(parsed.version, '2.0.0');
+});
+
+test('generatePackageJson writes packageConfig fields', () => {
+  const result = generatePackageJson('1.0.0', {
+    name: 'my-skill',
+    packageConfig: { description: 'A skill', license: 'Apache-2.0', files: ['bin'] },
+  });
+  const parsed = JSON.parse(result);
+  assert.equal(parsed.description, 'A skill');
+  assert.equal(parsed.license, 'Apache-2.0');
+  assert.deepEqual(parsed.files, ['bin']);
+});
+
+test('generatePackageJson packageConfig.name overrides default name', () => {
+  const result = generatePackageJson('1.0.0', {
+    name: 'my-skill',
+    packageConfig: { name: '@org/my-skill' },
+  });
+  const parsed = JSON.parse(result);
+  assert.equal(parsed.name, '@org/my-skill');
+});
+
+test('generatePackageJson passes through arbitrary fields from packageConfig', () => {
+  const result = generatePackageJson('1.0.0', {
+    name: 'my-skill',
+    packageConfig: { repository: { type: 'git', url: 'https://example.com' }, keywords: ['skill'] },
+  });
+  const parsed = JSON.parse(result);
+  assert.deepEqual(parsed.repository, { type: 'git', url: 'https://example.com' });
+  assert.deepEqual(parsed.keywords, ['skill']);
+});
+
+test('generatePackageJson merges with existing package.json', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pkg-merge-'));
+  try {
+    const existingPath = join(dir, 'package.json');
+    writeFileSync(existingPath, JSON.stringify({ name: 'old', version: '0.0.1', customField: true }));
+    const result = generatePackageJson('1.0.0', { name: 'new-name', existingPath });
+    const parsed = JSON.parse(result);
+    assert.equal(parsed.name, 'new-name');
+    assert.equal(parsed.version, '1.0.0');
+    assert.equal(parsed.customField, true);
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+test('generatePackageJson merge prefers packageConfig over existing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pkg-merge-'));
+  try {
+    const existingPath = join(dir, 'package.json');
+    writeFileSync(existingPath, JSON.stringify({ name: 'old', version: '0.0.1', license: 'ISC' }));
+    const result = generatePackageJson('1.0.0', {
+      name: 'my-skill',
+      packageConfig: { license: 'MIT' },
+      existingPath,
+    });
+    const parsed = JSON.parse(result);
+    assert.equal(parsed.license, 'MIT');
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
 });
 
 test('resolveTargets returns defaults when no args', () => {

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -11,6 +11,7 @@ import { generateNodeScriptsRun } from './node-scripts-run-template.js';
 import { generateSkillMd } from './skillmd-template.js';
 import { generateReferenceMd } from './reference-md-template.js';
 import { generatePackageJson } from './package-json-template.js';
+import { resolveVersionFromAncestor } from './resolve-version.js';
 import { resolveTargets, type BuildTarget } from './targets.js';
 
 const exec = promisify(execFile);
@@ -73,8 +74,23 @@ export async function buildSkill(opts: BuildOptions): Promise<BuildResult> {
   const skillMdPath = join(outDir, 'SKILL.md');
   writeFileSync(skillMdPath, skillMdContent);
 
-  const pkgJson = generatePackageJson(defName, def.version);
-  writeFileSync(join(outDir, 'package.json'), pkgJson);
+  let buildVersion = def.version;
+  if (def.resolveVersion) {
+    const resolved = resolveVersionFromAncestor(dirname(entryPath));
+    if (resolved) {
+      buildVersion = resolved.version;
+    } else {
+      process.stderr.write('Warning: resolveVersion is set but no ancestor package.json with a version was found.\n');
+    }
+  }
+
+  const outPkgPath = join(outDir, 'package.json');
+  const pkgJson = generatePackageJson(buildVersion, {
+    name: defName,
+    packageConfig: def.package,
+    existingPath: outPkgPath,
+  });
+  writeFileSync(outPkgPath, pkgJson);
 
   const refsDir = join(dirname(entryPath), 'references');
   if (existsSync(refsDir)) {

--- a/src/build/package-json-template.ts
+++ b/src/build/package-json-template.ts
@@ -1,10 +1,30 @@
-export function generatePackageJson(name: string, version: string): string {
-  return JSON.stringify(
-    {
-      name,
-      version,
-    },
-    null,
-    2,
-  );
+import { readFileSync, existsSync } from 'node:fs';
+import type { PackageConfig } from '../types.js';
+
+export interface PackageJsonOptions {
+  name: string;
+  packageConfig?: PackageConfig;
+  existingPath?: string;
+}
+
+export function generatePackageJson(version: string, opts: PackageJsonOptions): string {
+  let existing: Record<string, unknown> = {};
+  if (opts.existingPath && existsSync(opts.existingPath)) {
+    try {
+      existing = JSON.parse(readFileSync(opts.existingPath, 'utf-8'));
+    } catch {
+      // malformed existing file — start fresh
+    }
+  }
+
+  const { name: pkgName, ...restConfig } = opts.packageConfig ?? {};
+
+  const result: Record<string, unknown> = {
+    ...existing,
+    ...restConfig,
+    name: pkgName ?? opts.name,
+    version,
+  };
+
+  return JSON.stringify(result, null, 2);
 }

--- a/src/build/resolve-version.test.ts
+++ b/src/build/resolve-version.test.ts
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveVersionFromAncestor } from './resolve-version.js';
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'resolve-version-'));
+}
+
+test('resolves version from package.json in the same directory', () => {
+  const dir = makeTmpDir();
+  try {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ version: '3.2.1' }));
+    const result = resolveVersionFromAncestor(dir);
+    assert.ok(result);
+    assert.equal(result.version, '3.2.1');
+    assert.equal(result.source, join(dir, 'package.json'));
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+test('walks up to find ancestor package.json', () => {
+  const root = makeTmpDir();
+  const child = join(root, 'packages', 'my-skill', 'src');
+  try {
+    mkdirSync(child, { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ version: '1.5.0' }));
+    const result = resolveVersionFromAncestor(child);
+    assert.ok(result);
+    assert.equal(result.version, '1.5.0');
+    assert.equal(result.source, join(root, 'package.json'));
+  } finally {
+    rmSync(root, { recursive: true });
+  }
+});
+
+test('skips package.json without a version field', () => {
+  const root = makeTmpDir();
+  const child = join(root, 'child');
+  try {
+    mkdirSync(child);
+    writeFileSync(join(child, 'package.json'), JSON.stringify({ name: 'no-version' }));
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ version: '2.0.0' }));
+    const result = resolveVersionFromAncestor(child);
+    assert.ok(result);
+    assert.equal(result.version, '2.0.0');
+    assert.equal(result.source, join(root, 'package.json'));
+  } finally {
+    rmSync(root, { recursive: true });
+  }
+});
+
+test('skips malformed package.json', () => {
+  const root = makeTmpDir();
+  const child = join(root, 'child');
+  try {
+    mkdirSync(child);
+    writeFileSync(join(child, 'package.json'), '{ not valid json');
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ version: '4.0.0' }));
+    const result = resolveVersionFromAncestor(child);
+    assert.ok(result);
+    assert.equal(result.version, '4.0.0');
+  } finally {
+    rmSync(root, { recursive: true });
+  }
+});
+
+test('returns nearest ancestor when multiple exist', () => {
+  const root = makeTmpDir();
+  const mid = join(root, 'packages', 'my-skill');
+  const child = join(mid, 'src');
+  try {
+    mkdirSync(child, { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ version: '1.0.0' }));
+    writeFileSync(join(mid, 'package.json'), JSON.stringify({ version: '2.0.0' }));
+    const result = resolveVersionFromAncestor(child);
+    assert.ok(result);
+    assert.equal(result.version, '2.0.0');
+    assert.equal(result.source, join(mid, 'package.json'));
+  } finally {
+    rmSync(root, { recursive: true });
+  }
+});
+
+test('returns undefined when no package.json found', () => {
+  const dir = makeTmpDir();
+  const child = join(dir, 'deep', 'nested');
+  try {
+    mkdirSync(child, { recursive: true });
+    // No package.json anywhere in the tmp subtree — the walk will eventually
+    // reach the filesystem root or a real package.json outside our control,
+    // but inside the tmp dir there is none. We test the isolated subtree.
+    // To truly test "not found" we'd need to mock fs, so instead we verify
+    // the function returns a result (from some ancestor) or undefined.
+    const result = resolveVersionFromAncestor(child);
+    // In practice this will find the system's package.json or return undefined.
+    // We mainly verify it doesn't throw.
+    assert.ok(result === undefined || typeof result.version === 'string');
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});

--- a/src/build/resolve-version.ts
+++ b/src/build/resolve-version.ts
@@ -1,0 +1,28 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export interface ResolvedVersion {
+  version: string;
+  source: string;
+}
+
+export function resolveVersionFromAncestor(startDir: string): ResolvedVersion | undefined {
+  let dir = startDir;
+  while (true) {
+    const candidate = join(dir, 'package.json');
+    if (existsSync(candidate)) {
+      try {
+        const raw = JSON.parse(readFileSync(candidate, 'utf-8'));
+        if (typeof raw.version === 'string' && raw.version) {
+          return { version: raw.version, source: candidate };
+        }
+      } catch {
+        // malformed JSON — skip and keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ export type {
   ReferenceDefinition,
   ReferenceBuilderConfig,
   TopicConfig,
+  PackageConfig,
+  VersionStrategy,
   SubskillRegistration,
   RedirectResult,
   Buildable,

--- a/src/reference-builder.ts
+++ b/src/reference-builder.ts
@@ -24,7 +24,9 @@ export class ReferenceBuilder {
       kind: 'reference' as const,
       name,
       version: this.config.version ?? '0.0.0',
+      resolveVersion: this.config.resolveVersion ?? false,
       description,
+      package: this.config.package,
       topics: Object.freeze({ ...this.topics }),
     });
   }

--- a/src/skill-builder.ts
+++ b/src/skill-builder.ts
@@ -116,6 +116,8 @@ export class SkillBuilder<TContext, TStash> {
       observers: this.config.observers,
       finalOutput: this.config.finalOutput,
       skillMd: this.config.skillMd,
+      resolveVersion: this.config.resolveVersion ?? false,
+      package: this.config.package,
       ...(hasSubskills ? { subskills: Object.freeze({ ...this.subskills }) } : {}),
       ...(hasTopics ? { topics: Object.freeze({ ...this.topics }) } : {}),
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,9 +186,7 @@ export interface PackageConfig {
   [key: string]: unknown;
 }
 
-export type VersionStrategy =
-  | { version?: string; resolveVersion?: never }
-  | { version?: never; resolveVersion: true };
+export type VersionStrategy = { version?: string; resolveVersion?: never } | { version?: never; resolveVersion: true };
 
 // --- Skill Builder Config (input to skill()) ---
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,11 +176,24 @@ export interface ObserverMap {
   onSkillComplete?: (ctx: { path: string[]; finalOutput: unknown; durationMs: number }) => void | Promise<void>;
 }
 
+// --- Package Config ---
+
+export interface PackageConfig {
+  name?: string;
+  description?: string;
+  license?: string;
+  files?: string[];
+  [key: string]: unknown;
+}
+
+export type VersionStrategy =
+  | { version?: string; resolveVersion?: never }
+  | { version?: never; resolveVersion: true };
+
 // --- Skill Builder Config (input to skill()) ---
 
-export interface SkillBuilderConfig<TContext extends z.ZodType = z.ZodType, TStash extends z.ZodType = z.ZodType> {
+export type SkillBuilderConfig<TContext extends z.ZodType = z.ZodType, TStash extends z.ZodType = z.ZodType> = {
   name: string;
-  version?: string;
   description?: string;
   triggers?: string[];
   entry: string;
@@ -189,7 +202,8 @@ export interface SkillBuilderConfig<TContext extends z.ZodType = z.ZodType, TSta
   observers?: ObserverMap;
   finalOutput?: z.ZodType;
   skillMd?: string | ((skill: SkillDefinition) => string);
-}
+  package?: PackageConfig;
+} & VersionStrategy;
 
 // --- Skill Definition (output of .build()) ---
 
@@ -197,6 +211,7 @@ export interface SkillDefinition<TContext extends z.ZodType = z.ZodType, TStash 
   readonly kind: 'skill';
   readonly name: string;
   readonly version: string;
+  readonly resolveVersion: boolean;
   readonly description: string;
   readonly entry: string;
   readonly context: TContext | undefined;
@@ -205,6 +220,7 @@ export interface SkillDefinition<TContext extends z.ZodType = z.ZodType, TStash 
   readonly observers: ObserverMap | undefined;
   readonly finalOutput: z.ZodType | undefined;
   readonly skillMd: string | ((skill: SkillDefinition) => string) | undefined;
+  readonly package: PackageConfig | undefined;
   readonly subskills?: Readonly<Record<string, SubskillRegistration>>;
   readonly topics?: Readonly<Record<string, TopicConfig>>;
 }
@@ -226,17 +242,19 @@ export interface TopicConfig {
   content: (ctx: { refs: ReferenceLoader }) => string;
 }
 
-export interface ReferenceBuilderConfig {
+export type ReferenceBuilderConfig = {
   name: string;
-  version?: string;
   description: string;
-}
+  package?: PackageConfig;
+} & VersionStrategy;
 
 export interface ReferenceDefinition {
   readonly kind: 'reference';
   readonly name: string;
   readonly version: string;
+  readonly resolveVersion: boolean;
   readonly description: string;
+  readonly package: PackageConfig | undefined;
   readonly topics: Readonly<Record<string, TopicConfig>>;
 }
 

--- a/tasks/2026-04-24_1149_build-package-json/TASK.md
+++ b/tasks/2026-04-24_1149_build-package-json/TASK.md
@@ -70,12 +70,16 @@ Update `src/build/index.ts`: if `def.resolveVersion`, call `resolveVersionFromAn
 
 ## Steps
 
-- [ ] Add `PackageConfig`, `VersionStrategy` types; update config/definition interfaces
-- [ ] Export `PackageConfig` from `src/index.ts`
-- [ ] Thread `resolveVersion` and `package` through `SkillBuilder` and `ReferenceBuilder`
-- [ ] Create `src/build/resolve-version.ts` with tests
-- [ ] Rewrite `src/build/package-json-template.ts` and update tests
-- [ ] Update `src/build/index.ts` orchestrator
-- [ ] Verify: typecheck + tests + format + manual build
+- [x] Add `PackageConfig`, `VersionStrategy` types; update config/definition interfaces
+- [x] Export `PackageConfig` from `src/index.ts`
+- [x] Thread `resolveVersion` and `package` through `SkillBuilder` and `ReferenceBuilder`
+- [x] Create `src/build/resolve-version.ts` with tests
+- [x] Rewrite `src/build/package-json-template.ts` and update tests
+- [x] Update `src/build/index.ts` orchestrator
+- [x] Verify: typecheck + tests + format + manual build
 
 ## Notes
+
+- `SkillBuilderConfig` and `ReferenceBuilderConfig` changed from `interface` to `type` (intersection with `VersionStrategy`). This is backward compatible for consumers.
+- Manual build verification confirmed merge works: existing `package.json` fields are preserved, `name`/`version` are overwritten by build.
+- 208 tests pass, including 6 new resolve-version tests and 6 new/updated package-json generation tests.

--- a/tasks/2026-04-24_1149_build-package-json/TASK.md
+++ b/tasks/2026-04-24_1149_build-package-json/TASK.md
@@ -1,0 +1,83 @@
+# Build: Improved package.json Generation
+
+## Scope
+
+**In:** Version resolution from ancestor package.json (opt-in), `package` config for output metadata, merge with existing package.json, type-safe version strategy.
+
+**Out:** CLI flag changes, SKILL.md generation changes, scripts/run changes.
+
+## Context
+
+The build pipeline generates a minimal `package.json` with only `name` and `version` from the skill definition. This is limiting for three reasons:
+
+1. Version management tools (`release-it`) bump the root `package.json`, but the build ignores it — requiring manual sync.
+2. No way to set `description`, `license`, `files`, scoped package names, or other npm fields.
+3. The build overwrites any existing `package.json` in the output directory, losing manually-added fields.
+
+User feedback: version resolution must be **opt-in** (not implicit) to avoid surprising filesystem walks. The version strategy should be enforced at the type level: either `version` or `resolveVersion`, never both. The `version` parameter to `generatePackageJson` should be separate from `PackageJsonOptions` since version is a managed property.
+
+## Plan
+
+### Types
+
+Add `PackageConfig` (output-only bag) and `VersionStrategy` (discriminated union) to `src/types.ts`:
+
+```typescript
+export interface PackageConfig {
+  name?: string;
+  description?: string;
+  license?: string;
+  files?: string[];
+  [key: string]: unknown;
+}
+
+type VersionStrategy =
+  | { version?: string; resolveVersion?: never }
+  | { version?: never; resolveVersion: true };
+```
+
+`SkillBuilderConfig` and `ReferenceBuilderConfig` become intersections with `VersionStrategy` and gain `package?: PackageConfig`. `SkillDefinition` and `ReferenceDefinition` gain `readonly resolveVersion: boolean` and `readonly package: PackageConfig | undefined`.
+
+### Version resolution utility
+
+New `src/build/resolve-version.ts`: walks up from `dirname(entryPath)` to find nearest `package.json` with a version. Returns `{ version, source }` or `undefined`. No external deps — simple dirname loop.
+
+### Package.json generation
+
+Rewrite `src/build/package-json-template.ts`:
+
+```typescript
+export interface PackageJsonOptions {
+  name: string;
+  packageConfig?: PackageConfig;
+  existingPath?: string;
+}
+
+export function generatePackageJson(version: string, opts: PackageJsonOptions): string
+```
+
+`version` is a standalone managed parameter. Merge order: existing (base) -> packageConfig (override) -> name/version (authoritative).
+
+### Build orchestrator
+
+Update `src/build/index.ts`: if `def.resolveVersion`, call `resolveVersionFromAncestor`; otherwise use `def.version`. Pass `def.package` through to `generatePackageJson`.
+
+### Key design choices
+
+- `version` and `resolveVersion` mutually exclusive via union type — no runtime divergence warning needed
+- `PackageConfig` is output-only — no build directives mixed in
+- `version` param to `generatePackageJson` is separate from options (managed property)
+- Both skills and references support `package` + `resolveVersion`
+- SKILL.md unchanged — still uses `def.version` for metadata
+
+## Steps
+
+- [ ] Add `PackageConfig`, `VersionStrategy` types; update config/definition interfaces
+- [ ] Export `PackageConfig` from `src/index.ts`
+- [ ] Thread `resolveVersion` and `package` through `SkillBuilder` and `ReferenceBuilder`
+- [ ] Create `src/build/resolve-version.ts` with tests
+- [ ] Rewrite `src/build/package-json-template.ts` and update tests
+- [ ] Update `src/build/index.ts` orchestrator
+- [ ] Verify: typecheck + tests + format + manual build
+
+## Notes

--- a/tasks/2026-04-24_1149_build-package-json/TASK.md
+++ b/tasks/2026-04-24_1149_build-package-json/TASK.md
@@ -31,9 +31,7 @@ export interface PackageConfig {
   [key: string]: unknown;
 }
 
-type VersionStrategy =
-  | { version?: string; resolveVersion?: never }
-  | { version?: never; resolveVersion: true };
+type VersionStrategy = { version?: string; resolveVersion?: never } | { version?: never; resolveVersion: true };
 ```
 
 `SkillBuilderConfig` and `ReferenceBuilderConfig` become intersections with `VersionStrategy` and gain `package?: PackageConfig`. `SkillDefinition` and `ReferenceDefinition` gain `readonly resolveVersion: boolean` and `readonly package: PackageConfig | undefined`.
@@ -53,7 +51,7 @@ export interface PackageJsonOptions {
   existingPath?: string;
 }
 
-export function generatePackageJson(version: string, opts: PackageJsonOptions): string
+export function generatePackageJson(version: string, opts: PackageJsonOptions): string;
 ```
 
 `version` is a standalone managed parameter. Merge order: existing (base) -> packageConfig (override) -> name/version (authoritative).


### PR DESCRIPTION
## Summary

- **`PackageConfig`** — New optional `package` field on `skill()` and `reference()` configs. Sets `name`, `description`, `license`, `files`, or any arbitrary field on the generated `package.json`. The `packageConfig.name` overrides the skill name for scoped packages.
- **`resolveVersion`** — New opt-in version strategy (`resolveVersion: true`) that resolves the version from the nearest ancestor `package.json` instead of hardcoding it. Mutually exclusive with `version` at the type level via a discriminated union.
- **Merge behavior** — If a `package.json` already exists in the output directory, the build merges rather than overwrites: existing fields are preserved, `package` config fields override, `name`/`version` are always authoritative.
- **Documentation checklist** — Added a rule to CLAUDE.md: every feature touching public API or build behavior must update all 5 doc locations before the branch is complete.

## Test plan

- [x] 208 tests pass (6 new resolve-version tests, 6 new/updated package-json generation tests)
- [x] TypeScript typecheck clean
- [x] Prettier formatting clean
- [x] Manual build verification: merge preserves existing `package.json` fields
- [ ] Review docs across all 5 locations for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)