### PR TITLE
fix: prefix completed.step in composite subskill results

### DIFF
--- a/src/protocol/composite-entry.test.ts
+++ b/src/protocol/composite-entry.test.ts
@@ -116,7 +116,7 @@ test('composite: dispatcher advance with topic redirect returns done with conten
 test('composite: sub-skill advance with namespaced step', async () => {
   const history = JSON.stringify([
     { step: 'classify', output: { intent: 'doctor' } },
-    { step: 'doctor/diagnose', output: { issue: 'broken' } },
+    { step: 'doctor/diagnose', output: { issue: 'broken' }, action: { found: 'scanned:broken' } },
   ]);
   const { stdout } = await run(
     'advance',
@@ -128,8 +128,9 @@ test('composite: sub-skill advance with namespaced step', async () => {
     history,
   );
   const result = JSON.parse(stdout.trim());
-  assert.equal(result.done, true);
-  assert.deepEqual(result.finalOutput, { issue: 'fixed' });
+  assert.equal(result.step, 'doctor/triage');
+  assert.ok(result.completed);
+  assert.equal(result.completed.step, 'doctor/diagnose');
 });
 
 test('composite: direct sub-skill start bypasses dispatcher', async () => {
@@ -140,7 +141,9 @@ test('composite: direct sub-skill start bypasses dispatcher', async () => {
 });
 
 test('composite: direct sub-skill advance', async () => {
-  const history = JSON.stringify([{ step: 'doctor/diagnose', output: { issue: 'test' } }]);
+  const history = JSON.stringify([
+    { step: 'doctor/diagnose', output: { issue: 'test' }, action: { found: 'scanned:test' } },
+  ]);
   const { stdout } = await run(
     'doctor',
     'advance',
@@ -152,7 +155,7 @@ test('composite: direct sub-skill advance', async () => {
     history,
   );
   const result = JSON.parse(stdout.trim());
-  assert.equal(result.done, true);
+  assert.equal(result.step, 'doctor/triage');
 });
 
 test('composite: topics command lists available topics', async () => {
@@ -246,6 +249,7 @@ test('composite session: full lifecycle dispatcher → subskill (file mode)', as
   const subskillPrompt = linesAfterRedirect[line1 - 1]!;
   assert.equal(subskillPrompt.step, 'doctor/diagnose');
 
+  // Advance doctor/diagnose → action runs → transitions to doctor/triage
   appendFileSync(
     pointer.file,
     JSON.stringify({ type: 'output', step: 'doctor/diagnose', output: { issue: 'fixed' } }) + '\n',
@@ -253,10 +257,76 @@ test('composite session: full lifecycle dispatcher → subskill (file mode)', as
   const { stdout: adv2 } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
   const line2 = parseInt(adv2.trim(), 10);
 
+  const linesAfterDiagnose = readSessionLines(pointer.file);
+  const triagePrompt = linesAfterDiagnose[line2 - 1]!;
+  assert.equal(triagePrompt.type, 'prompt');
+  assert.equal(triagePrompt.step, 'doctor/triage');
+
+  // Advance doctor/triage → transitions to doctor/report (prompt needs stash from diagnose action)
+  appendFileSync(
+    pointer.file,
+    JSON.stringify({ type: 'output', step: 'doctor/triage', output: { priority: 'high' } }) + '\n',
+  );
+  const { stdout: adv3 } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
+  const line3 = parseInt(adv3.trim(), 10);
+
+  const linesAfterTriage = readSessionLines(pointer.file);
+  const reportPrompt = linesAfterTriage[line3 - 1]!;
+  assert.equal(reportPrompt.type, 'prompt');
+  assert.equal(reportPrompt.step, 'doctor/report');
+
+  // Advance doctor/report → terminal
+  appendFileSync(
+    pointer.file,
+    JSON.stringify({ type: 'output', step: 'doctor/report', output: { summary: 'all good' } }) + '\n',
+  );
+  const { stdout: adv4 } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
+  const line4 = parseInt(adv4.trim(), 10);
+
   const finalLines = readSessionLines(pointer.file);
-  const doneLine = finalLines[line2 - 1]!;
+  const doneLine = finalLines[line4 - 1]!;
   assert.equal(doneLine.type, 'done');
-  assert.deepEqual(doneLine.finalOutput, { issue: 'fixed' });
+  assert.deepEqual(doneLine.finalOutput, { summary: 'all good' });
+});
+
+test('composite session: subskill action stash survives across advances', async () => {
+  const dir = createTempDir();
+
+  // Start dispatcher
+  const { stdout: startOut } = await run('--context', '{}', '--session', 'new', '--session-dir', dir);
+  const pointer = JSON.parse(startOut.trim());
+
+  // Advance classify → redirects to doctor subskill, prompts for doctor/diagnose
+  appendFileSync(
+    pointer.file,
+    JSON.stringify({ type: 'output', step: 'classify', output: { intent: 'doctor' } }) + '\n',
+  );
+  await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
+
+  // Advance doctor/diagnose — action runs, stash populated, transitions to doctor/triage
+  appendFileSync(
+    pointer.file,
+    JSON.stringify({ type: 'output', step: 'doctor/diagnose', output: { issue: '/src' } }) + '\n',
+  );
+  await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
+
+  // Advance doctor/triage — THIS is the cross-process replay:
+  // Engine replays diagnose from history, must restore action stash,
+  // then builds doctor/report prompt which reads stash.scanResult
+  appendFileSync(
+    pointer.file,
+    JSON.stringify({ type: 'output', step: 'doctor/triage', output: { priority: 'high' } }) + '\n',
+  );
+  const { stdout: adv3 } = await run('advance', '--session', pointer.sessionId, '--session-dir', dir);
+  const line3 = parseInt(adv3.trim(), 10);
+
+  const lines = readSessionLines(pointer.file);
+  const reportLine = lines[line3 - 1]!;
+  assert.equal(reportLine.step, 'doctor/report');
+  assert.ok(
+    (reportLine.prompt as string).includes('scanned:/src'),
+    `report prompt should contain action stash value from diagnose, got: ${reportLine.prompt}`,
+  );
 });
 
 test('composite session: direct subskill start (file mode)', async () => {

--- a/src/protocol/composite-entry.ts
+++ b/src/protocol/composite-entry.ts
@@ -112,7 +112,11 @@ function filterHistory(history: HistoryEntry[], subskillName: string): HistoryEn
 
 function prefixResult(result: CliResult, subskillName: string): CliResult {
   if ('step' in result && typeof result.step === 'string') {
-    return { ...result, step: prefixStep(subskillName, result.step) };
+    const prefixed = { ...result, step: prefixStep(subskillName, result.step) };
+    if ('completed' in prefixed && prefixed.completed) {
+      prefixed.completed = { ...prefixed.completed, step: prefixStep(subskillName, prefixed.completed.step) };
+    }
+    return prefixed;
   }
   return result;
 }

--- a/src/protocol/fixtures/composite-skill.ts
+++ b/src/protocol/fixtures/composite-skill.ts
@@ -1,10 +1,32 @@
-import { skill, z } from '../../index.js';
+import { skill, z, action } from '../../index.js';
 import { compositeMain } from '../../cli.js';
 
-const doctorSkill = skill({ name: 'doctor', entry: 'diagnose' })
+const scanAction = action({
+  name: 'scan',
+  input: z.object({ path: z.string() }),
+  output: z.object({ found: z.string() }),
+  run: async ({ input }) => ({ found: `scanned:${input.path}` }),
+});
+
+const doctorSkill = skill({ name: 'doctor', entry: 'diagnose', stash: z.object({ scanResult: z.string() }) })
   .step('diagnose', {
     prompt: 'Diagnose the issue.',
     output: z.object({ issue: z.string() }),
+    action: {
+      run: scanAction,
+      input: ({ output }) => ({ path: output.issue }),
+      stash: ({ result }) => ({ scanResult: result.found }),
+    },
+    next: 'triage',
+  })
+  .step('triage', {
+    prompt: 'Triage the findings.',
+    output: z.object({ priority: z.string() }),
+    next: 'report',
+  })
+  .step('report', {
+    prompt: (ctx) => `Report: scanResult=${JSON.stringify(ctx.stash.scanResult)}`,
+    output: z.object({ summary: z.string() }),
     next: { terminal: true },
   })
   .build();

--- a/src/runtime/engine.test.ts
+++ b/src/runtime/engine.test.ts
@@ -417,6 +417,103 @@ test('afterAction is replayed correctly from history', () => {
   assert.deepEqual(capturedStash, { code: 404 });
 });
 
+test('action stash vs step stash: both survive replay into next prompt', async () => {
+  let capturedStash: unknown;
+
+  const fetchAction = action({
+    name: 'fetch',
+    input: z.object({ url: z.string() }),
+    output: z.object({ spaceId: z.string() }),
+    run: async () => ({ spaceId: 'never-called' }),
+  });
+
+  const s = skill({
+    name: 'stash-compare',
+    entry: 'explore',
+    stash: z.object({ fromStep: z.string(), fromAction: z.string() }),
+  })
+    .step('explore', {
+      prompt: 'Explore',
+      output: z.object({ url: z.string() }),
+      stash: ({ output }) => ({ fromStep: output.url }),
+      action: {
+        run: fetchAction,
+        stash: ({ result }) => ({ fromAction: result.spaceId }),
+      },
+      next: 'triage',
+    })
+    .step('triage', {
+      prompt: 'Triage',
+      output: z.object({ decision: z.string() }),
+      next: 'report',
+    })
+    .step('report', {
+      prompt: (ctx) => {
+        capturedStash = ctx.stash;
+        return 'Report';
+      },
+      output: z.object({}),
+      next: { terminal: true },
+    })
+    .build();
+
+  // Simulate: explore completed (with action), triage being advanced → report prompt built
+  const engine = new WorkflowEngine(s, genericHost, {});
+  engine.replayHistory([{ step: 'explore', output: { url: 'https://x.com' }, action: { spaceId: 'abc123' } }]);
+  engine.start();
+  await engine.advance('triage', { decision: 'go' });
+
+  assert.deepEqual(capturedStash, { fromStep: 'https://x.com', fromAction: 'abc123' });
+});
+
+test('action stash survives cross-process replay into next step prompt', async () => {
+  let capturedStash: unknown;
+
+  const fetchAction = action({
+    name: 'fetch',
+    input: z.object({ url: z.string() }),
+    output: z.object({ spaceId: z.string() }),
+    run: async () => ({ spaceId: 'never-called' }),
+  });
+
+  const s = skill({ name: 'cross-process', entry: 'explore', stash: z.object({ spaceId: z.string() }) })
+    .step('explore', {
+      prompt: 'Explore',
+      output: z.object({ url: z.string() }),
+      action: {
+        run: fetchAction,
+        stash: ({ result }) => ({ spaceId: result.spaceId }),
+      },
+      next: 'triage',
+    })
+    .step('triage', {
+      prompt: 'Triage',
+      output: z.object({ decision: z.string() }),
+      next: 'report',
+    })
+    .step('report', {
+      prompt: (ctx) => {
+        capturedStash = ctx.stash;
+        return 'Report';
+      },
+      output: z.object({ summary: z.string() }),
+      next: { terminal: true },
+    })
+    .build();
+
+  // Simulate process 3: explore and triage completed, advancing triage builds report prompt
+  const engine = new WorkflowEngine(s, genericHost, {});
+  engine.replayHistory([
+    { step: 'explore', output: { url: 'https://x.com' }, action: { spaceId: '58j6jt5cfhic' } },
+    { step: 'triage', output: { decision: 'fix' } },
+  ]);
+  engine.start();
+  const result = await engine.advance('triage', { decision: 'fix' });
+
+  assert.equal((result as PromptResult).step, 'report');
+  assert.deepEqual(capturedStash, { spaceId: '58j6jt5cfhic' });
+});
+
 test('getStep provides typed history access', async () => {
   let stepAResult: unknown;
 


### PR DESCRIPTION
## Summary

- `prefixResult` only prefixed the top-level `step` field (the next step to prompt) but not `completed.step` (the step that just finished)
- Subskill history entries were written with bare step names (e.g. `"explore"` instead of `"doctor/explore"`)
- On the next advance, `filterHistory` looked for `"doctor/"`-prefixed entries, silently dropped all bare-named ones, and the subskill engine replayed with empty history — losing all stash values

## Test plan

- [x] New test: `composite session: subskill action stash survives across advances` — full session round-trip through dispatcher → subskill with action.stash → verify stash in subsequent step prompt
- [x] Updated existing composite tests for multi-step subskill fixture (diagnose → triage → report)
- [x] Engine-level tests for action stash replay (non-composite path, regression coverage)
- [x] All 265 tests pass, typecheck clean, formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)