### PR TITLE
refactor: SubskillEngine for transparent step name qualification

### DIFF
--- a/src/protocol/composite-entry.test.ts
+++ b/src/protocol/composite-entry.test.ts
@@ -329,6 +329,31 @@ test('composite session: subskill action stash survives across advances', async 
   );
 });
 
+test('composite session: direct subskill advance with qualified step name from session', async () => {
+  const dir = createTempDir();
+
+  // Direct subskill start — prompts for doctor/diagnose
+  const { stdout: startOut } = await run('doctor', '--context', '{}', '--session', 'new', '--session-dir', dir);
+  const pointer = JSON.parse(startOut.trim());
+
+  // Host writes output with the QUALIFIED step name (as seen in the prompt output)
+  appendFileSync(
+    pointer.file,
+    JSON.stringify({ type: 'output', step: 'doctor/diagnose', output: { issue: '/src' } }) + '\n',
+  );
+
+  // Advance — should handle the qualified step name without double-prefixing
+  const { stdout: advOut } = await run('doctor', 'advance', '--session', pointer.sessionId, '--session-dir', dir);
+  const line = parseInt(advOut.trim(), 10);
+
+  const lines = readSessionLines(pointer.file);
+  const resultLine = lines[line - 1]!;
+  assert.equal(resultLine.type, 'prompt');
+  assert.equal(resultLine.step, 'doctor/triage');
+  assert.ok(resultLine.completed);
+  assert.equal((resultLine.completed as { step: string }).step, 'doctor/diagnose');
+});
+
 test('composite session: direct subskill start (file mode)', async () => {
   const dir = createTempDir();
   const { stdout } = await run('doctor', '--context', '{}', '--session', 'new', '--session-dir', dir);

--- a/src/protocol/composite-entry.ts
+++ b/src/protocol/composite-entry.ts
@@ -4,6 +4,7 @@ import { WorkflowEngine } from '../runtime/engine.js';
 import { createReferenceLoader } from '../runtime/reference-loader.js';
 import { resolveHost } from './host.js';
 import { SessionManager, type SessionFile } from './session.js';
+import { SubskillEngine } from './subskill-engine.js';
 
 function resolveSkillDir(): string {
   const binPath = process.execPath;
@@ -95,30 +96,13 @@ function parseFlags(args: string[], start: number): Record<string, string> {
   return flags;
 }
 
-function prefixStep(subskillName: string, step: string): string {
-  return `${subskillName}/${step}`;
+function detectSubskill(step: string): string | null {
+  const idx = step.indexOf('/');
+  return idx === -1 ? null : step.slice(0, idx);
 }
 
-function unprefixStep(step: string): { subskill: string; step: string } | null {
-  const slashIdx = step.indexOf('/');
-  if (slashIdx === -1) return null;
-  return { subskill: step.slice(0, slashIdx), step: step.slice(slashIdx + 1) };
-}
-
-function filterHistory(history: HistoryEntry[], subskillName: string): HistoryEntry[] {
-  const prefix = `${subskillName}/`;
-  return history.filter((e) => e.step.startsWith(prefix)).map((e) => ({ ...e, step: e.step.slice(prefix.length) }));
-}
-
-function prefixResult(result: CliResult, subskillName: string): CliResult {
-  if ('step' in result && typeof result.step === 'string') {
-    const prefixed = { ...result, step: prefixStep(subskillName, result.step) };
-    if ('completed' in prefixed && prefixed.completed) {
-      prefixed.completed = { ...prefixed.completed, step: prefixStep(subskillName, prefixed.completed.step) };
-    }
-    return prefixed;
-  }
-  return result;
+function extractDispatcherHistory(history: HistoryEntry[]): HistoryEntry[] {
+  return history.filter((e) => !e.step.includes('/'));
 }
 
 function writeOutput(data: unknown, session: SessionFile | undefined): void {
@@ -310,14 +294,20 @@ async function handleDispatcher(
 
   const { stepName, output, history } = resolveAdvanceInput(parsed.flags, session);
 
-  const parsed_ = unprefixStep(stepName);
-  if (parsed_) {
-    await handleSubskillAdvance(def, parsed_.subskill, parsed_.step, output, history, handshake, refs, session);
+  const subskillName = detectSubskill(stepName);
+  if (subskillName) {
+    const sub = def.subskills?.[subskillName];
+    if (!sub) throw new Error(`Unknown sub-skill "${subskillName}"`);
+    const subEngine = new SubskillEngine(sub.definition, handshake, {}, refs, subskillName);
+    subEngine.replayHistory(history);
+    subEngine.startForReplay();
+    const result = await subEngine.advance(stepName, output);
+    writeOutput(result, session);
     return;
   }
 
   const engine = new WorkflowEngine(def, handshake, {}, refs);
-  const dispatcherHistory = history.filter((e) => !e.step.includes('/'));
+  const dispatcherHistory = extractDispatcherHistory(history);
   if (dispatcherHistory.length > 0) {
     engine.replayHistory(dispatcherHistory);
   }
@@ -351,41 +341,17 @@ async function handleSubskill(
 
   if (isStart) {
     const context = parsed.flags['context'] ? (JSON.parse(parsed.flags['context']) as unknown) : {};
-    const engine = new WorkflowEngine(sub.definition, handshake, context, refs);
-    const result = engine.start();
-    writeStartOutput(prefixResult(result, parsed.name), session);
+    const subEngine = new SubskillEngine(sub.definition, handshake, context, refs, parsed.name);
+    writeStartOutput(subEngine.start(), session);
     return;
   }
 
   const { stepName, output, history } = resolveAdvanceInput(parsed.flags, session);
-  await handleSubskillAdvance(def, parsed.name, stepName, output, history, handshake, refs, session);
-}
-
-async function handleSubskillAdvance(
-  def: SkillDefinition,
-  subskillName: string,
-  stepName: string,
-  output: unknown,
-  history: HistoryEntry[],
-  handshake: ReturnType<typeof resolveHost>,
-  refs: ReferenceLoader,
-  session: SessionFile | undefined,
-): Promise<void> {
-  const sub = def.subskills?.[subskillName];
-  if (!sub) {
-    process.stderr.write(`error: unknown sub-skill "${subskillName}"\n`);
-    process.exit(1);
-  }
-
-  const subHistory = filterHistory(history, subskillName);
-  const engine = new WorkflowEngine(sub.definition, handshake, {}, refs);
-  if (subHistory.length > 0) {
-    engine.replayHistory(subHistory);
-  }
-  engine.start();
-
-  const result = await engine.advance(stepName, output);
-  writeOutput(prefixResult(result, subskillName), session);
+  const subEngine = new SubskillEngine(sub.definition, handshake, {}, refs, parsed.name);
+  subEngine.replayHistory(history);
+  subEngine.startForReplay();
+  const result = await subEngine.advance(stepName, output);
+  writeOutput(result, session);
 }
 
 async function handleRedirect(
@@ -416,9 +382,10 @@ async function handleRedirect(
     }
 
     const context = sub.contextMap ? sub.contextMap(redirect.completed.output, redirect.stash) : {};
-    const engine = new WorkflowEngine(sub.definition, handshake, context, refs);
-    const result = engine.start();
-    writeOutput({ ...prefixResult(result, subName), completed: redirect.completed }, session);
+    const subEngine = new SubskillEngine(sub.definition, handshake, context, refs, subName);
+    const startResult = subEngine.start();
+    // completed is from the dispatcher step that triggered the redirect — already in session convention
+    writeOutput({ ...startResult, completed: redirect.completed }, session);
     return;
   }
 

--- a/src/protocol/subskill-engine.test.ts
+++ b/src/protocol/subskill-engine.test.ts
@@ -1,0 +1,118 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+import { skill } from '../skill.js';
+import { action } from '../action.js';
+import { SubskillEngine } from './subskill-engine.js';
+import type { Handshake, PromptResult, DoneResult, ValidationErrorResult } from '../types.js';
+
+const genericHost: Handshake = { host: 'generic', toolsAvailable: [], isSubagent: false };
+
+const scanAction = action({
+  name: 'scan',
+  input: z.object({ path: z.string() }),
+  output: z.object({ found: z.string() }),
+  run: async ({ input }) => ({ found: `scanned:${input.path}` }),
+});
+
+const doctorSkill = skill({ name: 'doctor', entry: 'diagnose', stash: z.object({ scanResult: z.string() }) })
+  .step('diagnose', {
+    prompt: 'Diagnose.',
+    output: z.object({ issue: z.string() }),
+    action: {
+      run: scanAction,
+      input: ({ output }) => ({ path: output.issue }),
+      stash: ({ result }) => ({ scanResult: result.found }),
+    },
+    next: 'report',
+  })
+  .step('report', {
+    prompt: (ctx) => `Report: scanResult=${JSON.stringify(ctx.stash.scanResult)}`,
+    output: z.object({ summary: z.string() }),
+    next: { terminal: true },
+  })
+  .build();
+
+test('SubskillEngine.start qualifies step name', () => {
+  const sub = new SubskillEngine(doctorSkill, genericHost, {}, { load: () => '', asset: (p) => p }, 'doctor');
+  const result = sub.start();
+  assert.equal(result.step, 'doctor/diagnose');
+});
+
+test('SubskillEngine.advance qualifies prompt step and completed step', async () => {
+  const sub = new SubskillEngine(doctorSkill, genericHost, {}, { load: () => '', asset: (p) => p }, 'doctor');
+  sub.start();
+  const result = (await sub.advance('doctor/diagnose', { issue: '/src' })) as PromptResult;
+  assert.equal(result.step, 'doctor/report');
+  assert.equal(result.completed?.step, 'doctor/diagnose');
+});
+
+test('SubskillEngine.advance strips prefix from already-qualified step', async () => {
+  const sub = new SubskillEngine(doctorSkill, genericHost, {}, { load: () => '', asset: (p) => p }, 'doctor');
+  sub.start();
+  const result = (await sub.advance('doctor/diagnose', { issue: '/src' })) as PromptResult;
+  assert.equal(result.step, 'doctor/report');
+});
+
+test('SubskillEngine.advance tolerates bare step name', async () => {
+  const sub = new SubskillEngine(doctorSkill, genericHost, {}, { load: () => '', asset: (p) => p }, 'doctor');
+  sub.start();
+  const result = (await sub.advance('diagnose', { issue: '/src' })) as PromptResult;
+  assert.equal(result.step, 'doctor/report');
+});
+
+test('SubskillEngine.advance qualifies validation error step', async () => {
+  const sub = new SubskillEngine(doctorSkill, genericHost, {}, { load: () => '', asset: (p) => p }, 'doctor');
+  sub.start();
+  const result = (await sub.advance('diagnose', { bad: 'data' })) as ValidationErrorResult;
+  assert.equal(result.error, 'validation');
+  assert.equal(result.step, 'doctor/diagnose');
+});
+
+test('SubskillEngine.advance qualifies done result completed step', async () => {
+  const sub = new SubskillEngine(doctorSkill, genericHost, {}, { load: () => '', asset: (p) => p }, 'doctor');
+  sub.start();
+  await sub.advance('diagnose', { issue: '/src' });
+  const result = (await sub.advance('report', { summary: 'ok' })) as DoneResult;
+  assert.equal(result.done, true);
+  assert.equal(result.completed?.step, 'doctor/report');
+});
+
+test('SubskillEngine.replayHistory filters and unqualifies entries', async () => {
+  let capturedStash: unknown;
+
+  const stashSkill = skill({ name: 'doc', entry: 'a', stash: z.object({ val: z.string() }) })
+    .step('a', {
+      prompt: 'A',
+      output: z.object({ v: z.string() }),
+      stash: ({ output }) => ({ val: output.v }),
+      next: 'b',
+    })
+    .step('b', {
+      prompt: 'B',
+      output: z.object({ x: z.string() }),
+      next: 'c',
+    })
+    .step('c', {
+      prompt: (ctx) => {
+        capturedStash = ctx.stash;
+        return 'C';
+      },
+      output: z.object({}),
+      next: { terminal: true },
+    })
+    .build();
+
+  const sub = new SubskillEngine(stashSkill, genericHost, {}, { load: () => '', asset: (p) => p }, 'doc');
+  // Mixed history: dispatcher entry, this subskill entry, another subskill entry
+  sub.replayHistory([
+    { step: 'classify', output: { intent: 'doc' } },
+    { step: 'doc/a', output: { v: 'hello' } },
+    { step: 'other/x', output: {} },
+  ]);
+  sub.startForReplay();
+  // Advance b → builds c prompt which captures stash
+  const result = await sub.advance('doc/b', { x: 'ok' });
+  assert.equal((result as PromptResult).step, 'doc/c');
+  assert.deepEqual(capturedStash, { val: 'hello' });
+});

--- a/src/protocol/subskill-engine.ts
+++ b/src/protocol/subskill-engine.ts
@@ -1,0 +1,104 @@
+import type {
+  CliResult,
+  PromptResult,
+  DoneResult,
+  ValidationErrorResult,
+  StepResult,
+  Handshake,
+  SkillDefinition,
+  ReferenceLoader,
+} from '../types.js';
+import { WorkflowEngine } from '../runtime/engine.js';
+
+type HistoryEntry = { step: string; output: unknown; action?: unknown };
+
+/**
+ * Wraps a WorkflowEngine for a subskill, transparently qualifying step names
+ * on the way out (engine → session) and unqualifying on the way in (session → engine).
+ *
+ * Callers never prefix or unprefix manually — the boundary lives here.
+ */
+export class SubskillEngine {
+  private readonly engine: WorkflowEngine;
+  private readonly prefix: string;
+
+  constructor(
+    definition: SkillDefinition,
+    handshake: Handshake,
+    context: unknown,
+    refs: ReferenceLoader,
+    subskillName: string,
+  ) {
+    this.engine = new WorkflowEngine(definition, handshake, context, refs);
+    this.prefix = `${subskillName}/`;
+  }
+
+  start(): PromptResult {
+    return this.qualifyPrompt(this.engine.start());
+  }
+
+  startForReplay(): void {
+    this.engine.start();
+  }
+
+  replayHistory(history: HistoryEntry[]): void {
+    const filtered: HistoryEntry[] = [];
+    for (const entry of history) {
+      if (entry.step.startsWith(this.prefix)) {
+        filtered.push({ ...entry, step: entry.step.slice(this.prefix.length) });
+      }
+    }
+    if (filtered.length > 0) {
+      this.engine.replayHistory(filtered);
+    }
+  }
+
+  async advance(qualifiedStep: string, output: unknown): Promise<CliResult> {
+    const bareStep = this.stripPrefix(qualifiedStep);
+    return this.qualifyResult(await this.engine.advance(bareStep, output));
+  }
+
+  private stripPrefix(step: string): string {
+    return step.startsWith(this.prefix) ? step.slice(this.prefix.length) : step;
+  }
+
+  private qualify(step: string): string {
+    return `${this.prefix}${step}`;
+  }
+
+  private qualifyCompleted(completed: StepResult): StepResult {
+    return { ...completed, step: this.qualify(completed.step) };
+  }
+
+  private qualifyPrompt(result: PromptResult): PromptResult {
+    return {
+      ...result,
+      step: this.qualify(result.step),
+      ...(result.completed ? { completed: this.qualifyCompleted(result.completed) } : {}),
+    };
+  }
+
+  private qualifyResult(result: CliResult): CliResult {
+    if ('redirect' in result) {
+      throw new Error(
+        `SubskillEngine: unexpected redirect "${(result as { redirect: string }).redirect}" — ` +
+          `subskills should not produce redirect results`,
+      );
+    }
+
+    if ('error' in result) {
+      const err = result as ValidationErrorResult;
+      return { ...err, step: this.qualify(err.step) };
+    }
+
+    if ('done' in result) {
+      const done = result as DoneResult;
+      return {
+        ...done,
+        ...(done.completed ? { completed: this.qualifyCompleted(done.completed) } : {}),
+      };
+    }
+
+    return this.qualifyPrompt(result as PromptResult);
+  }
+}


### PR DESCRIPTION
## Summary

- Introduces `SubskillEngine` — a wrapper around `WorkflowEngine` that transparently qualifies step names on the way out (engine → session) and unqualifies on the way in (session → engine)
- Replaces 4 scattered helper functions (`prefixStep`, `unprefixStep`, `filterHistory`, `prefixResult`) across 6 manual call sites with a single boundary object
- Fixes the double-prefix bug where `handleSubskill` passed `"doctor/explore"` to the engine without stripping the prefix, producing `"doctor/doctor/explore"` in error responses (observed in session `3ca504d8`)

## Context

Two bugs in consecutive PRs from the same prefix/unprefix scatter:
1. PR #43: `prefixResult` forgot to prefix `completed.step`
2. This PR: `handleSubskill` forgot to unprefix the step name from `readLastOutput`

Root cause was structural — every call site manually applied helpers, and new code paths forgot.

## Test plan

- [x] 7 new `SubskillEngine` unit tests: start, advance (qualified/bare), validation error, done result, history filtering
- [x] New integration test: direct subskill session advance with qualified step name (reproduces double-prefix bug)
- [x] All 273 existing tests pass unchanged
- [x] Typecheck clean, formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)