### PR TITLE
feat: auto-inject allowed-tools defaults in SKILL.md

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1243,7 +1243,7 @@ exec node "$SKILL_DIR/bin/repo-doctor.mjs" "$@"
 
 The build generates a SKILL.md with:
 
-- **Frontmatter:** `name`, `description`, optional `metadata.version`, and optional extension fields set via the `skill()` config — including `argument-hint`, `allowed-tools`, `paths`, `context`, `license`, `compatibility`, `agent`, `model`, `effort`, `disable-model-invocation`, `user-invocable`. The build always emits `allowed-tools` with at least `Bash(scripts/run *)` and `Read` (required for CLI mode); author-declared tools are merged with these defaults.
+- **Frontmatter:** `name`, `description`, optional `metadata.version`, and optional extension fields set via the `skill()` config — including `argument-hint`, `allowed-tools`, `paths`, `context`, `license`, `compatibility`, `agent`, `model`, `effort`, `disable-model-invocation`, `user-invocable`. The build always emits `allowed-tools` with at least `Bash(scripts/run *)`, `Read` (required for CLI mode), and the skill's MCP tool names (`mcp__<name>__start`, `mcp__<name>__advance`, plus `mcp__<name>__topic` and `mcp__<name>__topics` when topics exist); author-declared tools are merged with these defaults.
 - **Invocation instructions:** step-by-step pattern for the agent (start → advance loop → parse JSON → follow schema)
 - **Step descriptions:** each step's purpose (extracted from the skill definition)
 - **Reference pointers:** links to files in `references/` (loaded on demand)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1243,7 +1243,7 @@ exec node "$SKILL_DIR/bin/repo-doctor.mjs" "$@"
 
 The build generates a SKILL.md with:
 
-- **Frontmatter:** `name`, `description`, optional `metadata.version`, and optional extension fields set via the `skill()` config — including `argument-hint`, `allowed-tools`, `paths`, `context`, `license`, `compatibility`, `agent`, `model`, `effort`, `disable-model-invocation`, `user-invocable`
+- **Frontmatter:** `name`, `description`, optional `metadata.version`, and optional extension fields set via the `skill()` config — including `argument-hint`, `allowed-tools`, `paths`, `context`, `license`, `compatibility`, `agent`, `model`, `effort`, `disable-model-invocation`, `user-invocable`. The build always emits `allowed-tools` with at least `Bash(scripts/run *)` and `Read` (required for CLI mode); author-declared tools are merged with these defaults.
 - **Invocation instructions:** step-by-step pattern for the agent (start → advance loop → parse JSON → follow schema)
 - **Step descriptions:** each step's purpose (extracted from the skill definition)
 - **Reference pointers:** links to files in `references/` (loaded on demand)

--- a/docs-site/src/pages/api/index.mdx
+++ b/docs-site/src/pages/api/index.mdx
@@ -38,7 +38,7 @@ skill({ name, entry, system?, params?, stash?, observers?, finalOutput?, skillMd
 | `package`                | `PackageConfig`                                | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`                                       | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]`                           | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged        |
+| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged       |
 | `paths`                  | `string \| string[]`                           | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`                                       | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`                                       | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |
@@ -204,7 +204,7 @@ reference({ name, description, version?, resolveVersion?, package? })
 | `package`                | `PackageConfig`      | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`             | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]` | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged        |
+| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged       |
 | `paths`                  | `string \| string[]` | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`             | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`             | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |

--- a/docs-site/src/pages/api/index.mdx
+++ b/docs-site/src/pages/api/index.mdx
@@ -38,7 +38,7 @@ skill({ name, entry, system?, params?, stash?, observers?, finalOutput?, skillMd
 | `package`                | `PackageConfig`                                | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`                                       | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]`                           | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged       |
+| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build auto-includes CLI and MCP defaults; author tools are merged                     |
 | `paths`                  | `string \| string[]`                           | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`                                       | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`                                       | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |
@@ -204,7 +204,7 @@ reference({ name, description, version?, resolveVersion?, package? })
 | `package`                | `PackageConfig`      | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`             | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]` | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged       |
+| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build auto-includes CLI and MCP defaults; author tools are merged                     |
 | `paths`                  | `string \| string[]` | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`             | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`             | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |

--- a/docs-site/src/pages/api/index.mdx
+++ b/docs-site/src/pages/api/index.mdx
@@ -38,7 +38,7 @@ skill({ name, entry, system?, params?, stash?, observers?, finalOutput?, skillMd
 | `package`                | `PackageConfig`                                | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`                                       | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]`                           | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]`                           | no       | Pre-approved tools. Emitted as `allowed-tools` in SKILL.md frontmatter                                               |
+| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged        |
 | `paths`                  | `string \| string[]`                           | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`                                       | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`                                       | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |
@@ -204,7 +204,7 @@ reference({ name, description, version?, resolveVersion?, package? })
 | `package`                | `PackageConfig`      | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`             | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]` | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]` | no       | Pre-approved tools. Emitted as `allowed-tools` in SKILL.md frontmatter                                               |
+| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged        |
 | `paths`                  | `string \| string[]` | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`             | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`             | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |

--- a/docs-site/src/pages/guides/reference-skills.mdx
+++ b/docs-site/src/pages/guides/reference-skills.mdx
@@ -37,7 +37,7 @@ export default reference({
 | `version`                | `string`             | No       | Semver version. Defaults to `'0.0.0'`.                                                                       |
 | `argumentHint`           | `string`             | No       | Autocomplete hint text. Emitted as `argument-hint` in frontmatter.                                           |
 | `arguments`              | `string \| string[]` | No       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in frontmatter. |
-| `allowedTools`           | `string \| string[]` | No       | Pre-approved tools. Emitted as `allowed-tools` in frontmatter.                                               |
+| `allowedTools`           | `string \| string[]` | No       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`.                       |
 | `paths`                  | `string \| string[]` | No       | Glob patterns for file-based activation. Emitted as `paths`.                                                 |
 | `context`                | `string`             | No       | Execution context (e.g. `'fork'`). Emitted as `context`.                                                     |
 | `license`                | `string`             | No       | License name or reference. Emitted as `license`.                                                             |

--- a/docs-site/src/pages/guides/reference-skills.mdx
+++ b/docs-site/src/pages/guides/reference-skills.mdx
@@ -37,7 +37,7 @@ export default reference({
 | `version`                | `string`             | No       | Semver version. Defaults to `'0.0.0'`.                                                                       |
 | `argumentHint`           | `string`             | No       | Autocomplete hint text. Emitted as `argument-hint` in frontmatter.                                           |
 | `arguments`              | `string \| string[]` | No       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in frontmatter. |
-| `allowedTools`           | `string \| string[]` | No       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`.                       |
+| `allowedTools`           | `string \| string[]` | No       | Additional pre-approved tools. Build auto-includes CLI and MCP defaults.                                     |
 | `paths`                  | `string \| string[]` | No       | Glob patterns for file-based activation. Emitted as `paths`.                                                 |
 | `context`                | `string`             | No       | Execution context (e.g. `'fork'`). Emitted as `context`.                                                     |
 | `license`                | `string`             | No       | License name or reference. Emitted as `license`.                                                             |

--- a/docs-site/src/pages/guides/workflow-skills.mdx
+++ b/docs-site/src/pages/guides/workflow-skills.mdx
@@ -47,7 +47,7 @@ export default skill({
 | `skillMd`                | `string \| ((skill) => string)` | No       | Custom SKILL.md template. Overrides the generated default.                                                   |
 | `argumentHint`           | `string`                        | No       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter.                                  |
 | `arguments`              | `string \| string[]`            | No       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in frontmatter. |
-| `allowedTools`           | `string \| string[]`            | No       | Pre-approved tools. Emitted as `allowed-tools` in SKILL.md frontmatter.                                      |
+| `allowedTools`           | `string \| string[]`            | No       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`.                       |
 | `paths`                  | `string \| string[]`            | No       | Glob patterns for file-based activation. Emitted as `paths` in frontmatter.                                  |
 | `context`                | `string`                        | No       | Execution context (e.g. `'fork'`). Emitted as `context` in frontmatter.                                      |
 | `license`                | `string`                        | No       | License name or reference. Emitted as `license` in frontmatter.                                              |

--- a/docs-site/src/pages/guides/workflow-skills.mdx
+++ b/docs-site/src/pages/guides/workflow-skills.mdx
@@ -47,7 +47,7 @@ export default skill({
 | `skillMd`                | `string \| ((skill) => string)` | No       | Custom SKILL.md template. Overrides the generated default.                                                   |
 | `argumentHint`           | `string`                        | No       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter.                                  |
 | `arguments`              | `string \| string[]`            | No       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in frontmatter. |
-| `allowedTools`           | `string \| string[]`            | No       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`.                       |
+| `allowedTools`           | `string \| string[]`            | No       | Additional pre-approved tools. Build auto-includes CLI and MCP defaults.                                     |
 | `paths`                  | `string \| string[]`            | No       | Glob patterns for file-based activation. Emitted as `paths` in frontmatter.                                  |
 | `context`                | `string`                        | No       | Execution context (e.g. `'fork'`). Emitted as `context` in frontmatter.                                      |
 | `license`                | `string`                        | No       | License name or reference. Emitted as `license` in frontmatter.                                              |

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,7 @@ skill({ name, entry, system?, params?, stash?, observers?, finalOutput?, skillMd
 | `package`                | `PackageConfig`                                | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`                                       | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]`                           | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged        |
+| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged       |
 | `paths`                  | `string \| string[]`                           | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`                                       | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`                                       | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |
@@ -214,7 +214,7 @@ reference({ name, description, version?, resolveVersion?, package? })
 | `package`                | `PackageConfig`      | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`             | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]` | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged        |
+| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged       |
 | `paths`                  | `string \| string[]` | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`             | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`             | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,7 @@ skill({ name, entry, system?, params?, stash?, observers?, finalOutput?, skillMd
 | `package`                | `PackageConfig`                                | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`                                       | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]`                           | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]`                           | no       | Pre-approved tools. Emitted as `allowed-tools` in SKILL.md frontmatter                                               |
+| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged        |
 | `paths`                  | `string \| string[]`                           | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`                                       | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`                                       | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |
@@ -214,7 +214,7 @@ reference({ name, description, version?, resolveVersion?, package? })
 | `package`                | `PackageConfig`      | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`             | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]` | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]` | no       | Pre-approved tools. Emitted as `allowed-tools` in SKILL.md frontmatter                                               |
+| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged        |
 | `paths`                  | `string \| string[]` | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`             | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`             | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,7 @@ skill({ name, entry, system?, params?, stash?, observers?, finalOutput?, skillMd
 | `package`                | `PackageConfig`                                | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`                                       | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]`                           | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged       |
+| `allowedTools`           | `string \| string[]`                           | no       | Additional pre-approved tools. Build auto-includes CLI and MCP defaults; author tools are merged                     |
 | `paths`                  | `string \| string[]`                           | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`                                       | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`                                       | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |
@@ -214,7 +214,7 @@ reference({ name, description, version?, resolveVersion?, package? })
 | `package`                | `PackageConfig`      | no       | Fields written to the output `package.json` (see [Package Config](#package-config))                                  |
 | `argumentHint`           | `string`             | no       | Autocomplete hint text. Emitted as `argument-hint` in SKILL.md frontmatter                                           |
 | `arguments`              | `string \| string[]` | no       | Named positional arguments for `$name` substitution in skill content. Emitted as `arguments` in SKILL.md frontmatter |
-| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build always includes `Bash(scripts/run *)` and `Read`; author tools are merged       |
+| `allowedTools`           | `string \| string[]` | no       | Additional pre-approved tools. Build auto-includes CLI and MCP defaults; author tools are merged                     |
 | `paths`                  | `string \| string[]` | no       | Glob patterns for file-based auto-activation. Emitted as `paths` in SKILL.md frontmatter                             |
 | `context`                | `string`             | no       | Execution context (e.g. `'fork'`). Emitted as `context` in SKILL.md frontmatter                                      |
 | `license`                | `string`             | no       | License name or reference. Emitted as `license` in SKILL.md frontmatter                                              |

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: contentful-help
-description: "Diagnose, configure, and look up Contentful topics. Trigger keywords: contentful help, contentful doctor, contentful setup"
+description: 'Diagnose, configure, and look up Contentful topics. Trigger keywords: contentful help, contentful doctor, contentful setup'
 metadata:
-  version: "1.0.0"
-argument-hint: "[doctor|setup]"
-allowed-tools: "Bash(scripts/run *) Read mcp__contentful-help__start mcp__contentful-help__advance mcp__contentful-help__topic mcp__contentful-help__topics"
+  version: '1.0.0'
+argument-hint: '[doctor|setup]'
+allowed-tools: 'Bash(scripts/run *) Read mcp__contentful-help__start mcp__contentful-help__advance mcp__contentful-help__topic mcp__contentful-help__topics'
 disable-model-invocation: true
 ---
 
@@ -71,6 +71,7 @@ In the examples below, `<skill>/scripts/run` is a placeholder for this absolute 
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
+
 - Claude Code: `--host claude-code`
 - Codex: `--host codex`
 - OpenCode: `--host opencode`
@@ -156,7 +157,6 @@ contains the skill's result. Present it to the user.
 - **choose**: (dynamic)
 - **get-space**: Ask the user for their Contentful space ID, or detect it from CONTENTFUL_SPACE_ID in the environm...
 - **ask-topic**: (dynamic)
-
 
 ## Sub-skills
 

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: contentful-help
-description: 'Diagnose, configure, and look up Contentful topics. Trigger keywords: contentful help, contentful doctor, contentful setup'
+description: "Diagnose, configure, and look up Contentful topics. Trigger keywords: contentful help, contentful doctor, contentful setup"
 metadata:
-  version: '1.0.0'
-argument-hint: '[doctor|setup]'
-allowed-tools: 'Bash(scripts/run *) Read mcp__contentful-help__start mcp__contentful-help__advance mcp__contentful-help__topic mcp__contentful-help__topics'
+  version: "1.0.0"
+argument-hint: "[doctor|setup]"
+allowed-tools: "Bash(scripts/run *) Read mcp__contentful-help__start mcp__contentful-help__advance mcp__contentful-help__topic mcp__contentful-help__topics"
 disable-model-invocation: true
 ---
 
@@ -68,13 +68,9 @@ Bash commands — do not `cd` into the skill directory.
 
 In the examples below, `<skill>/scripts/run` is a placeholder for this absolute path.
 
-**Before you begin:** Tell the user that they may be prompted to allow `scripts/run` and to
-read a file called `skill-kit-<id>.jsonl`. They should allow both permanently.
-
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
-
 - Claude Code: `--host claude-code`
 - Codex: `--host codex`
 - OpenCode: `--host opencode`
@@ -160,6 +156,7 @@ contains the skill's result. Present it to the user.
 - **choose**: (dynamic)
 - **get-space**: Ask the user for their Contentful space ID, or detect it from CONTENTFUL_SPACE_ID in the environm...
 - **ask-topic**: (dynamic)
+
 
 ## Sub-skills
 

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -4,6 +4,7 @@ description: 'Diagnose, configure, and look up Contentful topics. Trigger keywor
 metadata:
   version: '1.0.0'
 argument-hint: '[doctor|setup]'
+allowed-tools: 'Bash(scripts/run *) Read'
 disable-model-invocation: true
 ---
 

--- a/examples/contentful-help/skill/SKILL.md
+++ b/examples/contentful-help/skill/SKILL.md
@@ -4,7 +4,7 @@ description: 'Diagnose, configure, and look up Contentful topics. Trigger keywor
 metadata:
   version: '1.0.0'
 argument-hint: '[doctor|setup]'
-allowed-tools: 'Bash(scripts/run *) Read'
+allowed-tools: 'Bash(scripts/run *) Read mcp__contentful-help__start mcp__contentful-help__advance mcp__contentful-help__topic mcp__contentful-help__topics'
 disable-model-invocation: true
 ---
 

--- a/examples/game-jam/skill/SKILL.md
+++ b/examples/game-jam/skill/SKILL.md
@@ -4,6 +4,7 @@ description: 'A guided game creation skill that walks you through designing, pla
 metadata:
   version: '1.0.0'
 argument-hint: '[game-type]'
+allowed-tools: 'Bash(scripts/run *) Read'
 compatibility: 'Requires a modern browser for the game preview'
 ---
 

--- a/examples/game-jam/skill/SKILL.md
+++ b/examples/game-jam/skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: game-jam
-description: 'A guided game creation skill that walks you through designing, planning, and building a browser-based Tetris game. Demonstrates all SDK primitives: askUser, confirm, plan, checklist, and subagent. Trigger keywords: game jam, build a game, tetris, game tutorial'
+description: "A guided game creation skill that walks you through designing, planning, and building a browser-based Tetris game. Demonstrates all SDK primitives: askUser, confirm, plan, checklist, and subagent. Trigger keywords: game jam, build a game, tetris, game tutorial"
 metadata:
-  version: '1.0.0'
-argument-hint: '[game-type]'
-allowed-tools: 'Bash(scripts/run *) Read mcp__game-jam__start mcp__game-jam__advance'
-compatibility: 'Requires a modern browser for the game preview'
+  version: "1.0.0"
+argument-hint: "[game-type]"
+allowed-tools: "Bash(scripts/run *) Read mcp__game-jam__start mcp__game-jam__advance"
+compatibility: "Requires a modern browser for the game preview"
 ---
 
 # game-jam
@@ -68,13 +68,9 @@ Bash commands — do not `cd` into the skill directory.
 
 In the examples below, `<skill>/scripts/run` is a placeholder for this absolute path.
 
-**Before you begin:** Tell the user that they may be prompted to allow `scripts/run` and to
-read a file called `skill-kit-<id>.jsonl`. They should allow both permanently.
-
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
-
 - Claude Code: `--host claude-code`
 - Codex: `--host codex`
 - OpenCode: `--host opencode`
@@ -107,16 +103,16 @@ with the registry (since top-level agents often under-report their tools).
 
 ## Parameters
 
-| Name         | Type                                             | Required | Default          |
-| ------------ | ------------------------------------------------ | -------- | ---------------- |
-| `difficulty` | `"beginner"` \| `"intermediate"` \| `"advanced"` | No       | `"intermediate"` |
+| Name | Type | Required | Default |
+|------|------|----------|---------|
+| `difficulty` | `"beginner"` \| `"intermediate"` \| `"advanced"` | No | `"intermediate"` |
 
 All parameters have defaults — `--params '{}'` is valid.
 
 Example:
 
 ```json
-{ "difficulty": "intermediate" }
+{"difficulty":"intermediate"}
 ```
 
 ### Step 1: Start with a session

--- a/examples/game-jam/skill/SKILL.md
+++ b/examples/game-jam/skill/SKILL.md
@@ -4,7 +4,7 @@ description: 'A guided game creation skill that walks you through designing, pla
 metadata:
   version: '1.0.0'
 argument-hint: '[game-type]'
-allowed-tools: 'Bash(scripts/run *) Read'
+allowed-tools: 'Bash(scripts/run *) Read mcp__game-jam__start mcp__game-jam__advance'
 compatibility: 'Requires a modern browser for the game preview'
 ---
 

--- a/examples/game-jam/skill/SKILL.md
+++ b/examples/game-jam/skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: game-jam
-description: "A guided game creation skill that walks you through designing, planning, and building a browser-based Tetris game. Demonstrates all SDK primitives: askUser, confirm, plan, checklist, and subagent. Trigger keywords: game jam, build a game, tetris, game tutorial"
+description: 'A guided game creation skill that walks you through designing, planning, and building a browser-based Tetris game. Demonstrates all SDK primitives: askUser, confirm, plan, checklist, and subagent. Trigger keywords: game jam, build a game, tetris, game tutorial'
 metadata:
-  version: "1.0.0"
-argument-hint: "[game-type]"
-allowed-tools: "Bash(scripts/run *) Read mcp__game-jam__start mcp__game-jam__advance"
-compatibility: "Requires a modern browser for the game preview"
+  version: '1.0.0'
+argument-hint: '[game-type]'
+allowed-tools: 'Bash(scripts/run *) Read mcp__game-jam__start mcp__game-jam__advance'
+compatibility: 'Requires a modern browser for the game preview'
 ---
 
 # game-jam
@@ -71,6 +71,7 @@ In the examples below, `<skill>/scripts/run` is a placeholder for this absolute 
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
+
 - Claude Code: `--host claude-code`
 - Codex: `--host codex`
 - OpenCode: `--host opencode`
@@ -103,16 +104,16 @@ with the registry (since top-level agents often under-report their tools).
 
 ## Parameters
 
-| Name | Type | Required | Default |
-|------|------|----------|---------|
-| `difficulty` | `"beginner"` \| `"intermediate"` \| `"advanced"` | No | `"intermediate"` |
+| Name         | Type                                             | Required | Default          |
+| ------------ | ------------------------------------------------ | -------- | ---------------- |
+| `difficulty` | `"beginner"` \| `"intermediate"` \| `"advanced"` | No       | `"intermediate"` |
 
 All parameters have defaults — `--params '{}'` is valid.
 
 Example:
 
 ```json
-{"difficulty":"intermediate"}
+{ "difficulty": "intermediate" }
 ```
 
 ### Step 1: Start with a session

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: get-to-know-you
-description: 'A playful interview that gets to know the user and produces a profile trading card. Use when the user wants to introduce themselves or when you want to break the ice. Trigger keywords: introduce myself, trading card, get to know me, ice breaker'
+description: "A playful interview that gets to know the user and produces a profile trading card. Use when the user wants to introduce themselves or when you want to break the ice. Trigger keywords: introduce myself, trading card, get to know me, ice breaker"
 metadata:
-  version: '1.0.0'
-argument-hint: '[name]'
-allowed-tools: 'Bash(scripts/run *) Read mcp__get-to-know-you__start mcp__get-to-know-you__advance'
+  version: "1.0.0"
+argument-hint: "[name]"
+allowed-tools: "Bash(scripts/run *) Read mcp__get-to-know-you__start mcp__get-to-know-you__advance"
 ---
 
 # get-to-know-you
@@ -67,13 +67,9 @@ Bash commands — do not `cd` into the skill directory.
 
 In the examples below, `<skill>/scripts/run` is a placeholder for this absolute path.
 
-**Before you begin:** Tell the user that they may be prompted to allow `scripts/run` and to
-read a file called `skill-kit-<id>.jsonl`. They should allow both permanently.
-
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
-
 - Claude Code: `--host claude-code`
 - Codex: `--host codex`
 - OpenCode: `--host opencode`
@@ -106,16 +102,16 @@ with the registry (since top-level agents often under-report their tools).
 
 ## Parameters
 
-| Name       | Type   | Required | Default        |
-| ---------- | ------ | -------- | -------------- |
-| `greeting` | string | No       | `"Hey there!"` |
+| Name | Type | Required | Default |
+|------|------|----------|---------|
+| `greeting` | string | No | `"Hey there!"` |
 
 All parameters have defaults — `--params '{}'` is valid.
 
 Example:
 
 ```json
-{ "greeting": "Hey there!" }
+{"greeting":"Hey there!"}
 ```
 
 ### Step 1: Start with a session

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: get-to-know-you
-description: "A playful interview that gets to know the user and produces a profile trading card. Use when the user wants to introduce themselves or when you want to break the ice. Trigger keywords: introduce myself, trading card, get to know me, ice breaker"
+description: 'A playful interview that gets to know the user and produces a profile trading card. Use when the user wants to introduce themselves or when you want to break the ice. Trigger keywords: introduce myself, trading card, get to know me, ice breaker'
 metadata:
-  version: "1.0.0"
-argument-hint: "[name]"
-allowed-tools: "Bash(scripts/run *) Read mcp__get-to-know-you__start mcp__get-to-know-you__advance"
+  version: '1.0.0'
+argument-hint: '[name]'
+allowed-tools: 'Bash(scripts/run *) Read mcp__get-to-know-you__start mcp__get-to-know-you__advance'
 ---
 
 # get-to-know-you
@@ -70,6 +70,7 @@ In the examples below, `<skill>/scripts/run` is a placeholder for this absolute 
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
+
 - Claude Code: `--host claude-code`
 - Codex: `--host codex`
 - OpenCode: `--host opencode`
@@ -102,16 +103,16 @@ with the registry (since top-level agents often under-report their tools).
 
 ## Parameters
 
-| Name | Type | Required | Default |
-|------|------|----------|---------|
-| `greeting` | string | No | `"Hey there!"` |
+| Name       | Type   | Required | Default        |
+| ---------- | ------ | -------- | -------------- |
+| `greeting` | string | No       | `"Hey there!"` |
 
 All parameters have defaults — `--params '{}'` is valid.
 
 Example:
 
 ```json
-{"greeting":"Hey there!"}
+{ "greeting": "Hey there!" }
 ```
 
 ### Step 1: Start with a session

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -4,7 +4,7 @@ description: 'A playful interview that gets to know the user and produces a prof
 metadata:
   version: '1.0.0'
 argument-hint: '[name]'
-allowed-tools: 'Bash(scripts/run *) Read'
+allowed-tools: 'Bash(scripts/run *) Read mcp__get-to-know-you__start mcp__get-to-know-you__advance'
 ---
 
 # get-to-know-you

--- a/examples/get-to-know-you/skill/SKILL.md
+++ b/examples/get-to-know-you/skill/SKILL.md
@@ -4,6 +4,7 @@ description: 'A playful interview that gets to know the user and produces a prof
 metadata:
   version: '1.0.0'
 argument-hint: '[name]'
+allowed-tools: 'Bash(scripts/run *) Read'
 ---
 
 # get-to-know-you

--- a/examples/primitives-showcase/skill/SKILL.md
+++ b/examples/primitives-showcase/skill/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: primitives-showcase
-description: 'Exercises every SDK primitive in a single skill. Used as a reference and integration test.'
+description: "Exercises every SDK primitive in a single skill. Used as a reference and integration test."
 metadata:
-  version: '1.0.0'
-argument-hint: '[theme]'
-allowed-tools: 'Bash(scripts/run *) Read mcp__primitives-showcase__start mcp__primitives-showcase__advance'
+  version: "1.0.0"
+argument-hint: "[theme]"
+allowed-tools: "Bash(scripts/run *) Read mcp__primitives-showcase__start mcp__primitives-showcase__advance"
 ---
 
 # primitives-showcase
@@ -67,13 +67,9 @@ Bash commands — do not `cd` into the skill directory.
 
 In the examples below, `<skill>/scripts/run` is a placeholder for this absolute path.
 
-**Before you begin:** Tell the user that they may be prompted to allow `scripts/run` and to
-read a file called `skill-kit-<id>.jsonl`. They should allow both permanently.
-
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
-
 - Claude Code: `--host claude-code`
 - Codex: `--host codex`
 - OpenCode: `--host opencode`

--- a/examples/primitives-showcase/skill/SKILL.md
+++ b/examples/primitives-showcase/skill/SKILL.md
@@ -4,7 +4,7 @@ description: 'Exercises every SDK primitive in a single skill. Used as a referen
 metadata:
   version: '1.0.0'
 argument-hint: '[theme]'
-allowed-tools: 'Bash(scripts/run *) Read'
+allowed-tools: 'Bash(scripts/run *) Read mcp__primitives-showcase__start mcp__primitives-showcase__advance'
 ---
 
 # primitives-showcase

--- a/examples/primitives-showcase/skill/SKILL.md
+++ b/examples/primitives-showcase/skill/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: primitives-showcase
-description: "Exercises every SDK primitive in a single skill. Used as a reference and integration test."
+description: 'Exercises every SDK primitive in a single skill. Used as a reference and integration test.'
 metadata:
-  version: "1.0.0"
-argument-hint: "[theme]"
-allowed-tools: "Bash(scripts/run *) Read mcp__primitives-showcase__start mcp__primitives-showcase__advance"
+  version: '1.0.0'
+argument-hint: '[theme]'
+allowed-tools: 'Bash(scripts/run *) Read mcp__primitives-showcase__start mcp__primitives-showcase__advance'
 ---
 
 # primitives-showcase
@@ -70,6 +70,7 @@ In the examples below, `<skill>/scripts/run` is a placeholder for this absolute 
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as `--host`:
+
 - Claude Code: `--host claude-code`
 - Codex: `--host codex`
 - OpenCode: `--host opencode`

--- a/examples/primitives-showcase/skill/SKILL.md
+++ b/examples/primitives-showcase/skill/SKILL.md
@@ -4,6 +4,7 @@ description: 'Exercises every SDK primitive in a single skill. Used as a referen
 metadata:
   version: '1.0.0'
 argument-hint: '[theme]'
+allowed-tools: 'Bash(scripts/run *) Read'
 ---
 
 # primitives-showcase

--- a/examples/ts-patterns/skill/SKILL.md
+++ b/examples/ts-patterns/skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ts-patterns
-description: "TypeScript patterns and idioms reference. Use when writing TypeScript and need a quick refresher on generics, discriminated unions, builder patterns, or error handling."
+description: 'TypeScript patterns and idioms reference. Use when writing TypeScript and need a quick refresher on generics, discriminated unions, builder patterns, or error handling.'
 metadata:
-  version: "1.0.0"
-argument-hint: "[topic]"
-allowed-tools: "Bash(scripts/run *) Read mcp__ts-patterns__topic mcp__ts-patterns__topics"
-paths: "**/*.ts"
+  version: '1.0.0'
+argument-hint: '[topic]'
+allowed-tools: 'Bash(scripts/run *) Read mcp__ts-patterns__topic mcp__ts-patterns__topics'
+paths: '**/*.ts'
 ---
 
 # ts-patterns

--- a/examples/ts-patterns/skill/SKILL.md
+++ b/examples/ts-patterns/skill/SKILL.md
@@ -4,6 +4,7 @@ description: 'TypeScript patterns and idioms reference. Use when writing TypeScr
 metadata:
   version: '1.0.0'
 argument-hint: '[topic]'
+allowed-tools: 'Bash(scripts/run *) Read'
 paths: '**/*.ts'
 ---
 

--- a/examples/ts-patterns/skill/SKILL.md
+++ b/examples/ts-patterns/skill/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ts-patterns
-description: 'TypeScript patterns and idioms reference. Use when writing TypeScript and need a quick refresher on generics, discriminated unions, builder patterns, or error handling.'
+description: "TypeScript patterns and idioms reference. Use when writing TypeScript and need a quick refresher on generics, discriminated unions, builder patterns, or error handling."
 metadata:
-  version: '1.0.0'
-argument-hint: '[topic]'
-allowed-tools: 'Bash(scripts/run *) Read mcp__ts-patterns__topic mcp__ts-patterns__topics'
-paths: '**/*.ts'
+  version: "1.0.0"
+argument-hint: "[topic]"
+allowed-tools: "Bash(scripts/run *) Read mcp__ts-patterns__topic mcp__ts-patterns__topics"
+paths: "**/*.ts"
 ---
 
 # ts-patterns

--- a/examples/ts-patterns/skill/SKILL.md
+++ b/examples/ts-patterns/skill/SKILL.md
@@ -4,7 +4,7 @@ description: 'TypeScript patterns and idioms reference. Use when writing TypeScr
 metadata:
   version: '1.0.0'
 argument-hint: '[topic]'
-allowed-tools: 'Bash(scripts/run *) Read'
+allowed-tools: 'Bash(scripts/run *) Read mcp__ts-patterns__topic mcp__ts-patterns__topics'
 paths: '**/*.ts'
 ---
 

--- a/src/build/index.test.ts
+++ b/src/build/index.test.ts
@@ -123,7 +123,11 @@ test('generateSkillMd merges author allowed-tools string with defaults', () => {
     .build();
 
   const result = generateSkillMd(s);
-  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Write Edit"'));
+  assert.ok(
+    result.includes(
+      'allowed-tools: "Bash(scripts/run *) Read mcp__tools-str__start mcp__tools-str__advance Write Edit"',
+    ),
+  );
 });
 
 test('generateSkillMd merges author allowed-tools array with defaults', () => {
@@ -132,7 +136,11 @@ test('generateSkillMd merges author allowed-tools array with defaults', () => {
     .build();
 
   const result = generateSkillMd(s);
-  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Write Edit"'));
+  assert.ok(
+    result.includes(
+      'allowed-tools: "Bash(scripts/run *) Read mcp__tools-arr__start mcp__tools-arr__advance Write Edit"',
+    ),
+  );
 });
 
 test('generateSkillMd deduplicates author tools that overlap with defaults', () => {
@@ -141,7 +149,9 @@ test('generateSkillMd deduplicates author tools that overlap with defaults', () 
     .build();
 
   const result = generateSkillMd(s);
-  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Write"'));
+  assert.ok(
+    result.includes('allowed-tools: "Bash(scripts/run *) Read mcp__tools-dup__start mcp__tools-dup__advance Write"'),
+  );
 });
 
 test('generateSkillMd emits paths as string in frontmatter', () => {
@@ -226,7 +236,7 @@ test('generateSkillMd always emits allowed-tools with defaults even when not set
     .build();
 
   const result = generateSkillMd(s);
-  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read"'));
+  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read mcp__minimal__start mcp__minimal__advance"'));
 });
 
 test('generateSkillMd omits other frontmatter extension fields when not set', () => {
@@ -274,7 +284,7 @@ test('generateSkillMd emits all frontmatter extension fields together', () => {
   const result = generateSkillMd(s);
   assert.ok(result.includes('argument-hint: "What to check"'));
   assert.ok(result.includes('arguments: ["target", "level"]'));
-  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Bash"'));
+  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read mcp__full__start mcp__full__advance Bash"'));
   assert.ok(result.includes('paths: ["*.config.ts"]'));
   assert.ok(result.includes('context: "fork"'));
   assert.ok(result.includes('version: "2.0.0"'));
@@ -320,7 +330,9 @@ test('generateReferenceMd emits frontmatter extension fields', () => {
 
   const result = generateReferenceMd(ref);
   assert.ok(result.includes('argument-hint: "topic name"'));
-  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Bash"'));
+  assert.ok(
+    result.includes('allowed-tools: "Bash(scripts/run *) Read mcp__ref-with-fm__topic mcp__ref-with-fm__topics Bash"'),
+  );
   assert.ok(result.includes('paths: "docs/**/*.md"'));
   assert.ok(result.includes('context: "fork"'));
   assert.ok(result.includes('license: "MIT"'));
@@ -341,7 +353,9 @@ test('generateReferenceMd always emits allowed-tools with defaults', () => {
     .build();
 
   const result = generateReferenceMd(ref);
-  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read"'));
+  assert.ok(
+    result.includes('allowed-tools: "Bash(scripts/run *) Read mcp__ref-minimal__topic mcp__ref-minimal__topics"'),
+  );
 });
 
 test('generateReferenceMd omits other frontmatter extension fields when not set', () => {
@@ -528,6 +542,8 @@ test('generateSkillMd includes sub-skills and topics sections', () => {
   assert.ok(result.includes('**faq**: Frequently asked questions'));
   assert.ok(result.includes('scripts/run topics'));
   assert.ok(result.includes('scripts/run topic <name>'));
+  assert.ok(result.includes('mcp__composite__topic'));
+  assert.ok(result.includes('mcp__composite__topics'));
 });
 
 test('generateSkillMd documents params with defaults', () => {

--- a/src/build/index.test.ts
+++ b/src/build/index.test.ts
@@ -117,22 +117,31 @@ test('generateSkillMd emits arguments as string in frontmatter', () => {
   assert.ok(result.includes('arguments: "issue branch"'));
 });
 
-test('generateSkillMd emits allowed-tools as string in frontmatter', () => {
-  const s = skill({ name: 'tools-str', entry: 'a', allowedTools: 'Bash Read Write' })
+test('generateSkillMd merges author allowed-tools string with defaults', () => {
+  const s = skill({ name: 'tools-str', entry: 'a', allowedTools: 'Write Edit' })
     .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
     .build();
 
   const result = generateSkillMd(s);
-  assert.ok(result.includes('allowed-tools: "Bash Read Write"'));
+  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Write Edit"'));
 });
 
-test('generateSkillMd emits allowed-tools array as space-separated string', () => {
-  const s = skill({ name: 'tools-arr', entry: 'a', allowedTools: ['Bash', 'Read', 'Write'] })
+test('generateSkillMd merges author allowed-tools array with defaults', () => {
+  const s = skill({ name: 'tools-arr', entry: 'a', allowedTools: ['Write', 'Edit'] })
     .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
     .build();
 
   const result = generateSkillMd(s);
-  assert.ok(result.includes('allowed-tools: "Bash Read Write"'));
+  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Write Edit"'));
+});
+
+test('generateSkillMd deduplicates author tools that overlap with defaults', () => {
+  const s = skill({ name: 'tools-dup', entry: 'a', allowedTools: ['Read', 'Write'] })
+    .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
+    .build();
+
+  const result = generateSkillMd(s);
+  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Write"'));
 });
 
 test('generateSkillMd emits paths as string in frontmatter', () => {
@@ -211,7 +220,16 @@ test('generateSkillMd emits user-invocable in frontmatter', () => {
   assert.ok(generateSkillMd(s).includes('user-invocable: false'));
 });
 
-test('generateSkillMd omits frontmatter extension fields when not set', () => {
+test('generateSkillMd always emits allowed-tools with defaults even when not set', () => {
+  const s = skill({ name: 'minimal', entry: 'a' })
+    .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
+    .build();
+
+  const result = generateSkillMd(s);
+  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read"'));
+});
+
+test('generateSkillMd omits other frontmatter extension fields when not set', () => {
   const s = skill({ name: 'minimal', entry: 'a' })
     .step('a', { prompt: 'Go.', output: z.object({}), next: { terminal: true } })
     .build();
@@ -220,7 +238,6 @@ test('generateSkillMd omits frontmatter extension fields when not set', () => {
   const frontmatter = result.split('---')[1]!;
   assert.ok(!frontmatter.includes('argument-hint'));
   assert.ok(!frontmatter.includes('arguments'));
-  assert.ok(!frontmatter.includes('allowed-tools'));
   assert.ok(!frontmatter.includes('paths'));
   assert.ok(!frontmatter.includes('context'));
   assert.ok(!frontmatter.includes('license'));
@@ -257,7 +274,7 @@ test('generateSkillMd emits all frontmatter extension fields together', () => {
   const result = generateSkillMd(s);
   assert.ok(result.includes('argument-hint: "What to check"'));
   assert.ok(result.includes('arguments: ["target", "level"]'));
-  assert.ok(result.includes('allowed-tools: "Bash Read"'));
+  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Bash"'));
   assert.ok(result.includes('paths: ["*.config.ts"]'));
   assert.ok(result.includes('context: "fork"'));
   assert.ok(result.includes('version: "2.0.0"'));
@@ -303,7 +320,7 @@ test('generateReferenceMd emits frontmatter extension fields', () => {
 
   const result = generateReferenceMd(ref);
   assert.ok(result.includes('argument-hint: "topic name"'));
-  assert.ok(result.includes('allowed-tools: "Read Bash"'));
+  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read Bash"'));
   assert.ok(result.includes('paths: "docs/**/*.md"'));
   assert.ok(result.includes('context: "fork"'));
   assert.ok(result.includes('license: "MIT"'));
@@ -315,7 +332,19 @@ test('generateReferenceMd emits frontmatter extension fields', () => {
   assert.ok(result.includes('user-invocable: false'));
 });
 
-test('generateReferenceMd omits frontmatter extension fields when not set', () => {
+test('generateReferenceMd always emits allowed-tools with defaults', () => {
+  const ref = reference({
+    name: 'ref-minimal',
+    description: 'Minimal reference.',
+  })
+    .topic('info', { label: 'Info', content: () => 'Info.' })
+    .build();
+
+  const result = generateReferenceMd(ref);
+  assert.ok(result.includes('allowed-tools: "Bash(scripts/run *) Read"'));
+});
+
+test('generateReferenceMd omits other frontmatter extension fields when not set', () => {
   const ref = reference({
     name: 'ref-minimal',
     description: 'Minimal reference.',
@@ -327,7 +356,6 @@ test('generateReferenceMd omits frontmatter extension fields when not set', () =
   const frontmatter = result.split('---')[1]!;
   assert.ok(!frontmatter.includes('argument-hint'));
   assert.ok(!frontmatter.includes('arguments'));
-  assert.ok(!frontmatter.includes('allowed-tools'));
   assert.ok(!frontmatter.includes('paths'));
   assert.ok(!frontmatter.includes('context'));
   assert.ok(!frontmatter.includes('license'));

--- a/src/build/reference-md-template.ts
+++ b/src/build/reference-md-template.ts
@@ -1,5 +1,19 @@
 import type { ReferenceDefinition } from '../types.js';
 
+const DEFAULT_ALLOWED_TOOLS = ['Bash(scripts/run *)', 'Read'];
+
+function computeReferenceAllowedTools(def: ReferenceDefinition): string[] {
+  const author: string[] = [];
+  if (def.allowedTools) {
+    if (typeof def.allowedTools === 'string') {
+      author.push(...def.allowedTools.split(' ').filter(Boolean));
+    } else {
+      author.push(...def.allowedTools);
+    }
+  }
+  return [...new Set([...DEFAULT_ALLOWED_TOOLS, ...author])];
+}
+
 export function generateReferenceMd(def: ReferenceDefinition): string {
   const frontmatter = ['---', `name: ${def.name}`, `description: ${yamlDoubleQuoted(def.description)}`];
 
@@ -16,9 +30,7 @@ export function generateReferenceMd(def: ReferenceDefinition): string {
     frontmatter.push(yamlInlineList('arguments', def.arguments));
   }
 
-  if (def.allowedTools !== undefined && !(Array.isArray(def.allowedTools) && def.allowedTools.length === 0)) {
-    frontmatter.push(yamlSpaceSeparated('allowed-tools', def.allowedTools));
-  }
+  frontmatter.push(yamlSpaceSeparated('allowed-tools', computeReferenceAllowedTools(def)));
 
   if (def.paths !== undefined && !(Array.isArray(def.paths) && def.paths.length === 0)) {
     frontmatter.push(yamlInlineList('paths', def.paths));

--- a/src/build/reference-md-template.ts
+++ b/src/build/reference-md-template.ts
@@ -11,7 +11,8 @@ function computeReferenceAllowedTools(def: ReferenceDefinition): string[] {
       author.push(...def.allowedTools);
     }
   }
-  return [...new Set([...DEFAULT_ALLOWED_TOOLS, ...author])];
+  const mcp = [`mcp__${def.name}__topic`, `mcp__${def.name}__topics`];
+  return [...new Set([...DEFAULT_ALLOWED_TOOLS, ...mcp, ...author])];
 }
 
 export function generateReferenceMd(def: ReferenceDefinition): string {

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -107,6 +107,14 @@ function buildExampleParamsFlag(info: ParamInfo | null): string {
 
 const DEFAULT_ALLOWED_TOOLS = ['Bash(scripts/run *)', 'Read'];
 
+function mcpTools(name: string, hasTopics: boolean): string[] {
+  const tools = [`mcp__${name}__start`, `mcp__${name}__advance`];
+  if (hasTopics) {
+    tools.push(`mcp__${name}__topic`, `mcp__${name}__topics`);
+  }
+  return tools;
+}
+
 function computeAllowedTools(skill: SkillDefinition): string[] {
   const author: string[] = [];
   if (skill.allowedTools) {
@@ -116,7 +124,8 @@ function computeAllowedTools(skill: SkillDefinition): string[] {
       author.push(...skill.allowedTools);
     }
   }
-  return [...new Set([...DEFAULT_ALLOWED_TOOLS, ...author])];
+  const hasTopics = !!skill.topics && Object.keys(skill.topics).length > 0;
+  return [...new Set([...DEFAULT_ALLOWED_TOOLS, ...mcpTools(skill.name, hasTopics), ...author])];
 }
 
 const SKILL_DIR_INSTRUCTION = `This SKILL.md file is inside the skill directory. Resolve the **absolute path** to \`scripts/run\`

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -105,6 +105,20 @@ function buildExampleParamsFlag(info: ParamInfo | null): string {
   return `'${info.exampleJson}'`;
 }
 
+const DEFAULT_ALLOWED_TOOLS = ['Bash(scripts/run *)', 'Read'];
+
+function computeAllowedTools(skill: SkillDefinition): string[] {
+  const author: string[] = [];
+  if (skill.allowedTools) {
+    if (typeof skill.allowedTools === 'string') {
+      author.push(...skill.allowedTools.split(' ').filter(Boolean));
+    } else {
+      author.push(...skill.allowedTools);
+    }
+  }
+  return [...new Set([...DEFAULT_ALLOWED_TOOLS, ...author])];
+}
+
 const SKILL_DIR_INSTRUCTION = `This SKILL.md file is inside the skill directory. Resolve the **absolute path** to \`scripts/run\`
 from this file's location (e.g., \`/path/to/skill/scripts/run\`). Use the absolute path in all
 Bash commands — do not \`cd\` into the skill directory.
@@ -127,9 +141,7 @@ export function generateSkillMd(skill: SkillDefinition, protocol: BuildProtocol 
     frontmatter.push(yamlInlineList('arguments', skill.arguments));
   }
 
-  if (skill.allowedTools !== undefined && !(Array.isArray(skill.allowedTools) && skill.allowedTools.length === 0)) {
-    frontmatter.push(yamlSpaceSeparated('allowed-tools', skill.allowedTools));
-  }
+  frontmatter.push(yamlSpaceSeparated('allowed-tools', computeAllowedTools(skill)));
 
   if (skill.paths !== undefined && !(Array.isArray(skill.paths) && skill.paths.length === 0)) {
     frontmatter.push(yamlInlineList('paths', skill.paths));

--- a/src/build/skillmd-template.ts
+++ b/src/build/skillmd-template.ts
@@ -262,9 +262,6 @@ MCP tools are not available.
 
 ${SKILL_DIR_INSTRUCTION}
 
-**Before you begin:** Tell the user that they may be prompted to allow \`scripts/run\` and to
-read a file called \`skill-kit-<id>.jsonl\`. They should allow both permanently.
-
 ### Detect your host
 
 Determine which agent host you are running in, and pass it as \`--host\`:

--- a/tasks/2026-04-29_2027_auto-inject-allowed-tools/TASK.md
+++ b/tasks/2026-04-29_2027_auto-inject-allowed-tools/TASK.md
@@ -22,10 +22,10 @@ Add a `computeAllowedTools()` helper in both template files that merges defaults
 
 ```typescript
 // In skillmd-template.ts
-function computeAllowedTools(skill: SkillDefinition): string[]
+function computeAllowedTools(skill: SkillDefinition): string[];
 
-// In reference-md-template.ts  
-function computeReferenceAllowedTools(def: ReferenceDefinition): string[]
+// In reference-md-template.ts
+function computeReferenceAllowedTools(def: ReferenceDefinition): string[];
 ```
 
 Both return `[...new Set([...defaults, ...authorTools])]`.

--- a/tasks/2026-04-29_2027_auto-inject-allowed-tools/TASK.md
+++ b/tasks/2026-04-29_2027_auto-inject-allowed-tools/TASK.md
@@ -1,0 +1,52 @@
+# Auto-inject default `allowed-tools` in SKILL.md frontmatter
+
+## Scope
+
+**In:** Auto-inject `Bash(scripts/run *)` and `Read` into `allowed-tools` frontmatter at build time for both workflow and reference skills, merged with author-declared tools.
+
+**Out:** MCP tool names (host can't act on them), primitive-mapped tools (host-specific, already pre-approved), any changes to runtime behavior.
+
+## Context
+
+Every skill needs `Bash` and `Read` pre-approved in CLI mode — `Bash` to invoke `scripts/run`, `Read` to read the JSONL session file. Today `allowedTools` is optional and author-declared, meaning every skill invocation prompts users for permission. The SKILL.md body even says "allow both permanently" — we should just declare them.
+
+The agentskills.io spec supports scoped patterns like `Bash(scripts/run *)` in the `allowed-tools` field.
+
+MCP tool names (`mcp__<name>__start` etc.) are NOT included because there's no host-side mechanism to pre-approve individual MCP tools via frontmatter — MCP server approval is a server-level trust decision in Claude Code settings.
+
+## Plan
+
+Add a `computeAllowedTools()` helper in both template files that merges defaults (`Bash(scripts/run *)`, `Read`) with author-declared tools. Always emit the `allowed-tools` field.
+
+### Type signatures
+
+```typescript
+// In skillmd-template.ts
+function computeAllowedTools(skill: SkillDefinition): string[]
+
+// In reference-md-template.ts  
+function computeReferenceAllowedTools(def: ReferenceDefinition): string[]
+```
+
+Both return `[...new Set([...defaults, ...authorTools])]`.
+
+The `yamlSpaceSeparated` function already handles `string[]` → space-separated quoted string.
+
+## Steps
+
+- [ ] Create branch
+- [ ] Commit task file
+- [ ] Implement `computeAllowedTools` in `skillmd-template.ts`
+- [ ] Implement `computeReferenceAllowedTools` in `reference-md-template.ts`
+- [ ] Update tests in `index.test.ts`
+- [ ] Typecheck + test + format
+- [ ] Update SPEC.md §11
+- [ ] Update docs/api.md
+- [ ] Update docs-site pages
+- [ ] Rebuild example skills
+- [ ] Final checkpoint
+
+## Notes
+
+- `Bash(scripts/run *)` is the idiomatic Claude Code scoped pattern (space before `*`, not colon)
+- Defaults go first in the output array so they appear before author tools in the frontmatter


### PR DESCRIPTION
## Summary

- Build pipeline now always emits `allowed-tools: "Bash(scripts/run *) Read"` in SKILL.md frontmatter, eliminating permission prompts for CLI mode invocation
- Author-declared `allowedTools` are merged with defaults and deduplicated
- Updated docs across all 5 locations (SPEC.md, docs/api.md, 3 docs-site pages)
- Rebuilt all 5 example skills

## Test plan

- [ ] `pnpm exec tsc --noEmit` passes
- [ ] All 339 SDK tests pass
- [ ] All 15 example skill tests pass
- [ ] Example SKILL.md files contain `allowed-tools: "Bash(scripts/run *) Read"`
- [ ] Skill with author `allowedTools: ['Write']` produces `"Bash(scripts/run *) Read Write"`
- [ ] Skill with author `allowedTools: ['Read']` deduplicates to `"Bash(scripts/run *) Read"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)