### PR TITLE
feat: surface skill params in generated SKILL.md

### DIFF
--- a/src/build/index.test.ts
+++ b/src/build/index.test.ts
@@ -265,6 +265,73 @@ test('generateSkillMd includes sub-skills and topics sections', () => {
   assert.ok(result.includes('scripts/run topic <name>'));
 });
 
+test('generateSkillMd documents params with defaults', () => {
+  const s = skill({
+    name: 'greeter',
+    entry: 'greet',
+    params: z.object({
+      greeting: z.string().default('Hey there!'),
+    }),
+  })
+    .step('greet', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
+    .build();
+
+  const result = generateSkillMd(s);
+  assert.ok(result.includes('## Parameters'));
+  assert.ok(result.includes('| `greeting` | string | No | `"Hey there!"` |'));
+  assert.ok(result.includes('All parameters have defaults'));
+  assert.ok(result.includes("--params '{}'"));
+});
+
+test('generateSkillMd documents required params and uses them in start example', () => {
+  const s = skill({
+    name: 'doctor',
+    entry: 'diagnose',
+    params: z.object({
+      repoPath: z.string(),
+      strictness: z.enum(['lenient', 'normal', 'strict']).default('normal'),
+    }),
+  })
+    .step('diagnose', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
+    .build();
+
+  const result = generateSkillMd(s);
+  assert.ok(result.includes('| `repoPath` | string | **Yes** | — |'));
+  assert.ok(result.includes('`"lenient"` \\| `"normal"` \\| `"strict"`'));
+  assert.ok(result.includes('| `strictness` |'));
+  assert.ok(result.includes('"repoPath":"<repoPath>"'));
+});
+
+test('generateSkillMd shows no-params message when skill has no params', () => {
+  const s = skill({ name: 'minimal', entry: 'a' })
+    .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
+    .build();
+
+  const result = generateSkillMd(s);
+  assert.ok(result.includes('## Parameters'));
+  assert.ok(result.includes('This skill takes no parameters'));
+});
+
+test('generateSkillMd documents sub-skill params', () => {
+  const child = skill({
+    name: 'doctor',
+    description: 'Diagnose issues.',
+    entry: 'a',
+    params: z.object({ spaceId: z.string() }),
+  })
+    .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
+    .build();
+
+  const s = skill({ name: 'composite', entry: 'start' })
+    .step('start', { prompt: 'Classify.', output: z.object({}), next: 'subskill:doctor' })
+    .subskill('doctor', child)
+    .build();
+
+  const result = generateSkillMd(s);
+  assert.ok(result.includes('**doctor**: Diagnose issues.'));
+  assert.ok(result.includes('`spaceId` (string, required)'));
+});
+
 test('generateNodeScriptsRun produces valid bash delegator with Node version check', () => {
   const result = generateNodeScriptsRun('repo-doctor');
   assert.ok(result.startsWith('#!/usr/bin/env bash'));

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -1,6 +1,110 @@
 import type { SkillDefinition } from '../types.js';
 import type { BuildProtocol } from './index.js';
 
+interface ParamField {
+  name: string;
+  type: string;
+  required: boolean;
+  default?: unknown;
+}
+
+interface ParamInfo {
+  fields: ParamField[];
+  hasRequired: boolean;
+  exampleJson: string;
+}
+
+function formatType(prop: Record<string, unknown>): string {
+  if (Array.isArray(prop['enum'])) {
+    return (prop['enum'] as unknown[]).map((v) => `\`${JSON.stringify(v)}\``).join(' \\| ');
+  }
+  if (prop['type'] === 'array') return 'array';
+  if (prop['type'] === 'object') return 'object';
+  return String(prop['type'] ?? 'unknown');
+}
+
+function exampleValue(prop: Record<string, unknown>, name: string): unknown {
+  if ('default' in prop) return prop['default'];
+  if (Array.isArray(prop['enum'])) return prop['enum'][0];
+  switch (prop['type']) {
+    case 'string':
+      return `<${name}>`;
+    case 'number':
+    case 'integer':
+      return 0;
+    case 'boolean':
+      return false;
+    case 'array':
+      return [];
+    case 'object':
+      return {};
+    default:
+      return null;
+  }
+}
+
+function extractParamInfo(params: unknown): ParamInfo | null {
+  if (!params || typeof params !== 'object' || !('toJSONSchema' in params)) return null;
+
+  try {
+    const schema = (params as { toJSONSchema: () => Record<string, unknown> }).toJSONSchema() as Record<
+      string,
+      unknown
+    >;
+    const properties = (schema['properties'] as Record<string, Record<string, unknown>>) ?? {};
+    const requiredArr = (schema['required'] as string[]) ?? [];
+
+    const names = Object.keys(properties);
+    if (names.length === 0) return null;
+
+    const fields: ParamField[] = names.map((name) => {
+      const prop = properties[name] ?? {};
+      // A field is required from the caller's perspective only if it's
+      // in the JSON Schema `required` array AND has no `default` value.
+      const hasDefault = 'default' in prop;
+      return {
+        name,
+        type: formatType(prop),
+        required: requiredArr.includes(name) && !hasDefault,
+        ...(hasDefault ? { default: prop['default'] } : {}),
+      };
+    });
+
+    const hasRequired = fields.some((f) => f.required);
+
+    const example: Record<string, unknown> = {};
+    for (const name of names) {
+      example[name] = exampleValue(properties[name] ?? {}, name);
+    }
+    const exampleJson = JSON.stringify(example);
+
+    return { fields, hasRequired, exampleJson };
+  } catch {
+    return null;
+  }
+}
+
+function generateParamsSection(info: ParamInfo | null): string {
+  if (!info) return "## Parameters\n\nThis skill takes no parameters. Pass `--params '{}'`.";
+
+  const rows = info.fields.map((f) => {
+    const req = f.required ? '**Yes**' : 'No';
+    const def = 'default' in f ? `\`${JSON.stringify(f.default)}\`` : '—';
+    return `| \`${f.name}\` | ${f.type} | ${req} | ${def} |`;
+  });
+
+  const table = ['| Name | Type | Required | Default |', '|------|------|----------|---------|', ...rows].join('\n');
+
+  const note = info.hasRequired ? '' : "\nAll parameters have defaults — `--params '{}'` is valid.\n";
+
+  return `## Parameters\n\n${table}\n${note}\nExample:\n\n\`\`\`json\n${info.exampleJson}\n\`\`\``;
+}
+
+function buildExampleParamsFlag(info: ParamInfo | null): string {
+  if (!info || !info.hasRequired) return "'{}'";
+  return `'${info.exampleJson}'`;
+}
+
 const SKILL_DIR_INSTRUCTION = `This SKILL.md file is inside the skill directory. Resolve the **absolute path** to \`scripts/run\`
 from this file's location (e.g., \`/path/to/skill/scripts/run\`). Use the absolute path in all
 Bash commands — do not \`cd\` into the skill directory.
@@ -25,7 +129,12 @@ export function generateSkillMd(skill: SkillDefinition, protocol: BuildProtocol 
     })
     .join('\n');
 
-  const protocolInstructions = protocol === 'session' ? generateSessionInstructions() : generateStatelessInstructions();
+  const paramInfo = extractParamInfo(skill.params);
+  const paramsFlag = buildExampleParamsFlag(paramInfo);
+  const paramsSection = generateParamsSection(paramInfo);
+
+  const protocolInstructions =
+    protocol === 'session' ? generateSessionInstructions(paramsFlag) : generateStatelessInstructions(paramsFlag);
 
   const body = `
 # ${skill.name}
@@ -101,6 +210,8 @@ reported tools are a genuine subset — the skill will not merge them with the h
 Without \`--subagent\`, the skill assumes you are a top-level agent and merges your tools
 with the registry (since top-level agents often under-report their tools).
 
+${paramsSection}
+
 ${protocolInstructions}
 ### Important
 
@@ -121,11 +232,11 @@ function yamlDoubleQuoted(value: string): string {
   return JSON.stringify(value);
 }
 
-function generateSessionInstructions(): string {
+function generateSessionInstructions(paramsFlag: string): string {
   return `### Step 1: Start with a session
 
 \`\`\`bash
-<skill>/scripts/run --params '{}' --host claude-code --tools <your-tools> --session new 2>/dev/null
+<skill>/scripts/run --params ${paramsFlag} --host claude-code --tools <your-tools> --session new 2>/dev/null
 \`\`\`
 
 This returns a JSON pointer with \`sessionId\`, \`file\`, and \`line\`. The \`line\` field tells you
@@ -163,11 +274,11 @@ contains the skill's result. Present it to the user.
 `;
 }
 
-function generateStatelessInstructions(): string {
+function generateStatelessInstructions(paramsFlag: string): string {
   return `### Step 1: Start
 
 \`\`\`bash
-<skill>/scripts/run --params '{}' --host claude-code --tools <your-tools> 2>/dev/null
+<skill>/scripts/run --params ${paramsFlag} --host claude-code --tools <your-tools> 2>/dev/null
 \`\`\`
 
 The output is JSON with: \`preamble\`, \`step\`, \`prompt\`, \`schema\`.
@@ -228,10 +339,10 @@ function generateSubskillSection(skill: SkillDefinition, protocol: BuildProtocol
   lines.push('### Direct sub-skill access', '');
   lines.push('```bash');
   if (protocol === 'session') {
-    lines.push("<skill>/scripts/run <subskill> --params '{}' --session new");
+    lines.push("<skill>/scripts/run <subskill> --params '<json>' --session new");
     lines.push('<skill>/scripts/run <subskill> advance --session <id>');
   } else {
-    lines.push("<skill>/scripts/run <subskill> --params '{}'");
+    lines.push("<skill>/scripts/run <subskill> --params '<json>'");
     lines.push("<skill>/scripts/run <subskill> advance --step <step> --output '...' --history '[...]'");
   }
   lines.push('```');
@@ -239,7 +350,15 @@ function generateSubskillSection(skill: SkillDefinition, protocol: BuildProtocol
 
   for (const [name, reg] of Object.entries(skill.subskills)) {
     const desc = reg.definition.description || '(no description)';
-    lines.push(`- **${name}**: ${desc}`);
+    const subParamInfo = extractParamInfo(reg.definition.params);
+    if (subParamInfo) {
+      const paramSummary = subParamInfo.fields
+        .map((f) => `\`${f.name}\` (${f.type}${f.required ? ', required' : ''})`)
+        .join(', ');
+      lines.push(`- **${name}**: ${desc} — params: ${paramSummary}`);
+    } else {
+      lines.push(`- **${name}**: ${desc}`);
+    }
   }
 
   return lines.join('\n');

--- a/tasks/2026-04-29_1112_surface-params-in-skillmd/TASK.md
+++ b/tasks/2026-04-29_1112_surface-params-in-skillmd/TASK.md
@@ -19,6 +19,7 @@ This was surfaced by asking: "Do agents know what the params are that we expect 
 Add a `## Parameters` section to `generateSkillMd()` output:
 
 **No params:**
+
 ```markdown
 ## Parameters
 
@@ -26,21 +27,24 @@ This skill takes no parameters. Pass `--params '{}'`.
 ```
 
 **All optional (all have defaults):**
-```markdown
+
+````markdown
 ## Parameters
 
-| Name | Type | Required | Default |
-|------|------|----------|---------|
-| `greeting` | string | No | `"Hey there!"` |
+| Name       | Type   | Required | Default        |
+| ---------- | ------ | -------- | -------------- |
+| `greeting` | string | No       | `"Hey there!"` |
 
 All parameters have defaults — `--params '{}'` is valid.
 
 Example with custom values:
 
 ```json
-{"greeting": "Hey there!"}
+{ "greeting": "Hey there!" }
 ```
-```
+````
+
+````
 
 **Has required params:**
 ```markdown
@@ -55,7 +59,8 @@ Example:
 
 ```json
 {"repoPath": ".", "strictness": "normal"}
-```
+````
+
 ```
 
 Start command examples use realistic JSON when required params exist. Sub-skill params are documented in the sub-skills section.
@@ -73,19 +78,20 @@ Use Zod 4's `schema.toJSONSchema()` (already used at `skill-builder.ts:17`, `eng
 ## Steps
 
 - [ ] Create task doc (this file)
-- [ ] Add `extractParamInfo()`, `generateParamsSection()`, and `buildExampleParamsFlag()` to `skillmd-template.ts`
-- [ ] Integrate params section into `generateSkillMd()` body template
-- [ ] Pass params example into session/stateless instruction generators
-- [ ] Add sub-skill params to `generateSubskillSection()`
-- [ ] Add tests to `index.test.ts`
-- [ ] Typecheck + tests + prettier
-- [ ] Build example skill and verify SKILL.md output
+- [x] Add `extractParamInfo()`, `generateParamsSection()`, and `buildExampleParamsFlag()` to `skillmd-template.ts`
+- [x] Integrate params section into `generateSkillMd()` body template
+- [x] Pass params example into session/stateless instruction generators
+- [x] Add sub-skill params to `generateSubskillSection()`
+- [x] Add tests to `index.test.ts`
+- [x] Typecheck + tests + prettier
+- [x] Build example skill and verify SKILL.md output
 
 ## Notes
 
-_(Running log of decisions during implementation)_
+- Zod 4's `toJSONSchema()` puts fields with `.default()` in the `required` array but also adds a `default` property. The correct heuristic for "required from the caller's perspective" is: field is in `required` AND has no `default` value. Without this, all-defaults skills would show all fields as required.
 
 ## Files
 
 - `src/build/skillmd-template.ts` — all new logic
 - `src/build/index.test.ts` — new test cases
+```

--- a/tasks/2026-04-29_1112_surface-params-in-skillmd/TASK.md
+++ b/tasks/2026-04-29_1112_surface-params-in-skillmd/TASK.md
@@ -1,0 +1,91 @@
+# Surface skill params in generated SKILL.md
+
+## Scope
+
+**In:** Add a "## Parameters" section to the generated SKILL.md template that documents the skill's params schema — field names, types, required/optional, defaults. Update start command examples to show realistic param values. Document sub-skill params.
+
+**Out:** No CLI commands (like `--schema`), no runtime changes, no protocol changes.
+
+## Context
+
+Agents invoke skills via `--params '{}'` but the generated SKILL.md never documents what params a skill accepts. The Zod schema on `SkillDefinition.params` has all the info — names, types, defaults, optionality — it just needs to be rendered into SKILL.md at build time.
+
+This was surfaced by asking: "Do agents know what the params are that we expect them to pass in the first step?" The answer is no.
+
+## Plan
+
+### Design
+
+Add a `## Parameters` section to `generateSkillMd()` output:
+
+**No params:**
+```markdown
+## Parameters
+
+This skill takes no parameters. Pass `--params '{}'`.
+```
+
+**All optional (all have defaults):**
+```markdown
+## Parameters
+
+| Name | Type | Required | Default |
+|------|------|----------|---------|
+| `greeting` | string | No | `"Hey there!"` |
+
+All parameters have defaults — `--params '{}'` is valid.
+
+Example with custom values:
+
+```json
+{"greeting": "Hey there!"}
+```
+```
+
+**Has required params:**
+```markdown
+## Parameters
+
+| Name | Type | Required | Default |
+|------|------|----------|---------|
+| `repoPath` | string | **Yes** | — |
+| `strictness` | `"lenient"` \| `"normal"` \| `"strict"` | No | `"normal"` |
+
+Example:
+
+```json
+{"repoPath": ".", "strictness": "normal"}
+```
+```
+
+Start command examples use realistic JSON when required params exist. Sub-skill params are documented in the sub-skills section.
+
+### Approach: `toJSONSchema()`
+
+Use Zod 4's `schema.toJSONSchema()` (already used at `skill-builder.ts:17`, `engine.ts:285`) to extract field metadata from the params schema. Wrap in try-catch; fall back to no-params behavior on failure.
+
+### Rejected alternatives
+
+- **Dump raw JSON Schema in SKILL.md**: Too verbose, structural noise (`$schema`, `additionalProperties`). Agents parse structured markdown better.
+- **Add a `--schema` CLI command**: Overkill for this problem. The info belongs in the static documentation, not a runtime query.
+- **Zod introspection without `toJSONSchema()`**: Fragile, undocumented internals. `toJSONSchema()` is the public API.
+
+## Steps
+
+- [ ] Create task doc (this file)
+- [ ] Add `extractParamInfo()`, `generateParamsSection()`, and `buildExampleParamsFlag()` to `skillmd-template.ts`
+- [ ] Integrate params section into `generateSkillMd()` body template
+- [ ] Pass params example into session/stateless instruction generators
+- [ ] Add sub-skill params to `generateSubskillSection()`
+- [ ] Add tests to `index.test.ts`
+- [ ] Typecheck + tests + prettier
+- [ ] Build example skill and verify SKILL.md output
+
+## Notes
+
+_(Running log of decisions during implementation)_
+
+## Files
+
+- `src/build/skillmd-template.ts` — all new logic
+- `src/build/index.test.ts` — new test cases


### PR DESCRIPTION
## Summary

- Adds a **"## Parameters"** section to generated SKILL.md documenting each param's name, type, required/optional status, and default value
- Start command examples show realistic `--params` values when required fields exist; `'{}'` when all params have defaults
- Sub-skill params are documented inline in the sub-skills listing
- Graceful fallback when no params schema or `toJSONSchema()` fails

## Context

Agents invoking skills had no way to discover what params a skill expects — the generated SKILL.md always showed `--params '{}'` with no documentation of the schema. The Zod params schema already contained all the information; this PR surfaces it in the SKILL.md template at build time.

## Example output

For a skill with `params: z.object({ repoPath: z.string(), strictness: z.enum(['lenient','normal','strict']).default('normal') })`:

```markdown
## Parameters

| Name | Type | Required | Default |
|------|------|----------|---------|
| `repoPath` | string | **Yes** | — |
| `strictness` | `"lenient"` \| `"normal"` \| `"strict"` | No | `"normal"` |

Example:

```json
{"repoPath":"<repoPath>","strictness":"normal"}
```
```

## Test plan

- [x] New tests for params with defaults, required params, no params, enum types, sub-skill params (4 new test cases)
- [x] All 294 existing tests pass
- [x] Typecheck clean
- [x] Prettier clean
- [x] Built example skill and verified SKILL.md output

🤖 Generated with [Claude Code](https://claude.com/claude-code)