### PR TITLE
refactor: protocol layer structure & data ownership

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -954,7 +954,7 @@ The compiled skill binary is invoked by agents via Bash — one call per step. E
 ```
 
 ```json
-{ "step": "diagnose", "prompt": "Inspect the repository and report failed health checks.", "schema": {...} }
+{ "kind": "prompt", "step": "diagnose", "prompt": "Inspect the repository and report failed health checks.", "schema": {...} }
 ```
 
 **`advance`** — Submit a step's output and get the next prompt (or done signal).
@@ -968,20 +968,22 @@ The compiled skill binary is invoked by agents via Bash — one call per step. E
 ```
 
 ```json
-{ "step": "remediate", "prompt": "Fix these issues...", "schema": {...} }
+{ "kind": "prompt", "step": "remediate", "prompt": "Fix these issues...", "schema": {...} }
 ```
 
 **Terminal response:**
 
 ```json
-{ "done": true, "finalOutput": {...} }
+{ "kind": "done", "done": true, "finalOutput": {...} }
 ```
 
 **Validation error:**
 
 ```json
-{ "error": "validation", "step": "diagnose", "message": "Expected object, received string", "retry": true }
+{ "kind": "error", "error": "validation", "step": "diagnose", "message": "Expected object, received string", "retry": true }
 ```
+
+All CLI result types carry a `kind` field that serves as a discriminant for the `CliResult` union: `'prompt'`, `'done'`, `'error'`, or `'redirect'`. The SDK exports type guard helpers (`isPrompt`, `isDone`, `isError`, `isRedirect`) for narrowing.
 
 ### Flags
 

--- a/docs-site/src/pages/api/index.mdx
+++ b/docs-site/src/pages/api/index.mdx
@@ -353,6 +353,7 @@ When the engine's `next` resolves to a target not in the local step map, it retu
 
 ```typescript
 interface RedirectResult {
+  kind: 'redirect';
   redirect: string; // e.g. 'subskill:doctor'
   completed: StepResult; // the step that triggered the redirect
   stash: unknown; // dispatcher's accumulated stash

--- a/docs-site/src/pages/architecture/index.mdx
+++ b/docs-site/src/pages/architecture/index.mdx
@@ -59,6 +59,7 @@ Returns a `PromptResult`:
 
 ```json
 {
+  "kind": "prompt",
   "preamble": "In this session you will follow a structured workflow...",
   "step": "diagnose",
   "prompt": "Inspect the repository and report failed health checks.",
@@ -83,6 +84,7 @@ Returns another `PromptResult` (next step) or a `DoneResult`:
 
 ```json
 {
+  "kind": "done",
   "done": true,
   "finalOutput": { "summary": "..." },
   "completed": { "step": "report", "output": {} }
@@ -93,6 +95,7 @@ Returns another `PromptResult` (next step) or a `DoneResult`:
 
 ```json
 {
+  "kind": "error",
   "error": "validation",
   "step": "diagnose",
   "message": "Expected object, received string",
@@ -101,6 +104,8 @@ Returns another `PromptResult` (next step) or a `DoneResult`:
 ```
 
 The agent retries with corrected output. The `retry: true` flag tells the agent the step hasn't advanced.
+
+**Result type discrimination** — All result types carry a `kind` field (`'prompt'`, `'done'`, `'error'`, `'redirect'`) that serves as a discriminant for the `CliResult` union. The SDK exports type guard helpers: `isPrompt(r)`, `isDone(r)`, `isError(r)`, `isRedirect(r)`.
 
 ### CLI Flags
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -363,6 +363,7 @@ When the engine's `next` resolves to a target not in the local step map, it retu
 
 ```typescript
 interface RedirectResult {
+  kind: 'redirect';
   redirect: string; // e.g. 'subskill:doctor'
   completed: StepResult; // the step that triggered the redirect
   stash: unknown; // dispatcher's accumulated stash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,7 @@ Returns a `PromptResult`:
 
 ```json
 {
+  "kind": "prompt",
   "preamble": "In this session you will follow a structured workflow...",
   "step": "diagnose",
   "prompt": "Inspect the repository and report failed health checks.",
@@ -81,16 +82,24 @@ scripts/run advance \
 Returns another `PromptResult` (next step) or a `DoneResult`:
 
 ```json
-{ "done": true, "finalOutput": { "summary": "..." }, "completed": { "step": "report", "output": { ... } } }
+{ "kind": "done", "done": true, "finalOutput": { "summary": "..." }, "completed": { "step": "report", "output": { ... } } }
 ```
 
 **3. Validation error** — If the agent's output doesn't match the step schema:
 
 ```json
-{ "error": "validation", "step": "diagnose", "message": "Expected object, received string", "retry": true }
+{
+  "kind": "error",
+  "error": "validation",
+  "step": "diagnose",
+  "message": "Expected object, received string",
+  "retry": true
+}
 ```
 
 The agent retries with corrected output. The `retry: true` flag tells the agent the step hasn't advanced.
+
+**Result type discrimination** — All result types carry a `kind` field (`'prompt'`, `'done'`, `'error'`, `'redirect'`) that serves as a discriminant for the `CliResult` union. The SDK exports type guard helpers: `isPrompt(r)`, `isDone(r)`, `isError(r)`, `isRedirect(r)`.
 
 ### CLI Flags
 

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -83,10 +83,14 @@ reported tools are a genuine subset — the skill will not merge them with the h
 Without `--subagent`, the skill assumes you are a top-level agent and merges your tools
 with the registry (since top-level agents often under-report their tools).
 
+## Parameters
+
+This skill takes no parameters. Pass `--params '{}'`.
+
 ### Step 1: Start with a session
 
 ```bash
-<skill>/scripts/run --context '{}' --host claude-code --tools <your-tools> --session new 2>/dev/null
+<skill>/scripts/run --params '{}' --host claude-code --tools <your-tools> --session new 2>/dev/null
 ```
 
 This returns a JSON pointer with `sessionId`, `file`, and `line`. The `line` field tells you
@@ -146,13 +150,13 @@ Sub-skill step names are prefixed: `<subskill>/<step>` (e.g., `doctor/diagnose`)
 ### Direct sub-skill access
 
 ```bash
-<skill>/scripts/run <subskill> --context '{}' --session new
+<skill>/scripts/run <subskill> --params '<json>' --session new
 <skill>/scripts/run <subskill> advance --session <id>
 ```
 
 ### Available sub-skills
 
-- **doctor**: Diagnose and fix common Contentful issues.
+- **doctor**: Diagnose and fix common Contentful issues. — params: `spaceId` (string)
 - **setup**: Guided Contentful space setup and configuration.
 
 ## Reference topics

--- a/examples/game-jam/skill/SKILL.md
+++ b/examples/game-jam/skill/SKILL.md
@@ -83,10 +83,24 @@ reported tools are a genuine subset — the skill will not merge them with the h
 Without `--subagent`, the skill assumes you are a top-level agent and merges your tools
 with the registry (since top-level agents often under-report their tools).
 
+## Parameters
+
+| Name         | Type                                             | Required | Default          |
+| ------------ | ------------------------------------------------ | -------- | ---------------- |
+| `difficulty` | `"beginner"` \| `"intermediate"` \| `"advanced"` | No       | `"intermediate"` |
+
+All parameters have defaults — `--params '{}'` is valid.
+
+Example:
+
+```json
+{ "difficulty": "intermediate" }
+```
+
 ### Step 1: Start with a session
 
 ```bash
-<skill>/scripts/run --context '{}' --host claude-code --tools <your-tools> --session new 2>/dev/null
+<skill>/scripts/run --params '{}' --host claude-code --tools <your-tools> --session new 2>/dev/null
 ```
 
 This returns a JSON pointer with `sessionId`, `file`, and `line`. The `line` field tells you

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -83,10 +83,24 @@ reported tools are a genuine subset — the skill will not merge them with the h
 Without `--subagent`, the skill assumes you are a top-level agent and merges your tools
 with the registry (since top-level agents often under-report their tools).
 
+## Parameters
+
+| Name       | Type   | Required | Default        |
+| ---------- | ------ | -------- | -------------- |
+| `greeting` | string | No       | `"Hey there!"` |
+
+All parameters have defaults — `--params '{}'` is valid.
+
+Example:
+
+```json
+{ "greeting": "Hey there!" }
+```
+
 ### Step 1: Start with a session
 
 ```bash
-<skill>/scripts/run --context '{}' --host claude-code --tools <your-tools> --session new 2>/dev/null
+<skill>/scripts/run --params '{}' --host claude-code --tools <your-tools> --session new 2>/dev/null
 ```
 
 This returns a JSON pointer with `sessionId`, `file`, and `line`. The `line` field tells you

--- a/examples/primitives-showcase/skill/SKILL.md
+++ b/examples/primitives-showcase/skill/SKILL.md
@@ -83,10 +83,14 @@ reported tools are a genuine subset — the skill will not merge them with the h
 Without `--subagent`, the skill assumes you are a top-level agent and merges your tools
 with the registry (since top-level agents often under-report their tools).
 
+## Parameters
+
+This skill takes no parameters. Pass `--params '{}'`.
+
 ### Step 1: Start with a session
 
 ```bash
-<skill>/scripts/run --context '{}' --host claude-code --tools <your-tools> --session new 2>/dev/null
+<skill>/scripts/run --params '{}' --host claude-code --tools <your-tools> --session new 2>/dev/null
 ```
 
 This returns a JSON pointer with `sessionId`, `file`, and `line`. The `line` field tells you

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export { SkillBuilder } from './skill-builder.js';
 export { ReferenceBuilder } from './reference-builder.js';
 export { ModuleBuilder } from './module.js';
 export { checkSkill } from './lint/index.js';
+export { isPrompt, isDone, isError, isRedirect } from './types.js';
 export type { LintDiagnostic } from './lint/types.js';
 export type {
   SkillBuilderConfig,

--- a/src/protocol/arg-parser.ts
+++ b/src/protocol/arg-parser.ts
@@ -1,0 +1,82 @@
+export type CompositeCommand =
+  | { mode: 'dispatcher'; command: 'start' | 'advance'; flags: Record<string, string> }
+  | { mode: 'subskill'; name: string; command: 'start' | 'advance'; flags: Record<string, string> }
+  | { mode: 'topics' }
+  | { mode: 'topic'; name: string }
+  | { mode: 'help' };
+
+export function parseCompositeArgs(argv: string[], subskillNames: string[]): CompositeCommand {
+  const args = argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    return { mode: 'help' };
+  }
+
+  const first = args[0]!;
+
+  if (first === 'topics') return { mode: 'topics' };
+  if (first === 'topic') {
+    const name = args[1];
+    if (!name) {
+      process.stderr.write('error: topic name required. Run with "topics" to list.\n');
+      process.exit(1);
+    }
+    return { mode: 'topic', name };
+  }
+
+  if (subskillNames.includes(first)) {
+    return parseSubskillArgs(first, args.slice(1));
+  }
+
+  return parseDispatcherArgs(args);
+}
+
+function parseDispatcherArgs(args: string[]): CompositeCommand {
+  const first = args[0]!;
+  let command: 'start' | 'advance';
+  let flagStart: number;
+
+  if (first === 'start' || first === 'advance') {
+    command = first;
+    flagStart = 1;
+  } else if (first.startsWith('--')) {
+    command = 'start';
+    flagStart = 0;
+  } else {
+    return { mode: 'help' };
+  }
+
+  return { mode: 'dispatcher', command, flags: parseFlags(args, flagStart) };
+}
+
+function parseSubskillArgs(name: string, args: string[]): CompositeCommand {
+  if (args.length === 0 || args[0]!.startsWith('--')) {
+    return { mode: 'subskill', name, command: 'start', flags: parseFlags(args, 0) };
+  }
+
+  const first = args[0]!;
+  if (first === 'start' || first === 'advance') {
+    return { mode: 'subskill', name, command: first, flags: parseFlags(args, 1) };
+  }
+
+  return { mode: 'help' };
+}
+
+const BOOLEAN_FLAGS = new Set(['subagent']);
+
+export function parseFlags(args: string[], start: number): Record<string, string> {
+  const flags: Record<string, string> = {};
+  for (let i = start; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg.startsWith('--')) {
+      const name = arg.slice(2);
+      if (BOOLEAN_FLAGS.has(name)) {
+        flags[name] = 'true';
+      } else if (i + 1 < args.length) {
+        flags[name] = args[i + 1]!;
+        i++;
+      }
+    }
+  }
+  return flags;
+}

--- a/src/protocol/auto-advance.ts
+++ b/src/protocol/auto-advance.ts
@@ -1,4 +1,4 @@
-import type { CliResult, PromptResult, DoneResult, StepResult } from '../types.js';
+import type { CliResult, StepResult } from '../types.js';
 
 const MAX_AUTO_ADVANCE = 20;
 
@@ -16,27 +16,28 @@ export async function autoAdvance(
   let depth = 0;
   const collected: StepResult[] = [];
 
-  while ('step' in current && !('error' in current) && !('done' in current) && !('redirect' in current)) {
-    const prompt = current as PromptResult;
-    if (!engine.isPromptless(prompt.step)) break;
+  while (current.kind === 'prompt') {
+    if (!engine.isPromptless(current.step)) break;
     depth += 1;
     if (depth > MAX_AUTO_ADVANCE) {
       throw new Error(`Auto-advance depth exceeded (${MAX_AUTO_ADVANCE}). Check for infinite prompt-less step loops.`);
     }
     onIntermediateResult?.(current);
-    current = await engine.advance(prompt.step, {});
-    if ('completed' in current && current.completed) {
-      collected.push(current.completed as StepResult);
+    current = await engine.advance(current.step, {});
+    if (current.kind === 'prompt' || current.kind === 'done') {
+      if (current.completed) {
+        collected.push(current.completed);
+      }
     }
   }
 
   if (collected.length === 0) return current;
 
-  if ('step' in current && !('error' in current) && !('done' in current) && !('redirect' in current)) {
-    return { ...(current as PromptResult), autoAdvanced: collected };
+  if (current.kind === 'prompt') {
+    return { ...current, autoAdvanced: collected };
   }
-  if ('done' in current) {
-    return { ...(current as DoneResult), autoAdvanced: collected };
+  if (current.kind === 'done') {
+    return { ...current, autoAdvanced: collected };
   }
   return current;
 }

--- a/src/protocol/auto-advance.ts
+++ b/src/protocol/auto-advance.ts
@@ -1,14 +1,10 @@
 import type { CliResult, StepResult } from '../types.js';
+import type { SkillEngine } from './skill-engine.js';
 
 const MAX_AUTO_ADVANCE = 20;
 
-export interface Advanceable {
-  isPromptless(stepName: string): boolean;
-  advance(stepName: string, output: unknown): Promise<CliResult>;
-}
-
 export async function autoAdvance(
-  engine: Advanceable,
+  engine: SkillEngine,
   result: CliResult,
   onIntermediateResult?: (result: CliResult) => void,
 ): Promise<CliResult> {

--- a/src/protocol/cli-entry.ts
+++ b/src/protocol/cli-entry.ts
@@ -2,19 +2,12 @@ import type { SkillDefinition } from '../types.js';
 import type { SessionOutputMode } from '../types.js';
 import { parseArgs, handleStart, handleAdvance, printHelp } from './single-invocation.js';
 import { SessionManager } from './session.js';
+import { resolveStartContext, resolveAdvanceContext, parseTools, parseJsonFlag } from './invocation-context.js';
 
-function parseToolsFlag(raw?: string): string[] | undefined {
-  if (!raw) return undefined;
-  return raw
-    .split(',')
-    .map((t) => t.trim())
-    .filter(Boolean);
-}
+const NOOP_REFS = { load: () => '', asset: (p: string) => p };
 
 export async function main(skill: SkillDefinition): Promise<void> {
   const { command, flags, booleans } = parseArgs(process.argv);
-  const tools = parseToolsFlag(flags['tools']);
-  const isSubagent = booleans.has('subagent');
 
   try {
     switch (command) {
@@ -23,94 +16,37 @@ export async function main(skill: SkillDefinition): Promise<void> {
         break;
 
       case 'start': {
-        const params = flags['params'] ? (JSON.parse(flags['params']) as unknown) : {};
         const sessionFlag = flags['session'];
+        let session;
 
         if (sessionFlag === 'new') {
           const outputMode = (flags['output-mode'] as SessionOutputMode) ?? 'file';
-          const session = SessionManager.create({
+          session = SessionManager.create({
             sessionDir: flags['session-dir'],
             skill: skill.name,
             host: flags['host'] ?? 'generic',
-            tools,
-            isSubagent: isSubagent || undefined,
-            params,
+            tools: parseTools(flags),
+            isSubagent: booleans.has('subagent') || undefined,
+            params: parseJsonFlag(flags['params'], {}),
             outputMode,
           });
-          await handleStart(skill, params, flags['host'], session, tools, isSubagent);
-        } else {
-          await handleStart(skill, params, flags['host'], undefined, tools, isSubagent);
         }
+
+        const ctx = resolveStartContext(flags, session, NOOP_REFS);
+        await handleStart(skill, ctx);
         break;
       }
 
       case 'advance': {
         const sessionFlag = flags['session'];
+        let session;
 
         if (sessionFlag && sessionFlag !== 'new') {
-          const session = SessionManager.open(sessionFlag, flags['session-dir']);
-          let stepName: string;
-          let output: unknown;
-          let history: Array<{ step: string; stepOutput: unknown; actionOutput?: unknown }>;
-
-          history = session.reconstructHistory();
-
-          if (session.header.outputMode === 'file' && !flags['output']) {
-            const lastOutput = session.readLastOutput();
-            if (!lastOutput) {
-              process.stderr.write(
-                'error: no output found in session file. Write your output to the session file before advancing.\n',
-              );
-              process.exit(1);
-            }
-            stepName = lastOutput.step;
-            output = lastOutput.output;
-          } else {
-            stepName = flags['step']!;
-            output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
-
-            if (!stepName) {
-              process.stderr.write('error: --step is required for advance in flag mode\n');
-              process.exit(1);
-            }
-            if (output === undefined) {
-              process.stderr.write('error: --output is required for advance in flag mode\n');
-              process.exit(1);
-            }
-
-            session.append({ type: 'output', step: stepName, output });
-          }
-
-          await handleAdvance(
-            skill,
-            stepName,
-            output,
-            history,
-            session.header.params,
-            session.header.host,
-            session,
-            session.header.tools,
-            session.header.isSubagent,
-          );
-        } else {
-          const step = flags['step'];
-          const output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
-          const history = flags['history']
-            ? (JSON.parse(flags['history']) as Array<{ step: string; stepOutput: unknown; actionOutput?: unknown }>)
-            : [];
-          const params = flags['params'] ? (JSON.parse(flags['params']) as unknown) : {};
-
-          if (!step) {
-            process.stderr.write('error: --step is required for advance\n');
-            process.exit(1);
-          }
-          if (output === undefined) {
-            process.stderr.write('error: --output is required for advance\n');
-            process.exit(1);
-          }
-
-          await handleAdvance(skill, step, output, history, params, flags['host'], undefined, tools, isSubagent);
+          session = SessionManager.open(sessionFlag, flags['session-dir']);
         }
+
+        const ctx = resolveAdvanceContext(flags, session, NOOP_REFS);
+        await handleAdvance(skill, ctx);
         break;
       }
     }

--- a/src/protocol/composite-entry.ts
+++ b/src/protocol/composite-entry.ts
@@ -1,22 +1,13 @@
 import { dirname, resolve } from 'node:path';
-import type { SkillDefinition, RedirectResult, CliResult, ReferenceLoader, SessionOutputMode } from '../types.js';
+import type { SkillDefinition, RedirectResult, Handshake, ReferenceLoader, SessionOutputMode } from '../types.js';
 import { WorkflowEngine } from '../runtime/engine.js';
 import { createReferenceLoader } from '../runtime/reference-loader.js';
 import { SessionManager, type SessionFile } from './session.js';
 import { SubskillEngine } from './subskill-engine.js';
 import { autoAdvance } from './auto-advance.js';
 import type { HistoryEntry } from './types.js';
-import {
-  resolveStartContext,
-  resolveAdvanceContext,
-  resolveHandshake,
-  parseTools,
-  parseJsonFlag,
-} from './invocation-context.js';
-
-function sessionWriter(session: SessionFile | undefined): ((r: CliResult) => void) | undefined {
-  return session ? (r) => session.appendResult(r) : undefined;
-}
+import { resolveStartContext, resolveAdvanceContext, parseTools, parseJsonFlag } from './invocation-context.js';
+import { createOutputWriter, type OutputWriter } from './output-writer.js';
 
 function resolveSkillDir(): string {
   const binPath = process.execPath;
@@ -115,24 +106,6 @@ function extractDispatcherHistory(history: HistoryEntry[]): HistoryEntry[] {
   return history.filter((e) => !e.step.includes('/'));
 }
 
-function writeOutput(data: CliResult, session: SessionFile | undefined): void {
-  if (session) {
-    const line = session.appendResult(data);
-    session.writePointer(line);
-  } else {
-    process.stdout.write(JSON.stringify(data) + '\n');
-  }
-}
-
-function writeStartOutput(data: CliResult, session: SessionFile | undefined): void {
-  if (session) {
-    const line = session.appendResult(data);
-    session.writeStartPointer(line);
-  } else {
-    process.stdout.write(JSON.stringify(data) + '\n');
-  }
-}
-
 interface SessionContext {
   session: SessionFile | undefined;
   isStart: boolean;
@@ -228,13 +201,14 @@ async function handleDispatcher(
   refs: ReferenceLoader,
 ): Promise<void> {
   const { session, isStart } = resolveSessionForCommand(parsed.flags, parsed.command, def.name);
+  const writer = createOutputWriter(session);
 
   if (isStart) {
     const ctx = resolveStartContext(parsed.flags, session, refs);
     const engine = new WorkflowEngine(def, ctx.handshake, ctx.params, refs);
     const startResult = engine.start();
-    const result = await autoAdvance(engine, startResult, sessionWriter(session));
-    writeStartOutput(result, session);
+    const result = await autoAdvance(engine, startResult, writer.writeIntermediate);
+    writer.writeStart(result);
     return;
   }
 
@@ -248,8 +222,8 @@ async function handleDispatcher(
     subEngine.replayHistory(ctx.history);
     subEngine.startForReplay();
     const subResult = await subEngine.advance(ctx.stepName, ctx.output);
-    const result = await autoAdvance(subEngine, subResult, sessionWriter(session));
-    writeOutput(result, session);
+    const result = await autoAdvance(subEngine, subResult, writer.writeIntermediate);
+    writer.writeAdvance(result);
     return;
   }
 
@@ -261,14 +235,14 @@ async function handleDispatcher(
   engine.start();
 
   const advanceResult = await engine.advance(ctx.stepName, ctx.output);
-  const result = await autoAdvance(engine, advanceResult, sessionWriter(session));
+  const result = await autoAdvance(engine, advanceResult, writer.writeIntermediate);
 
   if (result.kind === 'redirect') {
-    await handleRedirect(def, result, ctx.handshake, refs, session);
+    await handleRedirect(def, result, ctx.handshake, refs, writer);
     return;
   }
 
-  writeOutput(result, session);
+  writer.writeAdvance(result);
 }
 
 async function handleSubskill(
@@ -283,13 +257,14 @@ async function handleSubskill(
   }
 
   const { session, isStart } = resolveSessionForCommand(parsed.flags, parsed.command, def.name);
+  const writer = createOutputWriter(session);
 
   if (isStart) {
     const ctx = resolveStartContext(parsed.flags, session, refs);
     const subEngine = new SubskillEngine(sub.definition, ctx.handshake, ctx.params, refs, parsed.name);
     const startResult = subEngine.start();
-    const result = await autoAdvance(subEngine, startResult, sessionWriter(session));
-    writeStartOutput(result, session);
+    const result = await autoAdvance(subEngine, startResult, writer.writeIntermediate);
+    writer.writeStart(result);
     return;
   }
 
@@ -298,16 +273,16 @@ async function handleSubskill(
   subEngine.replayHistory(ctx.history);
   subEngine.startForReplay();
   const advanceResult = await subEngine.advance(ctx.stepName, ctx.output);
-  const result = await autoAdvance(subEngine, advanceResult, sessionWriter(session));
-  writeOutput(result, session);
+  const result = await autoAdvance(subEngine, advanceResult, writer.writeIntermediate);
+  writer.writeAdvance(result);
 }
 
 async function handleRedirect(
   def: SkillDefinition,
   redirect: RedirectResult,
-  handshake: ReturnType<typeof resolveHandshake>,
+  handshake: Handshake,
   refs: ReferenceLoader,
-  session: SessionFile | undefined,
+  writer: OutputWriter,
 ): Promise<void> {
   const target = redirect.redirect;
 
@@ -318,10 +293,12 @@ async function handleRedirect(
       throw new Error(`Redirect to unknown topic "${topicName}"`);
     }
     const content = topic.content({ refs });
-    writeOutput(
-      { kind: 'done', done: true, finalOutput: { topic: topicName, content }, completed: redirect.completed },
-      session,
-    );
+    writer.writeAdvance({
+      kind: 'done',
+      done: true,
+      finalOutput: { topic: topicName, content },
+      completed: redirect.completed,
+    });
     return;
   }
 
@@ -335,11 +312,11 @@ async function handleRedirect(
     const params = sub.paramsMap ? sub.paramsMap(redirect.completed.stepOutput, redirect.stash) : {};
     const subEngine = new SubskillEngine(sub.definition, handshake, params, refs, subName);
     const rawStart = subEngine.start();
-    const startResult = await autoAdvance(subEngine, rawStart, sessionWriter(session));
+    const startResult = await autoAdvance(subEngine, rawStart, writer.writeIntermediate);
     if (startResult.kind === 'prompt' || startResult.kind === 'done') {
-      writeOutput({ ...startResult, completed: redirect.completed }, session);
+      writer.writeAdvance({ ...startResult, completed: redirect.completed });
     } else {
-      writeOutput(startResult, session);
+      writer.writeAdvance(startResult);
     }
     return;
   }

--- a/src/protocol/composite-entry.ts
+++ b/src/protocol/composite-entry.ts
@@ -2,11 +2,17 @@ import { dirname, resolve } from 'node:path';
 import type { SkillDefinition, RedirectResult, CliResult, ReferenceLoader, SessionOutputMode } from '../types.js';
 import { WorkflowEngine } from '../runtime/engine.js';
 import { createReferenceLoader } from '../runtime/reference-loader.js';
-import { resolveHost } from './host.js';
 import { SessionManager, type SessionFile } from './session.js';
 import { SubskillEngine } from './subskill-engine.js';
 import { autoAdvance } from './auto-advance.js';
 import type { HistoryEntry } from './types.js';
+import {
+  resolveStartContext,
+  resolveAdvanceContext,
+  resolveHandshake,
+  parseTools,
+  parseJsonFlag,
+} from './invocation-context.js';
 
 function sessionWriter(session: SessionFile | undefined): ((r: CliResult) => void) | undefined {
   return session ? (r) => session.appendResult(r) : undefined;
@@ -109,18 +115,18 @@ function extractDispatcherHistory(history: HistoryEntry[]): HistoryEntry[] {
   return history.filter((e) => !e.step.includes('/'));
 }
 
-function writeOutput(data: unknown, session: SessionFile | undefined): void {
+function writeOutput(data: CliResult, session: SessionFile | undefined): void {
   if (session) {
-    const line = session.appendResult(data as CliResult);
+    const line = session.appendResult(data);
     session.writePointer(line);
   } else {
     process.stdout.write(JSON.stringify(data) + '\n');
   }
 }
 
-function writeStartOutput(data: unknown, session: SessionFile | undefined): void {
+function writeStartOutput(data: CliResult, session: SessionFile | undefined): void {
   if (session) {
-    const line = session.appendResult(data as CliResult);
+    const line = session.appendResult(data);
     session.writeStartPointer(line);
   } else {
     process.stdout.write(JSON.stringify(data) + '\n');
@@ -130,6 +136,35 @@ function writeStartOutput(data: unknown, session: SessionFile | undefined): void
 interface SessionContext {
   session: SessionFile | undefined;
   isStart: boolean;
+}
+
+function resolveSessionForCommand(
+  flags: Record<string, string>,
+  command: 'start' | 'advance',
+  skillName: string,
+): SessionContext {
+  const sessionFlag = flags['session'];
+
+  if (command === 'start' && sessionFlag === 'new') {
+    const outputMode = (flags['output-mode'] as SessionOutputMode) ?? 'file';
+    const session = SessionManager.create({
+      sessionDir: flags['session-dir'],
+      skill: skillName,
+      host: flags['host'] ?? 'generic',
+      tools: parseTools(flags),
+      isSubagent: flags['subagent'] === 'true' || undefined,
+      params: parseJsonFlag(flags['params'], {}),
+      outputMode,
+    });
+    return { session, isStart: true };
+  }
+
+  if (command === 'advance' && sessionFlag && sessionFlag !== 'new') {
+    const session = SessionManager.open(sessionFlag, flags['session-dir']);
+    return { session, isStart: false };
+  }
+
+  return { session: undefined, isStart: command === 'start' };
 }
 
 export async function compositeMain(def: SkillDefinition, refsBasePath?: string): Promise<void> {
@@ -187,147 +222,49 @@ function handleTopic(def: SkillDefinition, topicName: string, refs: ReferenceLoa
   if (!content.endsWith('\n')) process.stdout.write('\n');
 }
 
-function resolveSessionForCommand(
-  flags: Record<string, string>,
-  command: 'start' | 'advance',
-  skillName: string,
-): SessionContext {
-  const sessionFlag = flags['session'];
-
-  if (command === 'start' && sessionFlag === 'new') {
-    const outputMode = (flags['output-mode'] as SessionOutputMode) ?? 'file';
-    const toolsRaw = flags['tools'];
-    const sessionTools = toolsRaw
-      ? toolsRaw
-          .split(',')
-          .map((t) => t.trim())
-          .filter(Boolean)
-      : undefined;
-    const isSubagent = flags['subagent'] === 'true' || undefined;
-    const session = SessionManager.create({
-      sessionDir: flags['session-dir'],
-      skill: skillName,
-      host: flags['host'] ?? 'generic',
-      tools: sessionTools,
-      isSubagent,
-      params: flags['params'] ? (JSON.parse(flags['params']) as unknown) : {},
-      outputMode,
-    });
-    return { session, isStart: true };
-  }
-
-  if (command === 'advance' && sessionFlag && sessionFlag !== 'new') {
-    const session = SessionManager.open(sessionFlag, flags['session-dir']);
-    return { session, isStart: false };
-  }
-
-  return { session: undefined, isStart: command === 'start' };
-}
-
-function resolveAdvanceInput(
-  flags: Record<string, string>,
-  session: SessionFile | undefined,
-): { stepName: string; output: unknown; history: HistoryEntry[] } {
-  if (session) {
-    const history = session.reconstructHistory();
-
-    if (session.header.outputMode === 'file' && !flags['output']) {
-      const lastOutput = session.readLastOutput();
-      if (!lastOutput) {
-        process.stderr.write(
-          'error: no output found in session file. Write your output to the session file before advancing.\n',
-        );
-        process.exit(1);
-      }
-      return { stepName: lastOutput.step, output: lastOutput.output, history };
-    }
-
-    const stepName = flags['step']!;
-    const output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
-    if (!stepName || output === undefined) {
-      process.stderr.write('error: --step and --output are required for advance in flag mode\n');
-      process.exit(1);
-    }
-    session.append({ type: 'output', step: stepName, output });
-    return { stepName, output, history };
-  }
-
-  const stepName = flags['step']!;
-  const output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
-  const history: HistoryEntry[] = flags['history'] ? (JSON.parse(flags['history']) as HistoryEntry[]) : [];
-
-  if (!stepName) {
-    process.stderr.write('error: --step is required for advance\n');
-    process.exit(1);
-  }
-  if (output === undefined) {
-    process.stderr.write('error: --output is required for advance\n');
-    process.exit(1);
-  }
-
-  return { stepName, output, history };
-}
-
-function parseTools(flags: Record<string, string>): string[] | undefined {
-  const raw = flags['tools'];
-  return raw
-    ? raw
-        .split(',')
-        .map((t) => t.trim())
-        .filter(Boolean)
-    : undefined;
-}
-
 async function handleDispatcher(
   def: SkillDefinition,
   parsed: { command: 'start' | 'advance'; flags: Record<string, string> },
   refs: ReferenceLoader,
 ): Promise<void> {
   const { session, isStart } = resolveSessionForCommand(parsed.flags, parsed.command, def.name);
-  const tools = session?.header.tools ?? parseTools(parsed.flags);
-  const isSubagent = session?.header.isSubagent ?? parsed.flags['subagent'] === 'true';
-  const handshake = resolveHost(session?.header.host ?? parsed.flags['host'], tools, isSubagent);
 
   if (isStart) {
-    const params = parsed.flags['params'] ? (JSON.parse(parsed.flags['params']) as unknown) : {};
-    const engine = new WorkflowEngine(def, handshake, params, refs);
+    const ctx = resolveStartContext(parsed.flags, session, refs);
+    const engine = new WorkflowEngine(def, ctx.handshake, ctx.params, refs);
     const startResult = engine.start();
     const result = await autoAdvance(engine, startResult, sessionWriter(session));
     writeStartOutput(result, session);
     return;
   }
 
-  const { stepName, output, history } = resolveAdvanceInput(parsed.flags, session);
-  const params =
-    session?.header.params ?? (parsed.flags['params'] ? (JSON.parse(parsed.flags['params']) as unknown) : {});
+  const ctx = resolveAdvanceContext(parsed.flags, session, refs);
 
-  const subskillName = detectSubskill(stepName);
+  const subskillName = detectSubskill(ctx.stepName);
   if (subskillName) {
     const sub = def.subskills?.[subskillName];
     if (!sub) throw new Error(`Unknown sub-skill "${subskillName}"`);
-    // Subskill params are derived from stash during redirect, not from CLI flags.
-    // The subskill engine rebuilds stash from history — pass {} here.
-    const subEngine = new SubskillEngine(sub.definition, handshake, {}, refs, subskillName);
-    subEngine.replayHistory(history as HistoryEntry[]);
+    const subEngine = new SubskillEngine(sub.definition, ctx.handshake, {}, refs, subskillName);
+    subEngine.replayHistory(ctx.history);
     subEngine.startForReplay();
-    const subResult = await subEngine.advance(stepName, output);
+    const subResult = await subEngine.advance(ctx.stepName, ctx.output);
     const result = await autoAdvance(subEngine, subResult, sessionWriter(session));
     writeOutput(result, session);
     return;
   }
 
-  const engine = new WorkflowEngine(def, handshake, params, refs);
-  const dispatcherHistory = extractDispatcherHistory(history as HistoryEntry[]);
+  const engine = new WorkflowEngine(def, ctx.handshake, ctx.params, refs);
+  const dispatcherHistory = extractDispatcherHistory(ctx.history);
   if (dispatcherHistory.length > 0) {
     engine.replayHistory(dispatcherHistory);
   }
   engine.start();
 
-  const advanceResult = await engine.advance(stepName, output);
+  const advanceResult = await engine.advance(ctx.stepName, ctx.output);
   const result = await autoAdvance(engine, advanceResult, sessionWriter(session));
 
   if (result.kind === 'redirect') {
-    await handleRedirect(def, result, handshake, refs, session);
+    await handleRedirect(def, result, ctx.handshake, refs, session);
     return;
   }
 
@@ -346,26 +283,21 @@ async function handleSubskill(
   }
 
   const { session, isStart } = resolveSessionForCommand(parsed.flags, parsed.command, def.name);
-  const subTools = session?.header.tools ?? parseTools(parsed.flags);
-  const subIsSubagent = session?.header.isSubagent ?? parsed.flags['subagent'] === 'true';
-  const handshake = resolveHost(session?.header.host ?? parsed.flags['host'], subTools, subIsSubagent);
 
   if (isStart) {
-    const params = parsed.flags['params'] ? (JSON.parse(parsed.flags['params']) as unknown) : {};
-    const subEngine = new SubskillEngine(sub.definition, handshake, params, refs, parsed.name);
+    const ctx = resolveStartContext(parsed.flags, session, refs);
+    const subEngine = new SubskillEngine(sub.definition, ctx.handshake, ctx.params, refs, parsed.name);
     const startResult = subEngine.start();
     const result = await autoAdvance(subEngine, startResult, sessionWriter(session));
     writeStartOutput(result, session);
     return;
   }
 
-  const { stepName, output, history } = resolveAdvanceInput(parsed.flags, session);
-  const subParams =
-    session?.header.params ?? (parsed.flags['params'] ? (JSON.parse(parsed.flags['params']) as unknown) : {});
-  const subEngine = new SubskillEngine(sub.definition, handshake, subParams, refs, parsed.name);
-  subEngine.replayHistory(history as HistoryEntry[]);
+  const ctx = resolveAdvanceContext(parsed.flags, session, refs);
+  const subEngine = new SubskillEngine(sub.definition, ctx.handshake, ctx.params, refs, parsed.name);
+  subEngine.replayHistory(ctx.history);
   subEngine.startForReplay();
-  const advanceResult = await subEngine.advance(stepName, output);
+  const advanceResult = await subEngine.advance(ctx.stepName, ctx.output);
   const result = await autoAdvance(subEngine, advanceResult, sessionWriter(session));
   writeOutput(result, session);
 }
@@ -373,7 +305,7 @@ async function handleSubskill(
 async function handleRedirect(
   def: SkillDefinition,
   redirect: RedirectResult,
-  handshake: ReturnType<typeof resolveHost>,
+  handshake: ReturnType<typeof resolveHandshake>,
   refs: ReferenceLoader,
   session: SessionFile | undefined,
 ): Promise<void> {
@@ -404,7 +336,11 @@ async function handleRedirect(
     const subEngine = new SubskillEngine(sub.definition, handshake, params, refs, subName);
     const rawStart = subEngine.start();
     const startResult = await autoAdvance(subEngine, rawStart, sessionWriter(session));
-    writeOutput({ ...startResult, completed: redirect.completed }, session);
+    if (startResult.kind === 'prompt' || startResult.kind === 'done') {
+      writeOutput({ ...startResult, completed: redirect.completed }, session);
+    } else {
+      writeOutput(startResult, session);
+    }
     return;
   }
 

--- a/src/protocol/composite-entry.ts
+++ b/src/protocol/composite-entry.ts
@@ -6,6 +6,7 @@ import { resolveHost } from './host.js';
 import { SessionManager, type SessionFile } from './session.js';
 import { SubskillEngine } from './subskill-engine.js';
 import { autoAdvance } from './auto-advance.js';
+import type { HistoryEntry } from './types.js';
 
 function sessionWriter(session: SessionFile | undefined): ((r: CliResult) => void) | undefined {
   return session ? (r) => session.appendResult(r) : undefined;
@@ -15,8 +16,6 @@ function resolveSkillDir(): string {
   const binPath = process.execPath;
   return resolve(dirname(binPath), '..');
 }
-
-type HistoryEntry = { step: string; stepOutput: unknown; actionOutput?: unknown };
 
 export type CompositeCommand =
   | { mode: 'dispatcher'; command: 'start' | 'advance'; flags: Record<string, string> }

--- a/src/protocol/composite-entry.ts
+++ b/src/protocol/composite-entry.ts
@@ -327,8 +327,8 @@ async function handleDispatcher(
   const advanceResult = await engine.advance(stepName, output);
   const result = await autoAdvance(engine, advanceResult, sessionWriter(session));
 
-  if ('redirect' in result) {
-    await handleRedirect(def, result as RedirectResult, handshake, refs, session);
+  if (result.kind === 'redirect') {
+    await handleRedirect(def, result, handshake, refs, session);
     return;
   }
 
@@ -387,7 +387,10 @@ async function handleRedirect(
       throw new Error(`Redirect to unknown topic "${topicName}"`);
     }
     const content = topic.content({ refs });
-    writeOutput({ done: true, finalOutput: { topic: topicName, content }, completed: redirect.completed }, session);
+    writeOutput(
+      { kind: 'done', done: true, finalOutput: { topic: topicName, content }, completed: redirect.completed },
+      session,
+    );
     return;
   }
 

--- a/src/protocol/composite-entry.ts
+++ b/src/protocol/composite-entry.ts
@@ -1,126 +1,26 @@
 import { dirname, resolve } from 'node:path';
-import type { SkillDefinition, RedirectResult, Handshake, ReferenceLoader, SessionOutputMode } from '../types.js';
-import { WorkflowEngine } from '../runtime/engine.js';
+import type { SkillDefinition, SessionOutputMode } from '../types.js';
 import { createReferenceLoader } from '../runtime/reference-loader.js';
-import { SessionManager, type SessionFile } from './session.js';
-import { SubskillEngine } from './subskill-engine.js';
-import { autoAdvance } from './auto-advance.js';
-import type { HistoryEntry } from './types.js';
-import { resolveStartContext, resolveAdvanceContext, parseTools, parseJsonFlag } from './invocation-context.js';
-import { createOutputWriter, type OutputWriter } from './output-writer.js';
+import { SessionManager } from './session.js';
+import { parseCompositeArgs, type CompositeCommand } from './arg-parser.js';
+import { parseTools, parseJsonFlag } from './invocation-context.js';
+import { createOutputWriter } from './output-writer.js';
+import { handleTopics, handleTopic } from './topic-handler.js';
+import { printCompositeHelp } from './help-printer.js';
+import { handleDispatcher } from './dispatcher-handler.js';
+import { handleSubskill } from './subskill-handler.js';
 
 function resolveSkillDir(): string {
   const binPath = process.execPath;
   return resolve(dirname(binPath), '..');
 }
 
-export type CompositeCommand =
-  | { mode: 'dispatcher'; command: 'start' | 'advance'; flags: Record<string, string> }
-  | { mode: 'subskill'; name: string; command: 'start' | 'advance'; flags: Record<string, string> }
-  | { mode: 'topics' }
-  | { mode: 'topic'; name: string }
-  | { mode: 'help' };
-
-export function parseCompositeArgs(argv: string[], subskillNames: string[]): CompositeCommand {
-  const args = argv.slice(2);
-
-  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
-    return { mode: 'help' };
-  }
-
-  const first = args[0]!;
-
-  if (first === 'topics') return { mode: 'topics' };
-  if (first === 'topic') {
-    const name = args[1];
-    if (!name) {
-      process.stderr.write('error: topic name required. Run with "topics" to list.\n');
-      process.exit(1);
-    }
-    return { mode: 'topic', name };
-  }
-
-  if (subskillNames.includes(first)) {
-    return parseSubskillArgs(first, args.slice(1));
-  }
-
-  return parseDispatcherArgs(args);
-}
-
-function parseDispatcherArgs(args: string[]): CompositeCommand {
-  const first = args[0]!;
-  let command: 'start' | 'advance';
-  let flagStart: number;
-
-  if (first === 'start' || first === 'advance') {
-    command = first;
-    flagStart = 1;
-  } else if (first.startsWith('--')) {
-    command = 'start';
-    flagStart = 0;
-  } else {
-    return { mode: 'help' };
-  }
-
-  return { mode: 'dispatcher', command, flags: parseFlags(args, flagStart) };
-}
-
-function parseSubskillArgs(name: string, args: string[]): CompositeCommand {
-  if (args.length === 0 || args[0]!.startsWith('--')) {
-    return { mode: 'subskill', name, command: 'start', flags: parseFlags(args, 0) };
-  }
-
-  const first = args[0]!;
-  if (first === 'start' || first === 'advance') {
-    return { mode: 'subskill', name, command: first, flags: parseFlags(args, 1) };
-  }
-
-  return { mode: 'help' };
-}
-
-const BOOLEAN_FLAGS = new Set(['subagent']);
-
-function parseFlags(args: string[], start: number): Record<string, string> {
-  const flags: Record<string, string> = {};
-  for (let i = start; i < args.length; i++) {
-    const arg = args[i]!;
-    if (arg.startsWith('--')) {
-      const name = arg.slice(2);
-      if (BOOLEAN_FLAGS.has(name)) {
-        flags[name] = 'true';
-      } else if (i + 1 < args.length) {
-        flags[name] = args[i + 1]!;
-        i++;
-      }
-    }
-  }
-  return flags;
-}
-
-function detectSubskill(step: string): string | null {
-  const idx = step.indexOf('/');
-  return idx === -1 ? null : step.slice(0, idx);
-}
-
-function extractDispatcherHistory(history: HistoryEntry[]): HistoryEntry[] {
-  return history.filter((e) => !e.step.includes('/'));
-}
-
-interface SessionContext {
-  session: SessionFile | undefined;
-  isStart: boolean;
-}
-
-function resolveSessionForCommand(
-  flags: Record<string, string>,
-  command: 'start' | 'advance',
-  skillName: string,
-): SessionContext {
+function resolveSession(flags: Record<string, string>, command: 'start' | 'advance', skillName: string) {
   const sessionFlag = flags['session'];
 
   if (command === 'start' && sessionFlag === 'new') {
     const outputMode = (flags['output-mode'] as SessionOutputMode) ?? 'file';
-    const session = SessionManager.create({
+    return SessionManager.create({
       sessionDir: flags['session-dir'],
       skill: skillName,
       host: flags['host'] ?? 'generic',
@@ -129,15 +29,13 @@ function resolveSessionForCommand(
       params: parseJsonFlag(flags['params'], {}),
       outputMode,
     });
-    return { session, isStart: true };
   }
 
   if (command === 'advance' && sessionFlag && sessionFlag !== 'new') {
-    const session = SessionManager.open(sessionFlag, flags['session-dir']);
-    return { session, isStart: false };
+    return SessionManager.open(sessionFlag, flags['session-dir']);
   }
 
-  return { session: undefined, isStart: command === 'start' };
+  return undefined;
 }
 
 export async function compositeMain(def: SkillDefinition, refsBasePath?: string): Promise<void> {
@@ -159,13 +57,19 @@ export async function compositeMain(def: SkillDefinition, refsBasePath?: string)
         handleTopic(def, parsed.name, refs);
         break;
 
-      case 'dispatcher':
-        await handleDispatcher(def, parsed, refs);
+      case 'dispatcher': {
+        const session = resolveSession(parsed.flags, parsed.command, def.name);
+        const writer = createOutputWriter(session);
+        await handleDispatcher(def, parsed, refs, session, writer);
         break;
+      }
 
-      case 'subskill':
-        await handleSubskill(def, parsed, refs);
+      case 'subskill': {
+        const session = resolveSession(parsed.flags, parsed.command, def.name);
+        const writer = createOutputWriter(session);
+        await handleSubskill(def, parsed, refs, session, writer);
         break;
+      }
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -174,205 +78,4 @@ export async function compositeMain(def: SkillDefinition, refsBasePath?: string)
   }
 }
 
-function handleTopics(def: SkillDefinition): void {
-  if (!def.topics || Object.keys(def.topics).length === 0) {
-    process.stderr.write('No topics available.\n');
-    return;
-  }
-  for (const [name, topic] of Object.entries(def.topics)) {
-    process.stdout.write(`${name}: ${topic.label}\n`);
-  }
-}
-
-function handleTopic(def: SkillDefinition, topicName: string, refs: ReferenceLoader): void {
-  const topic = def.topics?.[topicName];
-  if (!topic) {
-    process.stderr.write(`error: unknown topic "${topicName}". Run with "topics" to list.\n`);
-    process.exit(1);
-  }
-  const content = topic.content({ refs });
-  process.stdout.write(content);
-  if (!content.endsWith('\n')) process.stdout.write('\n');
-}
-
-async function handleDispatcher(
-  def: SkillDefinition,
-  parsed: { command: 'start' | 'advance'; flags: Record<string, string> },
-  refs: ReferenceLoader,
-): Promise<void> {
-  const { session, isStart } = resolveSessionForCommand(parsed.flags, parsed.command, def.name);
-  const writer = createOutputWriter(session);
-
-  if (isStart) {
-    const ctx = resolveStartContext(parsed.flags, session, refs);
-    const engine = new WorkflowEngine(def, ctx.handshake, ctx.params, refs);
-    const startResult = engine.start();
-    const result = await autoAdvance(engine, startResult, writer.writeIntermediate);
-    writer.writeStart(result);
-    return;
-  }
-
-  const ctx = resolveAdvanceContext(parsed.flags, session, refs);
-
-  const subskillName = detectSubskill(ctx.stepName);
-  if (subskillName) {
-    const sub = def.subskills?.[subskillName];
-    if (!sub) throw new Error(`Unknown sub-skill "${subskillName}"`);
-    const subEngine = new SubskillEngine(sub.definition, ctx.handshake, {}, refs, subskillName);
-    subEngine.replayHistory(ctx.history);
-    subEngine.startForReplay();
-    const subResult = await subEngine.advance(ctx.stepName, ctx.output);
-    const result = await autoAdvance(subEngine, subResult, writer.writeIntermediate);
-    writer.writeAdvance(result);
-    return;
-  }
-
-  const engine = new WorkflowEngine(def, ctx.handshake, ctx.params, refs);
-  const dispatcherHistory = extractDispatcherHistory(ctx.history);
-  if (dispatcherHistory.length > 0) {
-    engine.replayHistory(dispatcherHistory);
-  }
-  engine.start();
-
-  const advanceResult = await engine.advance(ctx.stepName, ctx.output);
-  const result = await autoAdvance(engine, advanceResult, writer.writeIntermediate);
-
-  if (result.kind === 'redirect') {
-    await handleRedirect(def, result, ctx.handshake, refs, writer);
-    return;
-  }
-
-  writer.writeAdvance(result);
-}
-
-async function handleSubskill(
-  def: SkillDefinition,
-  parsed: { name: string; command: 'start' | 'advance'; flags: Record<string, string> },
-  refs: ReferenceLoader,
-): Promise<void> {
-  const sub = def.subskills?.[parsed.name];
-  if (!sub) {
-    process.stderr.write(`error: unknown sub-skill "${parsed.name}"\n`);
-    process.exit(1);
-  }
-
-  const { session, isStart } = resolveSessionForCommand(parsed.flags, parsed.command, def.name);
-  const writer = createOutputWriter(session);
-
-  if (isStart) {
-    const ctx = resolveStartContext(parsed.flags, session, refs);
-    const subEngine = new SubskillEngine(sub.definition, ctx.handshake, ctx.params, refs, parsed.name);
-    const startResult = subEngine.start();
-    const result = await autoAdvance(subEngine, startResult, writer.writeIntermediate);
-    writer.writeStart(result);
-    return;
-  }
-
-  const ctx = resolveAdvanceContext(parsed.flags, session, refs);
-  const subEngine = new SubskillEngine(sub.definition, ctx.handshake, ctx.params, refs, parsed.name);
-  subEngine.replayHistory(ctx.history);
-  subEngine.startForReplay();
-  const advanceResult = await subEngine.advance(ctx.stepName, ctx.output);
-  const result = await autoAdvance(subEngine, advanceResult, writer.writeIntermediate);
-  writer.writeAdvance(result);
-}
-
-async function handleRedirect(
-  def: SkillDefinition,
-  redirect: RedirectResult,
-  handshake: Handshake,
-  refs: ReferenceLoader,
-  writer: OutputWriter,
-): Promise<void> {
-  const target = redirect.redirect;
-
-  if (target.startsWith('topic:')) {
-    const topicName = target.slice('topic:'.length);
-    const topic = def.topics?.[topicName];
-    if (!topic) {
-      throw new Error(`Redirect to unknown topic "${topicName}"`);
-    }
-    const content = topic.content({ refs });
-    writer.writeAdvance({
-      kind: 'done',
-      done: true,
-      finalOutput: { topic: topicName, content },
-      completed: redirect.completed,
-    });
-    return;
-  }
-
-  if (target.startsWith('subskill:')) {
-    const subName = target.slice('subskill:'.length);
-    const sub = def.subskills?.[subName];
-    if (!sub) {
-      throw new Error(`Redirect to unknown sub-skill "${subName}"`);
-    }
-
-    const params = sub.paramsMap ? sub.paramsMap(redirect.completed.stepOutput, redirect.stash) : {};
-    const subEngine = new SubskillEngine(sub.definition, handshake, params, refs, subName);
-    const rawStart = subEngine.start();
-    const startResult = await autoAdvance(subEngine, rawStart, writer.writeIntermediate);
-    if (startResult.kind === 'prompt' || startResult.kind === 'done') {
-      writer.writeAdvance({ ...startResult, completed: redirect.completed });
-    } else {
-      writer.writeAdvance(startResult);
-    }
-    return;
-  }
-
-  throw new Error(`Unknown redirect target "${target}" — expected subskill:<name> or topic:<name>`);
-}
-
-function printCompositeHelp(def: SkillDefinition): void {
-  const subNames = def.subskills ? Object.keys(def.subskills) : [];
-  const topicNames = def.topics ? Object.keys(def.topics) : [];
-
-  const lines = [
-    `${def.name} — composite skill`,
-    '',
-    'Usage:',
-    `  ${def.name} --params '{"key":"value"}' [--host claude-code] [--session new]`,
-    `  ${def.name} advance --session <id>`,
-    `  ${def.name} advance --step <name> --output '{"..."}' --history '[...]'`,
-  ];
-
-  if (subNames.length > 0) {
-    lines.push('');
-    lines.push('Sub-skills (direct access):');
-    for (const name of subNames) {
-      const desc = def.subskills![name]!.definition.description;
-      lines.push(`  ${name.padEnd(20)} ${desc}`);
-    }
-    lines.push('');
-    lines.push(`  ${def.name} <subskill> --params '{"..."}' [--host claude-code]`);
-    lines.push(`  ${def.name} <subskill> advance --step <name> --output '{"..."}' --history '[...]'`);
-  }
-
-  if (topicNames.length > 0) {
-    lines.push('');
-    lines.push('Reference topics:');
-    for (const name of topicNames) {
-      lines.push(`  ${name.padEnd(20)} ${def.topics![name]!.label}`);
-    }
-    lines.push('');
-    lines.push(`  ${def.name} topics              List all topics`);
-    lines.push(`  ${def.name} topic <name>         Load a topic`);
-  }
-
-  lines.push('');
-  lines.push('Flags:');
-  lines.push('  --params       JSON string. Validated against skill params schema. (start only)');
-  lines.push('  --step         Step name (advance only). Sub-skill steps: <subskill>/<step>');
-  lines.push('  --output       JSON string. Agent response for the step. (advance only)');
-  lines.push('  --history      JSON array of {step, output, action?} objects. (advance only)');
-  lines.push('  --host         Host identifier for prose generation. Default: generic.');
-  lines.push('  --tools        Comma-separated list of available tools (merged with host registry).');
-  lines.push('  --subagent     Indicates a subagent with a genuine tool subset (no registry merge).');
-  lines.push('  --session      "new" to create a session (start), or session ID (advance).');
-  lines.push('  --session-dir  Directory for session files. Default: OS temp directory.');
-  lines.push('  --output-mode  "file" (default) or "flag". How agent passes step output.');
-  lines.push('  --help         Print this message.');
-
-  process.stderr.write(lines.join('\n') + '\n');
-}
+export { parseCompositeArgs, type CompositeCommand };

--- a/src/protocol/dispatcher-handler.ts
+++ b/src/protocol/dispatcher-handler.ts
@@ -1,0 +1,113 @@
+import type { SkillDefinition, RedirectResult, Handshake, ReferenceLoader } from '../types.js';
+import { WorkflowEngine } from '../runtime/engine.js';
+import { SubskillEngine } from './subskill-engine.js';
+import { autoAdvance } from './auto-advance.js';
+import type { HistoryEntry } from './types.js';
+import { resolveStartContext, resolveAdvanceContext } from './invocation-context.js';
+import { type OutputWriter } from './output-writer.js';
+import type { SessionFile } from './session.js';
+
+function detectSubskill(step: string): string | null {
+  const idx = step.indexOf('/');
+  return idx === -1 ? null : step.slice(0, idx);
+}
+
+function extractDispatcherHistory(history: HistoryEntry[]): HistoryEntry[] {
+  return history.filter((e) => !e.step.includes('/'));
+}
+
+export async function handleDispatcher(
+  def: SkillDefinition,
+  parsed: { command: 'start' | 'advance'; flags: Record<string, string> },
+  refs: ReferenceLoader,
+  session: SessionFile | undefined,
+  writer: OutputWriter,
+): Promise<void> {
+  if (parsed.command === 'start') {
+    const ctx = resolveStartContext(parsed.flags, session, refs);
+    const engine = new WorkflowEngine(def, ctx.handshake, ctx.params, refs);
+    const startResult = engine.start();
+    const result = await autoAdvance(engine, startResult, writer.writeIntermediate);
+    writer.writeStart(result);
+    return;
+  }
+
+  const ctx = resolveAdvanceContext(parsed.flags, session, refs);
+
+  const subskillName = detectSubskill(ctx.stepName);
+  if (subskillName) {
+    const sub = def.subskills?.[subskillName];
+    if (!sub) throw new Error(`Unknown sub-skill "${subskillName}"`);
+    const subEngine = new SubskillEngine(sub.definition, ctx.handshake, {}, refs, subskillName);
+    subEngine.replayHistory(ctx.history);
+    subEngine.startForReplay();
+    const subResult = await subEngine.advance(ctx.stepName, ctx.output);
+    const result = await autoAdvance(subEngine, subResult, writer.writeIntermediate);
+    writer.writeAdvance(result);
+    return;
+  }
+
+  const engine = new WorkflowEngine(def, ctx.handshake, ctx.params, refs);
+  const dispatcherHistory = extractDispatcherHistory(ctx.history);
+  if (dispatcherHistory.length > 0) {
+    engine.replayHistory(dispatcherHistory);
+  }
+  engine.start();
+
+  const advanceResult = await engine.advance(ctx.stepName, ctx.output);
+  const result = await autoAdvance(engine, advanceResult, writer.writeIntermediate);
+
+  if (result.kind === 'redirect') {
+    await handleRedirect(def, result, ctx.handshake, refs, writer);
+    return;
+  }
+
+  writer.writeAdvance(result);
+}
+
+async function handleRedirect(
+  def: SkillDefinition,
+  redirect: RedirectResult,
+  handshake: Handshake,
+  refs: ReferenceLoader,
+  writer: OutputWriter,
+): Promise<void> {
+  const target = redirect.redirect;
+
+  if (target.startsWith('topic:')) {
+    const topicName = target.slice('topic:'.length);
+    const topic = def.topics?.[topicName];
+    if (!topic) {
+      throw new Error(`Redirect to unknown topic "${topicName}"`);
+    }
+    const content = topic.content({ refs });
+    writer.writeAdvance({
+      kind: 'done',
+      done: true,
+      finalOutput: { topic: topicName, content },
+      completed: redirect.completed,
+    });
+    return;
+  }
+
+  if (target.startsWith('subskill:')) {
+    const subName = target.slice('subskill:'.length);
+    const sub = def.subskills?.[subName];
+    if (!sub) {
+      throw new Error(`Redirect to unknown sub-skill "${subName}"`);
+    }
+
+    const params = sub.paramsMap ? sub.paramsMap(redirect.completed.stepOutput, redirect.stash) : {};
+    const subEngine = new SubskillEngine(sub.definition, handshake, params, refs, subName);
+    const rawStart = subEngine.start();
+    const startResult = await autoAdvance(subEngine, rawStart, writer.writeIntermediate);
+    if (startResult.kind === 'prompt' || startResult.kind === 'done') {
+      writer.writeAdvance({ ...startResult, completed: redirect.completed });
+    } else {
+      writer.writeAdvance(startResult);
+    }
+    return;
+  }
+
+  throw new Error(`Unknown redirect target "${target}" — expected subskill:<name> or topic:<name>`);
+}

--- a/src/protocol/help-printer.ts
+++ b/src/protocol/help-printer.ts
@@ -1,0 +1,54 @@
+import type { SkillDefinition } from '../types.js';
+
+export function printCompositeHelp(def: SkillDefinition): void {
+  const subNames = def.subskills ? Object.keys(def.subskills) : [];
+  const topicNames = def.topics ? Object.keys(def.topics) : [];
+
+  const lines = [
+    `${def.name} — composite skill`,
+    '',
+    'Usage:',
+    `  ${def.name} --params '{"key":"value"}' [--host claude-code] [--session new]`,
+    `  ${def.name} advance --session <id>`,
+    `  ${def.name} advance --step <name> --output '{"..."}' --history '[...]'`,
+  ];
+
+  if (subNames.length > 0) {
+    lines.push('');
+    lines.push('Sub-skills (direct access):');
+    for (const name of subNames) {
+      const desc = def.subskills![name]!.definition.description;
+      lines.push(`  ${name.padEnd(20)} ${desc}`);
+    }
+    lines.push('');
+    lines.push(`  ${def.name} <subskill> --params '{"..."}' [--host claude-code]`);
+    lines.push(`  ${def.name} <subskill> advance --step <name> --output '{"..."}' --history '[...]'`);
+  }
+
+  if (topicNames.length > 0) {
+    lines.push('');
+    lines.push('Reference topics:');
+    for (const name of topicNames) {
+      lines.push(`  ${name.padEnd(20)} ${def.topics![name]!.label}`);
+    }
+    lines.push('');
+    lines.push(`  ${def.name} topics              List all topics`);
+    lines.push(`  ${def.name} topic <name>         Load a topic`);
+  }
+
+  lines.push('');
+  lines.push('Flags:');
+  lines.push('  --params       JSON string. Validated against skill params schema. (start only)');
+  lines.push('  --step         Step name (advance only). Sub-skill steps: <subskill>/<step>');
+  lines.push('  --output       JSON string. Agent response for the step. (advance only)');
+  lines.push('  --history      JSON array of {step, output, action?} objects. (advance only)');
+  lines.push('  --host         Host identifier for prose generation. Default: generic.');
+  lines.push('  --tools        Comma-separated list of available tools (merged with host registry).');
+  lines.push('  --subagent     Indicates a subagent with a genuine tool subset (no registry merge).');
+  lines.push('  --session      "new" to create a session (start), or session ID (advance).');
+  lines.push('  --session-dir  Directory for session files. Default: OS temp directory.');
+  lines.push('  --output-mode  "file" (default) or "flag". How agent passes step output.');
+  lines.push('  --help         Print this message.');
+
+  process.stderr.write(lines.join('\n') + '\n');
+}

--- a/src/protocol/invocation-context.ts
+++ b/src/protocol/invocation-context.ts
@@ -1,0 +1,122 @@
+import type { Handshake, ReferenceLoader } from '../types.js';
+import { resolveHost } from './host.js';
+import type { SessionFile } from './session.js';
+import type { HistoryEntry } from './types.js';
+
+export interface InvocationContext {
+  readonly handshake: Handshake;
+  readonly params: unknown;
+  readonly refs: ReferenceLoader;
+  readonly session: SessionFile | undefined;
+}
+
+export interface StartContext extends InvocationContext {
+  readonly command: 'start';
+}
+
+export interface AdvanceContext extends InvocationContext {
+  readonly command: 'advance';
+  readonly stepName: string;
+  readonly output: unknown;
+  readonly history: HistoryEntry[];
+}
+
+export function parseTools(flags: Record<string, string>): string[] | undefined {
+  const raw = flags['tools'];
+  return raw
+    ? raw
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+    : undefined;
+}
+
+export function parseJsonFlag(raw: string | undefined, fallback: unknown): unknown {
+  return raw ? (JSON.parse(raw) as unknown) : fallback;
+}
+
+export function resolveHandshake(flags: Record<string, string>, session: SessionFile | undefined): Handshake {
+  const tools = session?.header.tools ?? parseTools(flags);
+  const isSubagent = session?.header.isSubagent ?? flags['subagent'] === 'true';
+  return resolveHost(session?.header.host ?? flags['host'], tools, isSubagent);
+}
+
+export function resolveParams(flags: Record<string, string>, session: SessionFile | undefined): unknown {
+  return session?.header.params ?? parseJsonFlag(flags['params'], {});
+}
+
+export function resolveStartContext(
+  flags: Record<string, string>,
+  session: SessionFile | undefined,
+  refs: ReferenceLoader,
+): StartContext {
+  return {
+    command: 'start',
+    handshake: resolveHandshake(flags, session),
+    params: session?.header.params ?? parseJsonFlag(flags['params'], {}),
+    refs,
+    session,
+  };
+}
+
+export function resolveAdvanceContext(
+  flags: Record<string, string>,
+  session: SessionFile | undefined,
+  refs: ReferenceLoader,
+): AdvanceContext {
+  const { stepName, output, history } = resolveAdvanceInput(flags, session);
+  return {
+    command: 'advance',
+    handshake: resolveHandshake(flags, session),
+    params: resolveParams(flags, session),
+    refs,
+    session,
+    stepName,
+    output,
+    history,
+  };
+}
+
+function resolveAdvanceInput(
+  flags: Record<string, string>,
+  session: SessionFile | undefined,
+): { stepName: string; output: unknown; history: HistoryEntry[] } {
+  if (session) {
+    const history = session.reconstructHistory();
+
+    if (session.header.outputMode === 'file' && !flags['output']) {
+      const lastOutput = session.readLastOutput();
+      if (!lastOutput) {
+        process.stderr.write(
+          'error: no output found in session file. Write your output to the session file before advancing.\n',
+        );
+        process.exit(1);
+      }
+      return { stepName: lastOutput.step, output: lastOutput.output, history };
+    }
+
+    const stepName = flags['step']!;
+    const output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
+    if (!stepName || output === undefined) {
+      process.stderr.write('error: --step and --output are required for advance in flag mode\n');
+      process.exit(1);
+    }
+    session.append({ type: 'output', step: stepName, output });
+    return { stepName, output, history };
+  }
+
+  const stepName = flags['step']!;
+  const output = flags['output'] ? (JSON.parse(flags['output']) as unknown) : undefined;
+  const history: HistoryEntry[] = flags['history'] ? (JSON.parse(flags['history']) as HistoryEntry[]) : [];
+
+  if (!stepName) {
+    process.stderr.write('error: --step is required for advance\n');
+    process.exit(1);
+  }
+  if (output === undefined) {
+    process.stderr.write('error: --output is required for advance\n');
+    process.exit(1);
+  }
+
+  return { stepName, output, history };
+}

--- a/src/protocol/output-writer.ts
+++ b/src/protocol/output-writer.ts
@@ -1,0 +1,36 @@
+import type { CliResult } from '../types.js';
+import type { SessionFile } from './session.js';
+
+export interface OutputWriter {
+  writeStart(result: CliResult): void;
+  writeAdvance(result: CliResult): void;
+  writeIntermediate(result: CliResult): void;
+}
+
+export function createOutputWriter(session: SessionFile | undefined): OutputWriter {
+  if (session) {
+    return {
+      writeStart(result) {
+        const line = session.appendResult(result);
+        session.writeStartPointer(line);
+      },
+      writeAdvance(result) {
+        const line = session.appendResult(result);
+        session.writePointer(line);
+      },
+      writeIntermediate(result) {
+        session.appendResult(result);
+      },
+    };
+  }
+
+  const writeStdout = (result: CliResult) => {
+    process.stdout.write(JSON.stringify(result) + '\n');
+  };
+
+  return {
+    writeStart: writeStdout,
+    writeAdvance: writeStdout,
+    writeIntermediate() {},
+  };
+}

--- a/src/protocol/session.test.ts
+++ b/src/protocol/session.test.ts
@@ -193,7 +193,7 @@ test('SessionFile.appendResult adds type field to PromptResult', () => {
     params: {},
   });
 
-  const result: PromptResult = { step: 'greet', prompt: 'Hello', schema: { type: 'object' } };
+  const result: PromptResult = { kind: 'prompt', step: 'greet', prompt: 'Hello', schema: { type: 'object' } };
   const line = session.appendResult(result);
   assert.equal(line, 2);
 
@@ -213,7 +213,7 @@ test('SessionFile.appendResult adds type field to DoneResult', () => {
     params: {},
   });
 
-  const result: DoneResult = { done: true, finalOutput: { summary: 'done' } };
+  const result: DoneResult = { kind: 'done', done: true, finalOutput: { summary: 'done' } };
   session.appendResult(result);
 
   const content = readFileSync(session.filePath, 'utf-8');
@@ -232,7 +232,13 @@ test('SessionFile.appendResult adds type field to ValidationErrorResult', () => 
     params: {},
   });
 
-  const result: ValidationErrorResult = { error: 'validation', step: 'greet', message: 'bad', retry: true };
+  const result: ValidationErrorResult = {
+    kind: 'error',
+    error: 'validation',
+    step: 'greet',
+    message: 'bad',
+    retry: true,
+  };
   session.appendResult(result);
 
   const content = readFileSync(session.filePath, 'utf-8');

--- a/src/protocol/session.ts
+++ b/src/protocol/session.ts
@@ -2,9 +2,20 @@ import { randomBytes } from 'node:crypto';
 import { readFileSync, appendFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { SessionHeader, SessionOutputMode, SessionPointer, CliResult, StepResult } from '../types.js';
+import type { SessionHeader, SessionOutputMode, SessionPointer, CliResult } from '../types.js';
 
 const SESSION_ID_LENGTH = 4;
+
+function isStepResultShaped(value: unknown): value is { step: string; stepOutput: unknown; actionOutput?: unknown } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'step' in value &&
+    typeof (value as Record<string, unknown>).step === 'string' &&
+    'stepOutput' in value
+  );
+}
+
 const SESSION_FILE_PREFIX = 'skill-kit-';
 const SESSION_FILE_SUFFIX = '.jsonl';
 
@@ -53,18 +64,20 @@ export class SessionFile {
 
     for (const line of lines) {
       if (line.type === 'prompt' || line.type === 'done') {
-        const autoAdvanced = (line as Record<string, unknown>).autoAdvanced as StepResult[] | undefined;
-        if (autoAdvanced) {
+        const autoAdvanced = line.autoAdvanced;
+        if (Array.isArray(autoAdvanced)) {
           for (const entry of autoAdvanced) {
-            history.push({
-              step: entry.step,
-              stepOutput: entry.stepOutput,
-              ...(entry.actionOutput !== undefined ? { actionOutput: entry.actionOutput } : {}),
-            });
+            if (isStepResultShaped(entry)) {
+              history.push({
+                step: entry.step,
+                stepOutput: entry.stepOutput,
+                ...(entry.actionOutput !== undefined ? { actionOutput: entry.actionOutput } : {}),
+              });
+            }
           }
         }
-        const completed = (line as Record<string, unknown>).completed as StepResult | undefined;
-        if (completed) {
+        const completed = line.completed;
+        if (isStepResultShaped(completed)) {
           history.push({
             step: completed.step,
             stepOutput: completed.stepOutput,

--- a/src/protocol/session.ts
+++ b/src/protocol/session.ts
@@ -2,14 +2,7 @@ import { randomBytes } from 'node:crypto';
 import { readFileSync, appendFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type {
-  SessionHeader,
-  SessionOutputMode,
-  SessionPointer,
-  CliResult,
-  PromptResult,
-  StepResult,
-} from '../types.js';
+import type { SessionHeader, SessionOutputMode, SessionPointer, CliResult, StepResult } from '../types.js';
 
 const SESSION_ID_LENGTH = 4;
 const SESSION_FILE_PREFIX = 'skill-kit-';
@@ -186,14 +179,5 @@ export class SessionManager {
 }
 
 function addTypeField(result: CliResult): Record<string, unknown> {
-  if ('done' in result) return { type: 'done', ...result };
-  if ('error' in result) return { type: 'error', ...result };
-  if ('redirect' in result) return { type: 'redirect', ...result };
-  const prompt = result as PromptResult;
-  const obj: Record<string, unknown> = { type: 'prompt', step: prompt.step };
-  if (prompt.preamble) obj.preamble = prompt.preamble;
-  obj.prompt = prompt.prompt;
-  obj.schema = prompt.schema;
-  if (prompt.completed) obj.completed = prompt.completed;
-  return obj;
+  return { type: result.kind, ...result };
 }

--- a/src/protocol/single-invocation.ts
+++ b/src/protocol/single-invocation.ts
@@ -1,23 +1,19 @@
-import type { SkillDefinition, CliResult } from '../types.js';
+import type { SkillDefinition } from '../types.js';
 import { WorkflowEngine } from '../runtime/engine.js';
 import { autoAdvance } from './auto-advance.js';
 import type { StartContext, AdvanceContext } from './invocation-context.js';
+import { createOutputWriter } from './output-writer.js';
 
 export async function handleStart(skill: SkillDefinition, ctx: StartContext): Promise<void> {
+  const writer = createOutputWriter(ctx.session);
   const engine = new WorkflowEngine(skill, ctx.handshake, ctx.params, ctx.refs);
   const startResult = engine.start();
-  const onIntermediate = ctx.session ? (r: CliResult) => ctx.session!.appendResult(r) : undefined;
-  const result = await autoAdvance(engine, startResult, onIntermediate);
-
-  if (ctx.session) {
-    const line = ctx.session.appendResult(result);
-    ctx.session.writeStartPointer(line);
-  } else {
-    process.stdout.write(JSON.stringify(result) + '\n');
-  }
+  const result = await autoAdvance(engine, startResult, writer.writeIntermediate);
+  writer.writeStart(result);
 }
 
 export async function handleAdvance(skill: SkillDefinition, ctx: AdvanceContext): Promise<void> {
+  const writer = createOutputWriter(ctx.session);
   const engine = new WorkflowEngine(skill, ctx.handshake, ctx.params, ctx.refs);
 
   if (ctx.history.length > 0) {
@@ -26,15 +22,8 @@ export async function handleAdvance(skill: SkillDefinition, ctx: AdvanceContext)
 
   engine.start();
   const advanceResult = await engine.advance(ctx.stepName, ctx.output);
-  const onIntermediate = ctx.session ? (r: CliResult) => ctx.session!.appendResult(r) : undefined;
-  const result = await autoAdvance(engine, advanceResult, onIntermediate);
-
-  if (ctx.session) {
-    const line = ctx.session.appendResult(result);
-    ctx.session.writePointer(line);
-  } else {
-    process.stdout.write(JSON.stringify(result) + '\n');
-  }
+  const result = await autoAdvance(engine, advanceResult, writer.writeIntermediate);
+  writer.writeAdvance(result);
 }
 
 function printHelp(skillName: string): void {

--- a/src/protocol/single-invocation.ts
+++ b/src/protocol/single-invocation.ts
@@ -1,57 +1,37 @@
 import type { SkillDefinition, CliResult } from '../types.js';
 import { WorkflowEngine } from '../runtime/engine.js';
-import { resolveHost } from './host.js';
-import type { SessionFile } from './session.js';
 import { autoAdvance } from './auto-advance.js';
+import type { StartContext, AdvanceContext } from './invocation-context.js';
 
-export async function handleStart(
-  skill: SkillDefinition,
-  params: unknown,
-  hostName?: string,
-  session?: SessionFile,
-  tools?: string[],
-  isSubagent?: boolean,
-): Promise<void> {
-  const handshake = resolveHost(hostName, tools, isSubagent);
-  const engine = new WorkflowEngine(skill, handshake, params);
+export async function handleStart(skill: SkillDefinition, ctx: StartContext): Promise<void> {
+  const engine = new WorkflowEngine(skill, ctx.handshake, ctx.params, ctx.refs);
   const startResult = engine.start();
-  const onIntermediate = session ? (r: CliResult) => session.appendResult(r) : undefined;
+  const onIntermediate = ctx.session ? (r: CliResult) => ctx.session!.appendResult(r) : undefined;
   const result = await autoAdvance(engine, startResult, onIntermediate);
 
-  if (session) {
-    const line = session.appendResult(result);
-    session.writeStartPointer(line);
+  if (ctx.session) {
+    const line = ctx.session.appendResult(result);
+    ctx.session.writeStartPointer(line);
   } else {
     process.stdout.write(JSON.stringify(result) + '\n');
   }
 }
 
-export async function handleAdvance(
-  skill: SkillDefinition,
-  stepName: string,
-  output: unknown,
-  history: Array<{ step: string; stepOutput: unknown; actionOutput?: unknown }>,
-  params: unknown,
-  hostName?: string,
-  session?: SessionFile,
-  tools?: string[],
-  isSubagent?: boolean,
-): Promise<void> {
-  const handshake = resolveHost(hostName, tools, isSubagent);
-  const engine = new WorkflowEngine(skill, handshake, params);
+export async function handleAdvance(skill: SkillDefinition, ctx: AdvanceContext): Promise<void> {
+  const engine = new WorkflowEngine(skill, ctx.handshake, ctx.params, ctx.refs);
 
-  if (history.length > 0) {
-    engine.replayHistory(history);
+  if (ctx.history.length > 0) {
+    engine.replayHistory(ctx.history);
   }
 
   engine.start();
-  const advanceResult = await engine.advance(stepName, output);
-  const onIntermediate = session ? (r: CliResult) => session.appendResult(r) : undefined;
+  const advanceResult = await engine.advance(ctx.stepName, ctx.output);
+  const onIntermediate = ctx.session ? (r: CliResult) => ctx.session!.appendResult(r) : undefined;
   const result = await autoAdvance(engine, advanceResult, onIntermediate);
 
-  if (session) {
-    const line = session.appendResult(result);
-    session.writePointer(line);
+  if (ctx.session) {
+    const line = ctx.session.appendResult(result);
+    ctx.session.writePointer(line);
   } else {
     process.stdout.write(JSON.stringify(result) + '\n');
   }

--- a/src/protocol/skill-engine.ts
+++ b/src/protocol/skill-engine.ts
@@ -1,0 +1,9 @@
+import type { PromptResult, CliResult } from '../types.js';
+import type { HistoryEntry } from './types.js';
+
+export interface SkillEngine {
+  start(): PromptResult;
+  advance(stepName: string, output: unknown): Promise<CliResult>;
+  isPromptless(stepName: string): boolean;
+  replayHistory(history: HistoryEntry[]): void;
+}

--- a/src/protocol/subskill-engine.ts
+++ b/src/protocol/subskill-engine.ts
@@ -1,13 +1,4 @@
-import type {
-  CliResult,
-  PromptResult,
-  DoneResult,
-  ValidationErrorResult,
-  StepResult,
-  Handshake,
-  SkillDefinition,
-  ReferenceLoader,
-} from '../types.js';
+import type { CliResult, PromptResult, StepResult, Handshake, SkillDefinition, ReferenceLoader } from '../types.js';
 import { WorkflowEngine } from '../runtime/engine.js';
 
 type HistoryEntry = { step: string; stepOutput: unknown; actionOutput?: unknown };
@@ -90,27 +81,25 @@ export class SubskillEngine {
   }
 
   private qualifyResult(result: CliResult): CliResult {
-    if ('redirect' in result) {
-      throw new Error(
-        `SubskillEngine: unexpected redirect "${(result as { redirect: string }).redirect}" — ` +
-          `subskills should not produce redirect results`,
-      );
-    }
+    switch (result.kind) {
+      case 'redirect':
+        throw new Error(
+          `SubskillEngine: unexpected redirect "${result.redirect}" — ` +
+            `subskills should not produce redirect results`,
+        );
 
-    if ('error' in result) {
-      const err = result as ValidationErrorResult;
-      return { ...err, step: this.qualify(err.step) };
-    }
+      case 'error':
+        return { ...result, step: this.qualify(result.step) };
 
-    if ('done' in result) {
-      const done = result as DoneResult;
-      return {
-        ...done,
-        ...(done.completed ? { completed: this.qualifyCompleted(done.completed) } : {}),
-        ...(done.autoAdvanced ? { autoAdvanced: this.qualifyAutoAdvanced(done.autoAdvanced) } : {}),
-      };
-    }
+      case 'done':
+        return {
+          ...result,
+          ...(result.completed ? { completed: this.qualifyCompleted(result.completed) } : {}),
+          ...(result.autoAdvanced ? { autoAdvanced: this.qualifyAutoAdvanced(result.autoAdvanced) } : {}),
+        };
 
-    return this.qualifyPrompt(result as PromptResult);
+      case 'prompt':
+        return this.qualifyPrompt(result);
+    }
   }
 }

--- a/src/protocol/subskill-engine.ts
+++ b/src/protocol/subskill-engine.ts
@@ -1,7 +1,7 @@
 import type { CliResult, PromptResult, StepResult, Handshake, SkillDefinition, ReferenceLoader } from '../types.js';
 import { WorkflowEngine } from '../runtime/engine.js';
-
-type HistoryEntry = { step: string; stepOutput: unknown; actionOutput?: unknown };
+import type { SkillEngine } from './skill-engine.js';
+import type { HistoryEntry } from './types.js';
 
 /**
  * Wraps a WorkflowEngine for a subskill, transparently qualifying step names
@@ -9,7 +9,7 @@ type HistoryEntry = { step: string; stepOutput: unknown; actionOutput?: unknown 
  *
  * Callers never prefix or unprefix manually — the boundary lives here.
  */
-export class SubskillEngine {
+export class SubskillEngine implements SkillEngine {
   private readonly engine: WorkflowEngine;
   private readonly prefix: string;
 

--- a/src/protocol/subskill-handler.ts
+++ b/src/protocol/subskill-handler.ts
@@ -1,0 +1,37 @@
+import type { SkillDefinition, ReferenceLoader } from '../types.js';
+import { SubskillEngine } from './subskill-engine.js';
+import { autoAdvance } from './auto-advance.js';
+import { resolveStartContext, resolveAdvanceContext } from './invocation-context.js';
+import type { OutputWriter } from './output-writer.js';
+import type { SessionFile } from './session.js';
+
+export async function handleSubskill(
+  def: SkillDefinition,
+  parsed: { name: string; command: 'start' | 'advance'; flags: Record<string, string> },
+  refs: ReferenceLoader,
+  session: SessionFile | undefined,
+  writer: OutputWriter,
+): Promise<void> {
+  const sub = def.subskills?.[parsed.name];
+  if (!sub) {
+    process.stderr.write(`error: unknown sub-skill "${parsed.name}"\n`);
+    process.exit(1);
+  }
+
+  if (parsed.command === 'start') {
+    const ctx = resolveStartContext(parsed.flags, session, refs);
+    const subEngine = new SubskillEngine(sub.definition, ctx.handshake, ctx.params, refs, parsed.name);
+    const startResult = subEngine.start();
+    const result = await autoAdvance(subEngine, startResult, writer.writeIntermediate);
+    writer.writeStart(result);
+    return;
+  }
+
+  const ctx = resolveAdvanceContext(parsed.flags, session, refs);
+  const subEngine = new SubskillEngine(sub.definition, ctx.handshake, ctx.params, refs, parsed.name);
+  subEngine.replayHistory(ctx.history);
+  subEngine.startForReplay();
+  const advanceResult = await subEngine.advance(ctx.stepName, ctx.output);
+  const result = await autoAdvance(subEngine, advanceResult, writer.writeIntermediate);
+  writer.writeAdvance(result);
+}

--- a/src/protocol/topic-handler.ts
+++ b/src/protocol/topic-handler.ts
@@ -1,0 +1,22 @@
+import type { SkillDefinition, ReferenceLoader } from '../types.js';
+
+export function handleTopics(def: SkillDefinition): void {
+  if (!def.topics || Object.keys(def.topics).length === 0) {
+    process.stderr.write('No topics available.\n');
+    return;
+  }
+  for (const [name, topic] of Object.entries(def.topics)) {
+    process.stdout.write(`${name}: ${topic.label}\n`);
+  }
+}
+
+export function handleTopic(def: SkillDefinition, topicName: string, refs: ReferenceLoader): void {
+  const topic = def.topics?.[topicName];
+  if (!topic) {
+    process.stderr.write(`error: unknown topic "${topicName}". Run with "topics" to list.\n`);
+    process.exit(1);
+  }
+  const content = topic.content({ refs });
+  process.stdout.write(content);
+  if (!content.endsWith('\n')) process.stdout.write('\n');
+}

--- a/src/runtime/engine.ts
+++ b/src/runtime/engine.ts
@@ -21,6 +21,8 @@ import { ObserverDispatcher } from './observer-dispatch.js';
 import { generatePreamble } from './preamble.js';
 import { act } from '../act.js';
 import { system } from '../system.js';
+import type { SkillEngine } from '../protocol/skill-engine.js';
+import type { HistoryEntry } from '../protocol/types.js';
 
 function normalizePieces(raw: PromptReturn): PromptPiece[] {
   if (typeof raw === 'string') return [raw];
@@ -33,7 +35,7 @@ const NOOP_REFS: ReferenceLoader = {
   asset: (p) => p,
 };
 
-export class WorkflowEngine {
+export class WorkflowEngine implements SkillEngine {
   private readonly skill: SkillDefinition;
   private readonly handshake: Handshake;
   private readonly skillParams: Readonly<unknown>;
@@ -191,7 +193,7 @@ export class WorkflowEngine {
     return { ...this.buildPrompt(nextStep), completed };
   }
 
-  replayHistory(history: Array<{ step: string; stepOutput: unknown; actionOutput?: unknown }>): void {
+  replayHistory(history: HistoryEntry[]): void {
     for (const entry of history) {
       const stepDef = this.skill.steps[entry.step];
       if (!stepDef) continue;

--- a/src/runtime/engine.ts
+++ b/src/runtime/engine.ts
@@ -82,7 +82,7 @@ export class WorkflowEngine {
     const rawPreamble = generatePreamble(this.handshake);
     const preamble = this.skill.system ? `${this.skill.system}\n\n${rawPreamble}` : rawPreamble;
     this.observers.fire('onStepStart', { step: this.currentStep, params: this.skillParams });
-    return { step, preamble, prompt, schema };
+    return { kind: 'prompt', step, preamble, prompt, schema };
   }
 
   isPromptless(stepName: string): boolean {
@@ -94,7 +94,13 @@ export class WorkflowEngine {
     const stepStartTime = Date.now();
     const stepDef = this.skill.steps[stepName];
     if (!stepDef) {
-      return { error: 'validation', step: stepName, message: `Unknown step "${stepName}"`, retry: false };
+      return {
+        kind: 'error',
+        error: 'validation',
+        step: stepName,
+        message: `Unknown step "${stepName}"`,
+        retry: false,
+      };
     }
 
     let stepOutput: unknown;
@@ -109,6 +115,7 @@ export class WorkflowEngine {
           attempt: this.history.visitCount(stepName) + 1,
         });
         return {
+          kind: 'error',
           error: 'validation',
           step: stepName,
           message: validation.error!,
@@ -174,7 +181,7 @@ export class WorkflowEngine {
     if (!this.skill.steps[nextStep]) {
       this.observers.fire('onTransition', { from: stepName, to: nextStep, reason: 'redirect' });
       await this.observers.flush();
-      return { redirect: nextStep, completed, stash: this.stash.all() } satisfies RedirectResult;
+      return { kind: 'redirect', redirect: nextStep, completed, stash: this.stash.all() } satisfies RedirectResult;
     }
 
     this.observers.fire('onTransition', { from: stepName, to: nextStep, reason: 'next' });
@@ -295,7 +302,7 @@ export class WorkflowEngine {
       }
     }
 
-    return { step: stepName, prompt: promptText, schema };
+    return { kind: 'prompt', step: stepName, prompt: promptText, schema };
   }
 
   private validateParentSentinels(): void {
@@ -345,6 +352,6 @@ export class WorkflowEngine {
       }
     }
 
-    return { done: true, finalOutput };
+    return { kind: 'done', done: true, finalOutput };
   }
 }

--- a/src/runtime/engine.ts
+++ b/src/runtime/engine.ts
@@ -22,7 +22,7 @@ import { generatePreamble } from './preamble.js';
 import { act } from '../act.js';
 import { system } from '../system.js';
 import type { SkillEngine } from '../protocol/skill-engine.js';
-import type { HistoryEntry } from '../protocol/types.js';
+import { HistoryEntrySchema, type HistoryEntry } from '../protocol/types.js';
 
 function normalizePieces(raw: PromptReturn): PromptPiece[] {
   if (typeof raw === 'string') return [raw];
@@ -194,7 +194,14 @@ export class WorkflowEngine implements SkillEngine {
   }
 
   replayHistory(history: HistoryEntry[]): void {
-    for (const entry of history) {
+    for (const raw of history) {
+      const parsed = HistoryEntrySchema.safeParse(raw);
+      if (!parsed.success) {
+        const issues = parsed.error.issues.map((i: { message: string }) => i.message).join('; ');
+        process.stderr.write(`[skill-kit] skipping malformed history entry: ${issues}\n`);
+        continue;
+      }
+      const entry = parsed.data;
       const stepDef = this.skill.steps[entry.step];
       if (!stepDef) continue;
 

--- a/src/testing/run-composite.ts
+++ b/src/testing/run-composite.ts
@@ -2,8 +2,6 @@ import type {
   SkillDefinition,
   Handshake,
   ModelAdapter,
-  PromptResult,
-  DoneResult,
   RedirectResult,
   StepResult,
   ReferenceLoader,
@@ -31,8 +29,8 @@ const NOOP_REFS: ReferenceLoader = { load: () => '', asset: (p) => p };
 const MAX_AUTO_ADVANCE = 20;
 
 function collectAutoAdvanced(result: CliResult, history: StepResult[]): void {
-  if ('autoAdvanced' in result && Array.isArray(result.autoAdvanced)) {
-    for (const entry of result.autoAdvanced as StepResult[]) {
+  if ((result.kind === 'prompt' || result.kind === 'done') && result.autoAdvanced) {
+    for (const entry of result.autoAdvanced) {
       history.push(entry);
     }
   }
@@ -46,15 +44,14 @@ interface Advanceable {
 async function drainPromptless(engine: Advanceable, result: CliResult, path: string[]): Promise<CliResult> {
   let current = result;
   let depth = 0;
-  while ('step' in current && !('error' in current) && !('done' in current) && !('redirect' in current)) {
-    const prompt = current as PromptResult;
-    if (!engine.isPromptless(prompt.step)) break;
+  while (current.kind === 'prompt') {
+    if (!engine.isPromptless(current.step)) break;
     depth += 1;
     if (depth > MAX_AUTO_ADVANCE) {
       throw new Error(`Auto-advance depth exceeded (${MAX_AUTO_ADVANCE}). Check for infinite prompt-less step loops.`);
     }
-    path.push(prompt.step);
-    current = await engine.advance(prompt.step, {});
+    path.push(current.step);
+    current = await engine.advance(current.step, {});
   }
   return current;
 }
@@ -88,22 +85,24 @@ async function runFromDispatcher(
   const allHistory: StepResult[] = [];
 
   const initial = await drainPromptless(engine, startResult, path);
-  if ('done' in initial && (initial as DoneResult).done) {
-    return { path, outputs, output: (initial as DoneResult).finalOutput, history: allHistory };
+  if (initial.kind === 'done') {
+    return { path, outputs, output: initial.finalOutput, history: allHistory };
   }
-  if ('redirect' in initial) {
-    const redirect = initial as RedirectResult;
-    allHistory.push(redirect.completed);
-    return handleRedirect(skill, redirect, path, outputs, allHistory, handshake, opts, refs);
+  if (initial.kind === 'redirect') {
+    allHistory.push(initial.completed);
+    return handleRedirect(skill, initial, path, outputs, allHistory, handshake, opts, refs);
   }
-  let current = initial as PromptResult;
+  if (initial.kind !== 'prompt') {
+    throw new Error(`Unexpected result kind "${initial.kind}" at start`);
+  }
+  let current = initial;
 
   while (true) {
     path.push(current.step);
     const response = await opts.model.respond(current.step, current.prompt);
     const result = await engine.advance(current.step, response);
 
-    if ('error' in result) {
+    if (result.kind === 'error') {
       throw new Error(`Validation error at step "${result.step}": ${result.message}`);
     }
 
@@ -112,21 +111,22 @@ async function runFromDispatcher(
     const drained = await drainPromptless(engine, result, path);
     collectAutoAdvanced(drained, allHistory);
 
-    if ('redirect' in drained) {
-      const redirect = drained as RedirectResult;
-      allHistory.push(redirect.completed);
-      return handleRedirect(skill, redirect, path, outputs, allHistory, handshake, opts, refs);
+    if (drained.kind === 'redirect') {
+      allHistory.push(drained.completed);
+      return handleRedirect(skill, drained, path, outputs, allHistory, handshake, opts, refs);
     }
 
-    if ('done' in drained && (drained as DoneResult).done) {
-      return { path, outputs, output: (drained as DoneResult).finalOutput, history: allHistory };
+    if (drained.kind === 'done') {
+      return { path, outputs, output: drained.finalOutput, history: allHistory };
     }
 
-    const prompt = drained as PromptResult;
-    if (prompt.completed) {
-      allHistory.push(prompt.completed);
+    if (drained.kind !== 'prompt') {
+      throw new Error(`Unexpected result kind "${drained.kind}" during run`);
     }
-    current = prompt;
+    if (drained.completed) {
+      allHistory.push(drained.completed);
+    }
+    current = drained;
   }
 }
 
@@ -205,10 +205,13 @@ async function runSubskillEngine(
   const history: StepResult[] = [];
 
   const initial = await drainPromptless(engine, startResult, path);
-  if ('done' in initial && (initial as DoneResult).done) {
-    return { path, outputs, output: (initial as DoneResult).finalOutput, history };
+  if (initial.kind === 'done') {
+    return { path, outputs, output: initial.finalOutput, history };
   }
-  let current = initial as PromptResult;
+  if (initial.kind !== 'prompt') {
+    throw new Error(`Unexpected result kind "${initial.kind}" in subskill start`);
+  }
+  let current = initial;
 
   while (true) {
     const prefixedStep = `${subName}/${current.step}`;
@@ -217,7 +220,7 @@ async function runSubskillEngine(
     const response = await opts.model.respond(prefixedStep, current.prompt);
     const result = await engine.advance(current.step, response);
 
-    if ('error' in result) {
+    if (result.kind === 'error') {
       throw new Error(`Validation error at step "${prefixedStep}": ${result.message}`);
     }
 
@@ -226,14 +229,16 @@ async function runSubskillEngine(
     const drained = await drainPromptless(engine, result, path);
     collectAutoAdvanced(drained, history);
 
-    if ('done' in drained && (drained as DoneResult).done) {
-      return { path, outputs, output: (drained as DoneResult).finalOutput, history };
+    if (drained.kind === 'done') {
+      return { path, outputs, output: drained.finalOutput, history };
     }
 
-    const prompt = drained as PromptResult;
-    if (prompt.completed) {
-      history.push({ ...prompt.completed, step: prefixedStep });
+    if (drained.kind !== 'prompt') {
+      throw new Error(`Unexpected result kind "${drained.kind}" in subskill`);
     }
-    current = prompt;
+    if (drained.completed) {
+      history.push({ ...drained.completed, step: prefixedStep });
+    }
+    current = drained;
   }
 }

--- a/src/testing/run-composite.ts
+++ b/src/testing/run-composite.ts
@@ -36,12 +36,7 @@ function collectAutoAdvanced(result: CliResult, history: StepResult[]): void {
   }
 }
 
-interface Advanceable {
-  isPromptless(stepName: string): boolean;
-  advance(stepName: string, output: unknown): Promise<CliResult>;
-}
-
-async function drainPromptless(engine: Advanceable, result: CliResult, path: string[]): Promise<CliResult> {
+async function drainPromptless(engine: WorkflowEngine, result: CliResult, path: string[]): Promise<CliResult> {
   let current = result;
   let depth = 0;
   while (current.kind === 'prompt') {

--- a/src/testing/run-skill.ts
+++ b/src/testing/run-skill.ts
@@ -1,12 +1,4 @@
-import type {
-  SkillDefinition,
-  Handshake,
-  ModelAdapter,
-  SkillRunResult,
-  PromptResult,
-  DoneResult,
-  CliResult,
-} from '../types.js';
+import type { SkillDefinition, Handshake, ModelAdapter, SkillRunResult, CliResult } from '../types.js';
 import { WorkflowEngine } from '../runtime/engine.js';
 
 export interface RunSkillOptions {
@@ -20,15 +12,14 @@ const MAX_AUTO_ADVANCE = 20;
 async function drainPromptless(engine: WorkflowEngine, result: CliResult, path: string[]): Promise<CliResult> {
   let current = result;
   let depth = 0;
-  while ('step' in current && !('error' in current) && !('done' in current) && !('redirect' in current)) {
-    const prompt = current as PromptResult;
-    if (!engine.isPromptless(prompt.step)) break;
+  while (current.kind === 'prompt') {
+    if (!engine.isPromptless(current.step)) break;
     depth += 1;
     if (depth > MAX_AUTO_ADVANCE) {
       throw new Error(`Auto-advance depth exceeded (${MAX_AUTO_ADVANCE}). Check for infinite prompt-less step loops.`);
     }
-    path.push(prompt.step);
-    current = await engine.advance(prompt.step, {});
+    path.push(current.step);
+    current = await engine.advance(current.step, {});
   }
   return current;
 }
@@ -47,10 +38,13 @@ export async function runSkill(skill: SkillDefinition, opts: RunSkillOptions): P
   const outputs: Record<string, unknown> = {};
 
   let initial = await drainPromptless(engine, startResult, path);
-  if ('done' in initial && (initial as DoneResult).done) {
-    return { path, outputs, stepOutput: (initial as DoneResult).finalOutput, history: engine['history'].all() };
+  if (initial.kind === 'done') {
+    return { path, outputs, stepOutput: initial.finalOutput, history: engine['history'].all() };
   }
-  let current = initial as PromptResult;
+  if (initial.kind !== 'prompt') {
+    throw new Error(`Unexpected result kind "${initial.kind}" at start`);
+  }
+  let current = initial;
 
   while (true) {
     path.push(current.step);
@@ -58,7 +52,7 @@ export async function runSkill(skill: SkillDefinition, opts: RunSkillOptions): P
     const response = await opts.model.respond(current.step, current.prompt);
     const result = await engine.advance(current.step, response);
 
-    if ('error' in result) {
+    if (result.kind === 'error') {
       throw new Error(`Validation error at step "${result.step}": ${result.message}`);
     }
 
@@ -66,15 +60,18 @@ export async function runSkill(skill: SkillDefinition, opts: RunSkillOptions): P
 
     const drained = await drainPromptless(engine, result, path);
 
-    if ('done' in drained && (drained as DoneResult).done) {
+    if (drained.kind === 'done') {
       return {
         path,
         outputs,
-        stepOutput: (drained as DoneResult).finalOutput,
+        stepOutput: drained.finalOutput,
         history: engine['history'].all(),
       };
     }
 
-    current = drained as PromptResult;
+    if (drained.kind !== 'prompt') {
+      throw new Error(`Unexpected result kind "${drained.kind}" during run`);
+    }
+    current = drained;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -360,6 +360,7 @@ export type Buildable = SkillDefinition | ReferenceDefinition;
 // --- Protocol (CLI output) ---
 
 export interface PromptResult {
+  readonly kind: 'prompt';
   step: string;
   preamble?: string;
   prompt: string;
@@ -369,6 +370,7 @@ export interface PromptResult {
 }
 
 export interface DoneResult {
+  readonly kind: 'done';
   done: true;
   finalOutput: unknown;
   completed?: StepResult;
@@ -376,6 +378,7 @@ export interface DoneResult {
 }
 
 export interface ValidationErrorResult {
+  readonly kind: 'error';
   error: 'validation';
   step: string;
   message: string;
@@ -383,12 +386,26 @@ export interface ValidationErrorResult {
 }
 
 export interface RedirectResult {
+  readonly kind: 'redirect';
   redirect: string;
   completed: StepResult;
   stash: unknown;
 }
 
 export type CliResult = PromptResult | DoneResult | ValidationErrorResult | RedirectResult;
+
+export function isPrompt(r: CliResult): r is PromptResult {
+  return r.kind === 'prompt';
+}
+export function isDone(r: CliResult): r is DoneResult {
+  return r.kind === 'done';
+}
+export function isError(r: CliResult): r is ValidationErrorResult {
+  return r.kind === 'error';
+}
+export function isRedirect(r: CliResult): r is RedirectResult {
+  return r.kind === 'redirect';
+}
 
 // --- Session Protocol ---
 

--- a/tasks/2026-04-29_1257_protocol-layer-refactor/TASK.md
+++ b/tasks/2026-04-29_1257_protocol-layer-refactor/TASK.md
@@ -66,15 +66,18 @@ Split the 464-line god module into: `arg-parser.ts`, `dispatcher-handler.ts`, `s
 
 ## Steps
 
-- [ ] Create branch `refactor/protocol-layer-structure`
-- [ ] Commit task document
-- [ ] Phase 1: Add `kind` discriminant to CliResult
-- [ ] Phase 2: SkillEngine interface + HistoryEntry consolidation
-- [ ] Phase 3: InvocationContext
-- [ ] Phase 4: OutputWriter
-- [ ] Phase 5: History validation
-- [ ] Phase 6: Decompose composite-entry.ts
+- [x] Create branch `refactor/protocol-layer-structure`
+- [x] Commit task document
+- [x] Phase 1: Add `kind` discriminant to CliResult
+- [x] Phase 2: SkillEngine interface + HistoryEntry consolidation
+- [x] Phase 3: InvocationContext
+- [x] Phase 4: OutputWriter
+- [x] Phase 5: History validation
+- [x] Phase 6: Decompose composite-entry.ts
 
 ## Notes
 
-_Running log of decisions made during implementation._
+- Phase 1: Also found a manually-constructed `DoneResult` in `handleRedirect` (topic path) that was missing `kind`, causing session serialization to write `type: undefined`. Fixed by adding `kind: 'done'`.
+- Phase 1: The `{ ...startResult, completed: redirect.completed }` spread on subskill redirect needed type narrowing — `startResult` is a `CliResult` union, and adding `completed` to a `ValidationErrorResult` is invalid. Added `kind` check before spreading.
+- Phase 3: Kept `resolveSessionForCommand` in composite-entry.ts since session creation logic differs between composite and single entry points (composite passes tools/isSubagent from flags to session header). Extracted shared helpers (`parseTools`, `parseJsonFlag`, `resolveHandshake`, `resolveParams`) to invocation-context.ts.
+- Phase 6: Kept `resolveSession` in composite-entry.ts (session creation is entry-point-specific). Extracted 5 new modules. `drainPromptless` dedup deferred — the run-skill.ts version tracks `path` (string array) while autoAdvance doesn't, so they're not trivially interchangeable without changing the test harness API.

--- a/tasks/2026-04-29_1257_protocol-layer-refactor/TASK.md
+++ b/tasks/2026-04-29_1257_protocol-layer-refactor/TASK.md
@@ -1,0 +1,80 @@
+# Protocol Layer Refactor: Structure & Data Ownership
+
+## Scope
+
+**In scope:** Restructure the internal protocol layer (`src/protocol/`) and runtime result types to eliminate the class of bugs caused by ad-hoc state derivation, fragile result discrimination, and duplicated logic. Six phases, each independently shippable.
+
+**Out of scope:** Public SDK API (builder, types, primitives), CLI invocation format, session file format, build pipeline, lint rules, SPEC.md.
+
+## Context
+
+Several recent bugs share a root cause — the protocol layer is procedural spaghetti:
+
+- **Params-lost-on-advance (PR #47):** `handleAdvance` constructed the engine with `{}` because each handler independently re-derives state from raw flags, and one path was wrong.
+- **Preamble positioning:** Result object mutation order caused preamble to appear after prompt.
+- **Callback signature asymmetry:** Different callbacks had different views of runtime state.
+
+The pattern: no centralized invocation context, no shared engine interface, no type-safe result discrimination, and duplicated logic across 5+ locations. The fix for each bug was small, but the architecture guarantees the class of bug will recur.
+
+User feedback: "It's not okay to maintain a complex application made out of random functions from random modules. We need structure, shared state, interfaces, abstractions."
+
+## Plan
+
+### Phase 1: Add `kind` discriminant to CliResult
+
+Add `readonly kind: 'prompt' | 'done' | 'error' | 'redirect'` to the four CliResult variant interfaces. Replace all ad-hoc discrimination (`'step' in current && !('error' in current) && ...`) with `result.kind` switches. Add type guard helpers (`isPrompt`, `isDone`, `isError`, `isRedirect`).
+
+**Why:** Lowest-risk, highest-leverage. Eliminates fragile 4-way negation pattern. Makes every subsequent phase easier.
+
+**Files:** `src/types.ts`, `src/runtime/engine.ts`, `src/protocol/auto-advance.ts`, `src/protocol/subskill-engine.ts`, `src/protocol/session.ts`, `src/protocol/composite-entry.ts`, `src/testing/run-skill.ts`, `src/testing/run-composite.ts`, all test files constructing CliResult.
+
+### Phase 2: Shared SkillEngine interface + HistoryEntry consolidation
+
+Define `SkillEngine` interface (`start`, `advance`, `isPromptless`, `replayHistory`). Both `WorkflowEngine` and `SubskillEngine` implement it. Delete duplicate `Advanceable` (auto-advance.ts, run-composite.ts) and duplicate `HistoryEntry` (composite-entry.ts:19, subskill-engine.ts:13). Import canonical `HistoryEntry` from `protocol/types.ts`.
+
+**Why:** Single contract for engine-like objects. Eliminates 3 type duplications.
+
+### Phase 3: InvocationContext — centralize runtime state derivation
+
+New `InvocationContext` / `StartContext` / `AdvanceContext` types with factory functions. Each handler receives a complete, validated context instead of independently re-deriving handshake/params/tools/session from raw flags. `handleStart` goes from 6 positional params to `(skill, ctx: StartContext)`. `handleAdvance` goes from 9 positional params to `(skill, ctx: AdvanceContext)`.
+
+**Why:** Eliminates the entire class of "params-lost" bugs. Makes it impossible to construct an engine without first assembling complete state.
+
+### Phase 4: OutputWriter — consolidate output writing
+
+New `OutputWriter` interface with `writeStart`, `writeAdvance`, `writeIntermediate`. Single `createOutputWriter(session)` factory replaces 4 duplicated output-writing patterns.
+
+**Why:** Eliminates the start-vs-advance pointer confusion and session-vs-stdout duplication.
+
+### Phase 5: Validate history at engine boundary
+
+Use existing `HistoryEntrySchema` to validate history in `replayHistory()`, `reconstructHistory()`, and the `--history` flag parser. Warn-and-skip pattern (matching stash.ts).
+
+**Why:** Prevents corrupted session files or malformed flags from causing confusing deep errors.
+
+### Phase 6: Decompose composite-entry.ts
+
+Split the 464-line god module into: `arg-parser.ts`, `dispatcher-handler.ts`, `subskill-handler.ts`, `topic-handler.ts`, `help-printer.ts`. Deduplicate `drainPromptless` (copy-pasted in run-skill.ts and run-composite.ts).
+
+**Why:** Each module has a single responsibility, is independently testable, and the main entry becomes a ~40-line dispatcher.
+
+### Alternatives rejected
+
+- **Full pipeline abstraction** (a Pipeline class that owns the entire start→advance→output flow): Over-engineering for the current codebase size. InvocationContext + OutputWriter achieve the same goal without introducing a god object.
+- **Event-driven architecture** (emitting events instead of direct calls): Adds indirection without benefit. The protocol layer is request/response, not event-driven.
+- **Breaking CliResult backward compatibility** (removing old properties like `done: true`): Unnecessary risk. Adding `kind` is additive.
+
+## Steps
+
+- [ ] Create branch `refactor/protocol-layer-structure`
+- [ ] Commit task document
+- [ ] Phase 1: Add `kind` discriminant to CliResult
+- [ ] Phase 2: SkillEngine interface + HistoryEntry consolidation
+- [ ] Phase 3: InvocationContext
+- [ ] Phase 4: OutputWriter
+- [ ] Phase 5: History validation
+- [ ] Phase 6: Decompose composite-entry.ts
+
+## Notes
+
+_Running log of decisions made during implementation._


### PR DESCRIPTION
## Summary

- Add `kind` discriminant to all `CliResult` variants, replacing fragile property-check discrimination (`'step' in current && !('error' in current) && ...`) with type-safe `result.kind` switches
- Define shared `SkillEngine` interface implemented by both `WorkflowEngine` and `SubskillEngine`; consolidate 3 duplicate `HistoryEntry` type definitions into 1
- Extract `InvocationContext` with factory functions to centralize handshake/params/tools/session derivation — the 6-param `handleStart` and 9-param `handleAdvance` signatures that caused the params-lost bug are now `(skill, ctx: StartContext)` and `(skill, ctx: AdvanceContext)`
- Extract `OutputWriter` to consolidate 4 duplicated session-vs-stdout output patterns
- Add Zod validation at the engine boundary for replayed history entries; replace unsafe `as StepResult[]` casts in session reconstruction with runtime shape checks
- Decompose the 464-line `composite-entry.ts` god module into 5 focused modules: `arg-parser.ts`, `dispatcher-handler.ts`, `subskill-handler.ts`, `topic-handler.ts`, `help-printer.ts`

## Motivation

Several recent bugs (params-lost-on-advance PR #47, preamble positioning, callback signature asymmetry) shared a root cause: the protocol layer was procedural spaghetti where each handler independently re-derived runtime state from raw flags. No centralized invocation context, no shared engine interface, no type-safe result discrimination, and duplicated logic across 5+ locations.

## Test plan

- [x] `pnpm exec tsc --noEmit` — zero errors at every commit
- [x] `node --test --import tsx/esm 'src/**/*.test.ts'` — all 296 tests pass at every commit
- [x] `pnpm exec prettier --check .` — clean at every commit
- [x] Example tests (get-to-know-you, ts-patterns, contentful-help) pass
- [x] Manual smoke test with a real skill invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)