### PR TITLE
feat(docs-site): redesign homepage with animated hero and visual storytelling

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -1,12 +1,13 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import react from '@astrojs/react';
 
 export default defineConfig({
   // TODO: set custom domain or make Pages public so this serves at contentful.github.io/skill-kit/
   site: 'https://contentful.github.io',
   trailingSlash: 'always',
   output: 'static',
-  integrations: [mdx()],
+  integrations: [mdx(), react()],
   markdown: {
     shikiConfig: {
       theme: 'vitesse-dark',

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -10,7 +10,7 @@ export default defineConfig({
   integrations: [mdx(), react()],
   markdown: {
     shikiConfig: {
-      theme: 'vitesse-dark',
+      theme: 'github-dark',
     },
   },
 });

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -9,7 +9,12 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/mdx": "^4.3.0",
+    "@astrojs/react": "^5.0.4",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "astro": "^5.7.10",
-    "@astrojs/mdx": "^4.3.0"
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
   }
 }

--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -11,9 +11,24 @@ importers:
       '@astrojs/mdx':
         specifier: ^4.3.0
         version: 4.3.14(astro@5.18.1(rollup@4.60.2)(typescript@5.9.3))
+      '@astrojs/react':
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       astro:
         specifier: ^5.7.10
         version: 5.18.1(rollup@4.60.2)(typescript@5.9.3)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
 
 packages:
 
@@ -22,6 +37,9 @@ packages:
 
   '@astrojs/internal-helpers@0.7.6':
     resolution: {integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==}
+
+  '@astrojs/internal-helpers@0.9.0':
+    resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
 
   '@astrojs/markdown-remark@6.3.11':
     resolution: {integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==}
@@ -36,9 +54,56 @@ packages:
     resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
+  '@astrojs/react@5.0.4':
+    resolution: {integrity: sha512-yDNE4VnKOzCjH9dCBi7pT4F6kpI3M9TkS+uxnCB0sGIS6t5vKonOY+Hs/UUnSajJGT5jeBRfpI9IQp+r/n1fBA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
+      '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -48,10 +113,38 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -513,14 +606,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -677,6 +786,18 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -701,6 +822,14 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -709,6 +838,12 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -768,6 +903,11 @@ packages:
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
+  baseline-browser-mapping@2.10.24:
+    resolution: {integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -775,9 +915,17 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -827,6 +975,9 @@ packages:
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
@@ -860,6 +1011,9 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -921,6 +1075,9 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  electron-to-chromium@1.5.344:
+    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -953,6 +1110,10 @@ packages:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -1012,6 +1173,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
@@ -1111,8 +1276,21 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   kleur@3.0.3:
@@ -1125,6 +1303,9 @@ packages:
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1326,6 +1507,9 @@ packages:
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -1400,6 +1584,19 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -1482,6 +1679,13 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1689,6 +1893,12 @@ packages:
       uploadthing:
         optional: true
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -1711,6 +1921,46 @@ packages:
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -1764,6 +2014,9 @@ packages:
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -1802,6 +2055,10 @@ snapshots:
   '@astrojs/compiler@2.13.1': {}
 
   '@astrojs/internal-helpers@0.7.6': {}
+
+  '@astrojs/internal-helpers@0.9.0':
+    dependencies:
+      picomatch: 4.0.4
 
   '@astrojs/markdown-remark@6.3.11':
     dependencies:
@@ -1852,6 +2109,31 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
+  '@astrojs/react@5.0.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.9.0
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.2)
+      devalue: 5.7.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      ultrahtml: 1.6.0
+      vite: 7.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   '@astrojs/telemetry@3.3.0':
     dependencies:
       ci-info: 4.4.0
@@ -1864,13 +2146,112 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -2139,7 +2520,24 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -2172,6 +2570,8 @@ snapshots:
       - supports-color
 
   '@oslojs/encoding@1.1.0': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
     dependencies:
@@ -2289,6 +2689,27 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -2315,11 +2736,31 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.2
+    transitivePeerDependencies:
+      - supports-color
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -2458,6 +2899,8 @@ snapshots:
 
   base-64@1.0.0: {}
 
+  baseline-browser-mapping@2.10.24: {}
+
   boolbase@1.0.0: {}
 
   boxen@8.0.1:
@@ -2471,7 +2914,17 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.24
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.344
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   camelcase@8.0.0: {}
+
+  caniuse-lite@1.0.30001791: {}
 
   ccount@2.0.1: {}
 
@@ -2502,6 +2955,8 @@ snapshots:
   commander@11.1.0: {}
 
   common-ancestor-path@1.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
@@ -2536,6 +2991,8 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -2587,6 +3044,8 @@ snapshots:
       domhandler: 5.0.3
 
   dset@3.1.4: {}
+
+  electron-to-chromium@1.5.344: {}
 
   emoji-regex@10.6.0: {}
 
@@ -2670,6 +3129,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escalade@3.2.0: {}
+
   escape-string-regexp@5.0.0: {}
 
   estree-util-attach-comments@3.0.0:
@@ -2727,6 +3188,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  gensync@1.0.0-beta.2: {}
 
   get-east-asian-width@1.5.0: {}
 
@@ -2909,15 +3372,25 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
 
   kleur@3.0.3: {}
 
   longest-streak@3.1.0: {}
 
   lru-cache@11.3.5: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -3386,6 +3859,8 @@ snapshots:
 
   node-mock-http@1.0.4: {}
 
+  node-releases@2.0.38: {}
+
   normalize-path@3.0.0: {}
 
   nth-check@2.1.1:
@@ -3468,6 +3943,15 @@ snapshots:
   property-information@7.1.0: {}
 
   radix3@1.1.2: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-refresh@0.18.0: {}
+
+  react@19.2.5: {}
 
   readdirp@5.0.0: {}
 
@@ -3648,6 +4132,10 @@ snapshots:
       fsevents: 2.3.3
 
   sax@1.6.0: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -3850,6 +4338,12 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.3
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   vfile-location@5.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -3868,6 +4362,17 @@ snapshots:
   vite@6.4.2:
     dependencies:
       esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vite@7.3.2:
+    dependencies:
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.10
@@ -3895,6 +4400,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   xxhash-wasm@1.1.0: {}
+
+  yallist@3.1.1: {}
 
   yargs-parser@21.1.1: {}
 

--- a/docs-site/src/components/FeatureCard.astro
+++ b/docs-site/src/components/FeatureCard.astro
@@ -14,8 +14,10 @@ const icons: Record<string, string> = {
 ---
 
 <div class="feature-card">
-  {icon && <div class="feature-icon" aria-hidden="true" set:html={icons[icon]} />}
-  <h3 class="feature-title">{title}</h3>
+  <h3 class="feature-title">
+    {icon && <span class="feature-icon" aria-hidden="true" set:html={icons[icon]} />}
+    {title}
+  </h3>
   <p class="feature-body"><slot /></p>
 </div>
 
@@ -37,12 +39,6 @@ const icons: Record<string, string> = {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   }
 
-  .feature-icon {
-    color: var(--color-accent);
-    margin-bottom: var(--space-3);
-    line-height: 1;
-  }
-
   .feature-title {
     font-family: var(--font-display);
     font-size: var(--text-base);
@@ -50,6 +46,20 @@ const icons: Record<string, string> = {
     margin-bottom: var(--space-2);
     color: var(--color-text);
     line-height: 1.3;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .feature-icon {
+    color: var(--color-accent);
+    line-height: 0;
+    flex-shrink: 0;
+  }
+
+  .feature-icon :global(svg) {
+    width: 20px;
+    height: 20px;
   }
 
   .feature-body {

--- a/docs-site/src/components/FeatureCard.astro
+++ b/docs-site/src/components/FeatureCard.astro
@@ -47,19 +47,22 @@ const icons: Record<string, string> = {
     color: var(--color-text);
     line-height: 1.3;
     display: flex;
-    align-items: center;
+    align-items: first baseline;
     gap: var(--space-2);
   }
 
   .feature-icon {
     color: var(--color-accent);
-    line-height: 0;
     flex-shrink: 0;
+    display: inline-flex;
+    align-self: center;
+    position: relative;
+    top: 1px;
   }
 
   .feature-icon :global(svg) {
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
   }
 
   .feature-body {

--- a/docs-site/src/components/FeatureCard.astro
+++ b/docs-site/src/components/FeatureCard.astro
@@ -1,14 +1,20 @@
 ---
 interface Props {
   title: string;
-  icon?: string;
+  icon?: 'terminal' | 'git-branch' | 'package';
 }
 
 const { title, icon } = Astro.props;
+
+const icons: Record<string, string> = {
+  terminal: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>`,
+  'git-branch': `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>`,
+  package: `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16.5" y1="9.4" x2="7.5" y2="4.21"/><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>`,
+};
 ---
 
 <div class="feature-card">
-  {icon && <div class="feature-icon" aria-hidden="true">{icon}</div>}
+  {icon && <div class="feature-icon" aria-hidden="true" set:html={icons[icon]} />}
   <h3 class="feature-title">{title}</h3>
   <p class="feature-body"><slot /></p>
 </div>
@@ -18,7 +24,7 @@ const { title, icon } = Astro.props;
     background: var(--color-bg-elevated);
     border: 1px solid var(--color-border);
     border-radius: 8px;
-    padding: var(--space-6);
+    padding: var(--space-5);
     transition:
       border-color var(--transition-fast),
       transform var(--transition-fast),
@@ -32,16 +38,16 @@ const { title, icon } = Astro.props;
   }
 
   .feature-icon {
-    font-size: var(--text-2xl);
+    color: var(--color-accent);
     margin-bottom: var(--space-3);
     line-height: 1;
   }
 
   .feature-title {
     font-family: var(--font-display);
-    font-size: var(--text-lg);
+    font-size: var(--text-base);
     font-weight: 700;
-    margin-bottom: var(--space-3);
+    margin-bottom: var(--space-2);
     color: var(--color-text);
     line-height: 1.3;
   }
@@ -50,6 +56,6 @@ const { title, icon } = Astro.props;
     font-size: var(--text-sm);
     color: var(--color-text-muted);
     margin: 0;
-    line-height: 1.7;
+    line-height: 1.6;
   }
 </style>

--- a/docs-site/src/components/FeatureCard.astro
+++ b/docs-site/src/components/FeatureCard.astro
@@ -1,14 +1,14 @@
 ---
 interface Props {
   title: string;
-  icon: string;
+  icon?: string;
 }
 
 const { title, icon } = Astro.props;
 ---
 
 <div class="feature-card">
-  <div class="feature-icon" aria-hidden="true">{icon}</div>
+  {icon && <div class="feature-icon" aria-hidden="true">{icon}</div>}
   <h3 class="feature-title">{title}</h3>
   <p class="feature-body"><slot /></p>
 </div>
@@ -17,15 +17,18 @@ const { title, icon } = Astro.props;
   .feature-card {
     background: var(--color-bg-elevated);
     border: 1px solid var(--color-border);
-    padding: var(--space-5);
+    border-radius: 8px;
+    padding: var(--space-6);
     transition:
       border-color var(--transition-fast),
-      background var(--transition-fast);
+      transform var(--transition-fast),
+      box-shadow var(--transition-fast);
   }
 
   .feature-card:hover {
-    border-color: var(--color-border-focus);
-    background: var(--color-bg-inset);
+    border-color: var(--color-accent);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   }
 
   .feature-icon {
@@ -36,16 +39,17 @@ const { title, icon } = Astro.props;
 
   .feature-title {
     font-family: var(--font-display);
-    font-size: var(--text-base);
+    font-size: var(--text-lg);
     font-weight: 700;
-    margin-bottom: var(--space-2);
-    color: var(--color-accent);
+    margin-bottom: var(--space-3);
+    color: var(--color-text);
+    line-height: 1.3;
   }
 
   .feature-body {
     font-size: var(--text-sm);
     color: var(--color-text-muted);
     margin: 0;
-    line-height: 1.6;
+    line-height: 1.7;
   }
 </style>

--- a/docs-site/src/components/Footer.astro
+++ b/docs-site/src/components/Footer.astro
@@ -5,8 +5,8 @@ const base = import.meta.env.BASE_URL;
 <footer class="footer">
   <div class="footer-inner">
     <div class="footer-left">
-      <span class="footer-logo">▸ skill-kit</span>
-      <span class="footer-sep">—</span>
+      <span class="footer-logo">&#9656; skill-kit</span>
+      <span class="footer-sep">&mdash;</span>
       <span class="footer-text">Built by <a href="https://github.com/contentful" target="_blank" rel="noopener">Contentful</a></span>
     </div>
     <div class="footer-links">
@@ -76,6 +76,6 @@ const base = import.meta.env.BASE_URL;
   }
 
   .footer-links a:hover {
-    color: var(--color-text-muted);
+    color: var(--color-accent);
   }
 </style>

--- a/docs-site/src/components/Hero.astro
+++ b/docs-site/src/components/Hero.astro
@@ -30,11 +30,11 @@ const base = import.meta.env.BASE_URL;
 
 <style>
   .hero {
-    padding: var(--space-9) var(--space-5) var(--space-7);
+    padding: var(--space-9) var(--space-5) var(--space-5);
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--space-7);
+    gap: var(--space-6);
   }
 
   .hero-content {

--- a/docs-site/src/components/Hero.astro
+++ b/docs-site/src/components/Hero.astro
@@ -24,7 +24,7 @@ const base = import.meta.env.BASE_URL;
   <HeroDemo client:visible />
 
   <div class="hero-install">
-    <code class="hero-install-cmd">$ pnpm add @contentful/skill-kit</code>
+    <code class="hero-install-cmd">$ npm install @contentful/skill-kit</code>
   </div>
 </section>
 

--- a/docs-site/src/components/Hero.astro
+++ b/docs-site/src/components/Hero.astro
@@ -12,8 +12,8 @@ const base = import.meta.env.BASE_URL;
       <span class="hero-title-accent">Rich experiences.</span>
     </h1>
     <p class="hero-subtitle">
-      Define agent workflows as typed step chains. The SDK renders interactive
-      TUI&mdash;surveys, plans, subagents&mdash;in any host.
+      A TypeScript SDK for building multi-step agent skills.
+      You define the workflow. The SDK handles state, validation, and rich terminal UI.
     </p>
     <div class="hero-actions">
       <a href={`${base}getting-started/`} class="hero-btn hero-btn--primary">Get Started</a>
@@ -24,7 +24,7 @@ const base = import.meta.env.BASE_URL;
   <HeroDemo client:visible />
 
   <div class="hero-install">
-    <code class="hero-install-cmd">$ npx @contentful/skill-kit init</code>
+    <code class="hero-install-cmd">$ pnpm add @contentful/skill-kit</code>
   </div>
 </section>
 

--- a/docs-site/src/components/Hero.astro
+++ b/docs-site/src/components/Hero.astro
@@ -1,135 +1,59 @@
 ---
+import HeroDemo from './HeroDemo';
+
 const base = import.meta.env.BASE_URL;
 ---
 
 <section class="hero">
-  <div class="hero-scanline" aria-hidden="true"></div>
-  <div class="hero-banner">
-    <img src={`${base}images/banner.jpg`} alt="" class="hero-banner-img" loading="eager" />
-    <div class="hero-banner-fade"></div>
-  </div>
   <div class="hero-content">
     <div class="hero-badge">@contentful/skill-kit</div>
     <h1 class="hero-title">
-      Build agent skills<br />
-      <span class="hero-title-accent">that actually work.</span>
+      Typed steps.<br />
+      <span class="hero-title-accent">Rich experiences.</span>
     </h1>
     <p class="hero-subtitle">
-      Typed state machines for multi-step workflows. Progressive disclosure for reference docs. Composite dispatchers
-      that route across sub-skills and topics. All three compile to standalone CLI packages that any agent can invoke
-      via Bash.
+      Define agent workflows as typed step chains. The SDK renders interactive
+      TUI&mdash;surveys, plans, subagents&mdash;in any host.
     </p>
     <div class="hero-actions">
       <a href={`${base}getting-started/`} class="hero-btn hero-btn--primary">Get Started</a>
       <a href={`${base}api/`} class="hero-btn hero-btn--secondary">API Reference</a>
     </div>
   </div>
-  <div class="hero-terminal">
-    <div class="terminal-header">
-      <span class="terminal-dot"></span>
-      <span class="terminal-dot"></span>
-      <span class="terminal-dot"></span>
-      <span class="terminal-title">skill.ts</span>
-    </div>
-    <pre class="terminal-body"><code><span class="t-kw">import</span> {'{'} skill, z, act, prompt {'}'} <span class="t-kw">from</span> <span class="t-str">'@contentful/skill-kit'</span>;
 
-<span class="t-kw">export default</span> <span class="t-fn">skill</span>({'{'}
-  name: <span class="t-str">'changelog'</span>, entry: <span class="t-str">'audience'</span>,
-  triggers: [<span class="t-str">'generate changelog'</span>, <span class="t-str">'prep release notes'</span>],
-  stash: z.<span class="t-fn">object</span>({'{'} audience: z.<span class="t-fn">string</span>() {'}'}),
-{'}'})
-  .<span class="t-fn">step</span>(<span class="t-str">'audience'</span>, {'{'}
-    prompt: <span class="t-fn">act</span>.<span class="t-fn">askUser</span>({'{'}
-      type: <span class="t-str">'structured'</span>,
-      question: <span class="t-str">'Who is the changelog for?'</span>,
-      options: [
-        {'{'} value: <span class="t-str">'devs'</span>, label: <span class="t-str">'Developers'</span> {'}'},
-        {'{'} value: <span class="t-str">'users'</span>, label: <span class="t-str">'End users'</span> {'}'},
-      ],
-    {'}'}),
-    output: z.<span class="t-fn">object</span>({'{'} audience: z.<span class="t-fn">enum</span>([<span class="t-str">'devs'</span>, <span class="t-str">'users'</span>]) {'}'}),
-    updateStash: ({'{'} stepOutput {'}'}) {'=>'} ({'{'} audience: stepOutput.audience{'}'}),
-    next: <span class="t-str">'draft'</span>,
-  {'}'})
-  .<span class="t-fn">step</span>(<span class="t-str">'draft'</span>, {'{'}
-    prompt: ({'{'} stash {'}'}) {'=>'} <span class="t-fn">prompt</span><span class="t-str">`
-      Scan recent commits. Write a
-      ${'{'}</span>stash.audience === <span class="t-str">'devs'</span> ? <span class="t-str">'technical'</span> : <span class="t-str">'friendly'</span><span class="t-str">{'}'}
-      changelog to CHANGELOG.md.
-    `</span>,
-    output: z.<span class="t-fn">object</span>({'{'} path: z.<span class="t-fn">string</span>() {'}'}),
-    next: {'{'} terminal: <span class="t-bool">true</span> {'}'},
-  {'}'})
-  .<span class="t-fn">build</span>();</code></pre>
+  <HeroDemo client:visible />
+
+  <div class="hero-install">
+    <code class="hero-install-cmd">$ npx @contentful/skill-kit init</code>
   </div>
 </section>
 
 <style>
   .hero {
-    position: relative;
-    overflow: hidden;
-    padding: var(--space-9) var(--space-5) var(--space-8);
-    min-height: 90vh;
+    padding: var(--space-9) var(--space-5) var(--space-7);
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     gap: var(--space-7);
   }
 
-  /* Scan line */
-  .hero-scanline {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: linear-gradient(90deg, transparent, var(--color-accent), transparent);
-    animation: scanline 2s ease-out forwards;
-    animation-delay: 0.5s;
-    opacity: 0;
-    z-index: 2;
-  }
-
-  /* Banner background */
-  .hero-banner {
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-  }
-
-  .hero-banner-img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    opacity: 0.15;
-  }
-
-  .hero-banner-fade {
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(to bottom, rgba(10, 10, 10, 0.3) 0%, var(--color-bg) 85%);
-  }
-
-  /* Content */
   .hero-content {
-    position: relative;
-    z-index: 1;
     text-align: center;
-    max-width: 48rem;
+    max-width: 44rem;
   }
 
   .hero-badge {
     display: inline-block;
-    font-family: var(--font-display);
+    font-family: var(--font-mono);
     font-size: var(--text-xs);
     font-weight: 500;
     color: var(--color-accent);
-    border: 1px solid var(--color-accent-dim);
+    border: 1px solid var(--color-accent);
     padding: var(--space-1) var(--space-3);
     margin-bottom: var(--space-5);
     letter-spacing: 0.05em;
     background: var(--color-accent-glow);
+    border-radius: 100px;
   }
 
   .hero-title {
@@ -148,7 +72,7 @@ const base = import.meta.env.BASE_URL;
     color: var(--color-text-muted);
     max-width: 36rem;
     margin: 0 auto var(--space-6);
-    line-height: 1.6;
+    line-height: 1.7;
   }
 
   .hero-actions {
@@ -160,110 +84,60 @@ const base = import.meta.env.BASE_URL;
 
   .hero-btn {
     font-family: var(--font-display);
-    font-size: var(--text-sm);
-    font-weight: 500;
+    font-size: var(--text-base);
+    font-weight: 600;
     text-decoration: none;
-    padding: var(--space-3) var(--space-5);
+    padding: var(--space-3) var(--space-6);
+    border-radius: 6px;
     transition:
       background var(--transition-fast),
       color var(--transition-fast),
-      border-color var(--transition-fast);
+      border-color var(--transition-fast),
+      box-shadow var(--transition-fast);
   }
 
   .hero-btn--primary {
     background: var(--color-accent);
-    color: var(--color-bg);
+    color: #ffffff;
     border: 1px solid var(--color-accent);
   }
 
   .hero-btn--primary:hover {
     background: var(--color-accent-bright);
     border-color: var(--color-accent-bright);
-    color: var(--color-bg);
+    color: #ffffff;
+    box-shadow: 0 4px 12px rgba(13, 115, 119, 0.3);
   }
 
   .hero-btn--secondary {
     background: transparent;
     color: var(--color-accent);
-    border: 1px solid var(--color-accent-dim);
+    border: 1px solid var(--color-border-focus);
   }
 
   .hero-btn--secondary:hover {
     border-color: var(--color-accent);
     background: var(--color-accent-glow);
-    color: var(--color-accent-bright);
   }
 
-  /* Terminal */
-  .hero-terminal {
-    position: relative;
-    z-index: 1;
-    width: 100%;
-    max-width: 40rem;
-    background: var(--color-bg-elevated);
-    border: 1px solid var(--color-border);
+  .hero-install {
+    text-align: center;
   }
 
-  .terminal-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: var(--space-2) var(--space-4);
-    border-bottom: 1px solid var(--color-border);
-  }
-
-  .terminal-dot {
-    width: 10px;
-    height: 10px;
-    background: var(--color-border-focus);
-  }
-
-  .terminal-title {
-    font-family: var(--font-display);
-    font-size: var(--text-xs);
-    color: var(--color-text-dim);
-    margin-left: auto;
-  }
-
-  .terminal-body {
-    margin: 0;
-    padding: var(--space-4) !important;
-    background: var(--color-bg-elevated) !important;
-    border: none !important;
-    border-left: none !important;
+  .hero-install-cmd {
+    font-family: var(--font-mono);
     font-size: var(--text-sm);
-    line-height: 1.7;
-    overflow-x: auto;
-  }
-
-  .terminal-body code {
-    font-family: var(--font-display);
-  }
-
-  /* Syntax classes */
-  .t-dim {
     color: var(--color-text-dim);
-  }
-  .t-kw {
-    color: #c792ea;
-  }
-  .t-str {
-    color: var(--color-accent);
-  }
-  .t-fn {
-    color: #82aaff;
-  }
-  .t-bool {
-    color: var(--color-accent-bright);
-  }
-  .t-accent {
-    color: var(--color-accent);
+    background: var(--color-bg-inset);
+    border: 1px solid var(--color-border);
+    padding: var(--space-2) var(--space-5);
+    border-radius: 6px;
+    display: inline-block;
   }
 
   @media (max-width: 768px) {
     .hero {
-      padding: var(--space-7) var(--space-4) var(--space-6);
-      min-height: auto;
+      padding: var(--space-7) var(--space-4) var(--space-5);
     }
 
     .hero-title {

--- a/docs-site/src/components/Hero.astro
+++ b/docs-site/src/components/Hero.astro
@@ -19,13 +19,12 @@ const base = import.meta.env.BASE_URL;
       <a href={`${base}getting-started/`} class="hero-btn hero-btn--primary">Get Started</a>
       <a href={`${base}api/`} class="hero-btn hero-btn--secondary">API Reference</a>
     </div>
+    <div class="hero-install">
+      <code class="hero-install-cmd">$ npm install @contentful/skill-kit</code>
+    </div>
   </div>
 
   <HeroDemo client:visible />
-
-  <div class="hero-install">
-    <code class="hero-install-cmd">$ npm install @contentful/skill-kit</code>
-  </div>
 </section>
 
 <style>
@@ -122,6 +121,7 @@ const base = import.meta.env.BASE_URL;
 
   .hero-install {
     text-align: center;
+    margin-top: var(--space-4);
   }
 
   .hero-install-cmd {

--- a/docs-site/src/components/HeroDemo.tsx
+++ b/docs-site/src/components/HeroDemo.tsx
@@ -556,25 +556,13 @@ export default function HeroDemo() {
   }, [frameIndex, paused, advance]);
 
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el || startedRef.current) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       setFrameIndex(allFrames.length - 1);
       startedRef.current = true;
       return;
     }
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting && !startedRef.current) {
-          startedRef.current = true;
-          setFrameIndex(0);
-          observer.disconnect();
-        }
-      },
-      { threshold: 0.3 }
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
+    startedRef.current = true;
+    setFrameIndex(0);
   }, []);
 
   const safeFrameIndex = Math.max(0, frameIndex);

--- a/docs-site/src/components/HeroDemo.tsx
+++ b/docs-site/src/components/HeroDemo.tsx
@@ -102,7 +102,7 @@ function buildStepRanges(code: string): Map<number, string> {
 }
 const stepRanges = buildStepRanges(storyboard.code);
 
-function CodePanel({ activeStep }: { activeStep: string | null }) {
+function CodePanel({ activeStep, onClickStep }: { activeStep: string | null; onClickStep: (step: string) => void }) {
   return (
     <div style={{
       background: c.codeBg, border: `1px solid ${c.codeBorder}`, borderRadius: 10,
@@ -124,11 +124,12 @@ function CodePanel({ activeStep }: { activeStep: string | null }) {
           const step = stepRanges.get(i);
           const isActive = step !== undefined && step === activeStep;
           return (
-            <div key={i} style={{
+            <div key={i} onClick={step ? () => onClickStep(step) : undefined} style={{
               display: 'flex', minHeight: 21, whiteSpace: 'pre',
               borderLeft: isActive ? `3px solid ${c.accent}` : '3px solid transparent',
               background: isActive ? 'rgba(15,145,153,0.08)' : 'transparent',
               transition: 'background 400ms ease, border-color 400ms ease',
+              cursor: step ? 'pointer' : 'default',
             }}>
               {/* Line number */}
               <span style={{
@@ -537,6 +538,11 @@ export default function HeroDemo() {
     setFrameIndex(firstFrameOfScene(sceneIdx));
   }, [firstFrameOfScene]);
 
+  const jumpToStep = useCallback((stepName: string) => {
+    const sceneIdx = SCENES.findIndex((s) => s.stepName === stepName);
+    if (sceneIdx >= 0) jumpToScene(sceneIdx);
+  }, [jumpToScene]);
+
   useEffect(() => {
     if (!startedRef.current || paused) return;
     if (frameIndex === -1) {
@@ -585,7 +591,7 @@ export default function HeroDemo() {
     >
       {/* Code editor: full width base layer */}
       <div className="hero-demo-code">
-        <CodePanel activeStep={activeStep} />
+        <CodePanel activeStep={activeStep} onClickStep={jumpToStep} />
       </div>
       {/* Terminal: floating overlay, offset top-right */}
       <div className="hero-demo-terminal">

--- a/docs-site/src/components/HeroDemo.tsx
+++ b/docs-site/src/components/HeroDemo.tsx
@@ -214,7 +214,7 @@ function TabBar({ tabs }: { tabs: SurveyPicker['tabs'] }) {
           color: t.active ? c.blue : t.done ? c.muted : c.dim,
           border: t.active ? '1px solid rgba(96,165,250,0.3)' : '1px solid transparent',
         }}>
-          {t.done ? '✕ ' : '☐ '}{t.label}
+          {t.done ? '✓ ' : '☐ '}{t.label}
         </span>
       ))}
       <span style={{ color: c.dim }}>→</span>

--- a/docs-site/src/components/HeroDemo.tsx
+++ b/docs-site/src/components/HeroDemo.tsx
@@ -106,14 +106,18 @@ function CodePanel({ activeStep }: { activeStep: string | null }) {
   return (
     <div style={{
       background: c.codeBg, border: `1px solid ${c.codeBorder}`, borderRadius: 10,
-      overflow: 'hidden', boxShadow: '0 4px 20px rgba(0,0,0,0.12)',
+      overflow: 'hidden', boxShadow: '0 8px 32px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.12)',
       fontFamily: "'IBM Plex Mono', monospace", fontSize: 13, lineHeight: 1.65,
     }}>
+      {/* Window chrome */}
       <div style={{
-        padding: '8px 16px', borderBottom: `1px solid ${c.codeBorder}`,
-        background: 'rgba(0,0,0,0.2)', color: '#64748b', fontSize: 12,
+        padding: '10px 16px', borderBottom: `1px solid ${c.codeBorder}`,
+        background: 'rgba(0,0,0,0.25)', display: 'flex', alignItems: 'center', gap: 8,
       }}>
-        security-audit.ts
+        <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff5f57', flexShrink: 0 }} />
+        <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#febc2e', flexShrink: 0 }} />
+        <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#28c840', flexShrink: 0 }} />
+        <span style={{ marginLeft: 'auto', color: '#64748b', fontSize: 12 }}>security-audit.ts</span>
       </div>
       <div style={{ padding: '14px 0', overflowX: 'auto' }}>
         {codeTokens.map((tokens, i) => {
@@ -121,14 +125,22 @@ function CodePanel({ activeStep }: { activeStep: string | null }) {
           const isActive = step !== undefined && step === activeStep;
           return (
             <div key={i} style={{
-              padding: '0 16px', minHeight: 21, whiteSpace: 'pre',
+              display: 'flex', minHeight: 21, whiteSpace: 'pre',
               borderLeft: isActive ? `3px solid ${c.accent}` : '3px solid transparent',
               background: isActive ? 'rgba(15,145,153,0.08)' : 'transparent',
               transition: 'background 400ms ease, border-color 400ms ease',
             }}>
-              {tokens.length === 0 ? ' ' : tokens.map((t, j) =>
-                t.color ? <span key={j} style={{ color: t.color }}>{t.text}</span> : <span key={j}>{t.text}</span>
-              )}
+              {/* Line number */}
+              <span style={{
+                width: 36, flexShrink: 0, textAlign: 'right', paddingRight: 12,
+                color: isActive ? '#64748b' : '#3e4a5c', userSelect: 'none', fontSize: 12,
+              }}>{i + 1}</span>
+              {/* Code content */}
+              <span style={{ paddingRight: 16 }}>
+                {tokens.length === 0 ? ' ' : tokens.map((t, j) =>
+                  t.color ? <span key={j} style={{ color: t.color }}>{t.text}</span> : <span key={j}>{t.text}</span>
+                )}
+              </span>
             </div>
           );
         })}
@@ -406,12 +418,18 @@ function TerminalPanel({ frameIndex, activeSceneIdx }: { frameIndex: number; act
       background: c.termBg, border: `1px solid ${c.termBorder}`, borderRadius: 10,
       overflow: 'hidden', fontFamily: "'IBM Plex Mono', monospace",
       fontSize: 13, lineHeight: 1.55, color: c.termText,
-      boxShadow: '0 4px 20px rgba(0,0,0,0.25)',
+      boxShadow: '0 12px 40px rgba(0,0,0,0.35), 0 4px 12px rgba(0,0,0,0.2)',
       display: 'flex', flexDirection: 'column', height: '100%',
     }}>
-      {/* Command header */}
-      <div style={{ padding: '12px 20px', borderBottom: `1px solid ${c.termBorder}` }}>
-        <span style={{ color: c.dim, marginRight: 8 }}>▸</span>
+      {/* Window chrome + command */}
+      <div style={{
+        padding: '10px 20px', borderBottom: `1px solid ${c.termBorder}`,
+        background: 'rgba(255,255,255,0.02)', display: 'flex', alignItems: 'center', gap: 8,
+      }}>
+        <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff5f57', flexShrink: 0 }} />
+        <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#febc2e', flexShrink: 0 }} />
+        <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#28c840', flexShrink: 0 }} />
+        <span style={{ marginLeft: 12, color: c.dim }}>▸</span>
         <span style={{ color: '#fff', fontWeight: 600 }}>{storyboard.command}</span>
       </div>
 
@@ -545,9 +563,11 @@ export default function HeroDemo() {
       onMouseLeave={() => setPaused(false)}
       className="hero-demo"
     >
+      {/* Code editor: full width base layer */}
       <div className="hero-demo-code">
         <CodePanel activeStep={activeStep} />
       </div>
+      {/* Terminal: floating overlay, offset top-right */}
       <div className="hero-demo-terminal">
         <TerminalPanel frameIndex={safeFrameIndex} activeSceneIdx={activeScene} />
         <StepDots activeScene={activeScene} onClickScene={jumpToScene} />

--- a/docs-site/src/components/HeroDemo.tsx
+++ b/docs-site/src/components/HeroDemo.tsx
@@ -1,0 +1,557 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import {
+  securityAudit,
+  type TerminalFrame,
+  type SurveyPicker,
+  type SurveyReview,
+  type AnswersSummary,
+  type SubagentRunning,
+  type SubagentDone,
+  type PlanCard,
+  type ActionRunning,
+  type ActionDone,
+  type SummaryLine,
+} from '../data/storyboard';
+
+const storyboard = securityAudit;
+const SCENES = storyboard.scenes;
+const RESTART_DELAY = 2000;
+
+// Flatten scenes→frames into linear index
+const allFrames: { sceneIdx: number; stepName: string; content: TerminalFrame; duration: number }[] = [];
+for (let s = 0; s < SCENES.length; s++) {
+  for (const frame of SCENES[s].frames) {
+    allFrames.push({ sceneIdx: s, stepName: SCENES[s].stepName, content: frame.content, duration: frame.duration });
+  }
+}
+
+// --- Colors ---
+
+const c = {
+  codeBg: '#1e293b', codeBorder: '#334155', codeText: '#e2e8f0',
+  termBg: '#0e0e0e', termBorder: '#1e1e1e', termText: '#d4d4d4',
+  green: '#4ade80', blue: '#60a5fa', purple: '#c084fc', amber: '#fbbf24',
+  dim: '#525252', muted: '#737373', white: '#e5e5e5', accent: '#0f9199',
+  kw: '#c792ea', str: '#c3e88d', fn: '#82aaff', id: '#89ddff', brace: '#7c8ba0',
+};
+
+// ═══════════════════════════════════════════════════════
+// CODE PANEL (unchanged logic)
+// ═══════════════════════════════════════════════════════
+
+type Token = { text: string; color?: string };
+const KEYWORDS = new Set(['export', 'default', 'const']);
+const FN_NAMES = new Set(['skill', 'step', 'survey', 'subagent', 'plan', 'checklist', 'build', 'act']);
+const PROPS = new Set(['name', 'entry', 'prompt', 'next', 'question', 'options', 'steps', 'create', 'action', 'run']);
+const IDS = new Set(['terminal', 'saveReport', 'sections']);
+
+function tokenizeLine(raw: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < raw.length) {
+    if (raw[i] === ' ' || raw[i] === '\t') {
+      let j = i; while (j < raw.length && (raw[j] === ' ' || raw[j] === '\t')) j++;
+      tokens.push({ text: raw.slice(i, j) }); i = j;
+    } else if (raw[i] === "'") {
+      let j = i + 1; while (j < raw.length && raw[j] !== "'") j++; j++;
+      tokens.push({ text: raw.slice(i, j), color: c.str }); i = j;
+    } else if (raw.slice(i, i + 3) === '...') {
+      tokens.push({ text: '...', color: c.id }); i += 3;
+    } else if ('{}[]()'.includes(raw[i])) {
+      tokens.push({ text: raw[i], color: c.brace }); i++;
+    } else if (',:'.includes(raw[i])) {
+      tokens.push({ text: raw[i], color: c.brace }); i++;
+    } else if (raw[i] === '.') {
+      tokens.push({ text: '.', color: c.brace }); i++;
+    } else if (/[a-zA-Z_$]/.test(raw[i])) {
+      let j = i; while (j < raw.length && /[a-zA-Z0-9_$]/.test(raw[j])) j++;
+      const word = raw.slice(i, j);
+      const rest = raw.slice(j).match(/^(\s*)(.)/);
+      const nextChar = rest ? rest[2] : '';
+      let color: string | undefined;
+      if (KEYWORDS.has(word)) color = c.kw;
+      else if (FN_NAMES.has(word) && (nextChar === '(' || nextChar === '.')) color = c.fn;
+      else if (PROPS.has(word) && nextChar === ':') color = c.codeText;
+      else if (IDS.has(word)) color = c.id;
+      tokens.push({ text: word, color }); i = j;
+    } else {
+      tokens.push({ text: raw[i] }); i++;
+    }
+  }
+  return tokens;
+}
+
+const codeTokens = storyboard.code.split('\n').map(tokenizeLine);
+
+function buildStepRanges(code: string): Map<number, string> {
+  const lines = code.split('\n');
+  const map = new Map<number, string>();
+  let currentStep: string | null = null;
+  let depth = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = line.match(/\.step\('([^']+)'/);
+    if (m) { currentStep = m[1]; depth = 0; }
+    if (currentStep !== null) {
+      map.set(i, currentStep);
+      for (const ch of line) { if (ch === '{' || ch === '(') depth++; if (ch === '}' || ch === ')') depth--; }
+      if (depth <= 0) currentStep = null;
+    }
+  }
+  return map;
+}
+const stepRanges = buildStepRanges(storyboard.code);
+
+function CodePanel({ activeStep }: { activeStep: string | null }) {
+  return (
+    <div style={{
+      background: c.codeBg, border: `1px solid ${c.codeBorder}`, borderRadius: 10,
+      overflow: 'hidden', boxShadow: '0 4px 20px rgba(0,0,0,0.12)',
+      fontFamily: "'IBM Plex Mono', monospace", fontSize: 13, lineHeight: 1.65,
+    }}>
+      <div style={{
+        padding: '8px 16px', borderBottom: `1px solid ${c.codeBorder}`,
+        background: 'rgba(0,0,0,0.2)', color: '#64748b', fontSize: 12,
+      }}>
+        security-audit.ts
+      </div>
+      <div style={{ padding: '14px 0', overflowX: 'auto' }}>
+        {codeTokens.map((tokens, i) => {
+          const step = stepRanges.get(i);
+          const isActive = step !== undefined && step === activeStep;
+          return (
+            <div key={i} style={{
+              padding: '0 16px', minHeight: 21, whiteSpace: 'pre',
+              borderLeft: isActive ? `3px solid ${c.accent}` : '3px solid transparent',
+              background: isActive ? 'rgba(15,145,153,0.08)' : 'transparent',
+              transition: 'background 400ms ease, border-color 400ms ease',
+            }}>
+              {tokens.length === 0 ? ' ' : tokens.map((t, j) =>
+                t.color ? <span key={j} style={{ color: t.color }}>{t.text}</span> : <span key={j}>{t.text}</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════
+// TERMINAL: Summary line renderers (condensed past)
+// ═══════════════════════════════════════════════════════
+
+function SummaryAgent({ text }: { text: string }) {
+  return (
+    <div style={{ display: 'flex', gap: 10, alignItems: 'baseline' }}>
+      <span style={{ color: c.green, fontSize: 9 }}>●</span>
+      <span style={{ color: c.termText }}>{text}</span>
+    </div>
+  );
+}
+
+function SummaryAnswers({ answers }: { answers: { question: string; answer: string }[] }) {
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'baseline', marginBottom: 2 }}>
+        <span style={{ color: c.green, fontSize: 9 }}>●</span>
+        <span style={{ color: c.white, fontWeight: 600 }}>User answered questions:</span>
+      </div>
+      {answers.map((a, i) => (
+        <div key={i} style={{ display: 'flex', gap: 6, paddingLeft: 20, alignItems: 'baseline' }}>
+          <span style={{ color: c.dim, width: 12, flexShrink: 0 }}>{i === 0 ? '└' : ' '}</span>
+          <span style={{ color: c.dim }}>·</span>
+          <span style={{ color: c.muted }}>{a.question}</span>
+          <span style={{ color: c.dim }}>→</span>
+          <span style={{ color: c.blue, fontWeight: 500 }}>{a.answer}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SummarySubagent({ label, name, stats }: { label: string; name: string; stats: string }) {
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'baseline' }}>
+        <span style={{ color: c.blue, fontSize: 9 }}>●</span>
+        <span style={{ color: c.blue, fontWeight: 700 }}>{label}</span>
+        <span style={{ color: c.termText }}>({name})</span>
+      </div>
+      <div style={{ paddingLeft: 20, display: 'flex', gap: 6, alignItems: 'baseline' }}>
+        <span style={{ color: c.dim }}>└</span>
+        <span style={{ color: c.dim }}>Done ({stats})</span>
+      </div>
+    </div>
+  );
+}
+
+function SummaryMeta({ text }: { text: string }) {
+  return <div style={{ paddingLeft: 20, color: c.dim, fontSize: 12 }}>{text}</div>;
+}
+
+function RenderSummaryLine({ line }: { line: SummaryLine }) {
+  switch (line.type) {
+    case 'agent': return <SummaryAgent text={line.text} />;
+    case 'answers': return <SummaryAnswers answers={line.answers} />;
+    case 'subagent': return <SummarySubagent label={line.label} name={line.name} stats={line.stats} />;
+    case 'meta': return <SummaryMeta text={line.text} />;
+  }
+}
+
+// ═══════════════════════════════════════════════════════
+// TERMINAL: Rich frame renderers (active step)
+// ═══════════════════════════════════════════════════════
+
+function TabBar({ tabs }: { tabs: SurveyPicker['tabs'] }) {
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12 }}>
+      <span style={{ color: c.dim }}>←</span>
+      {tabs.map((t, i) => (
+        <span key={i} style={{
+          padding: '2px 8px', borderRadius: 3, fontSize: 12, fontWeight: 500,
+          background: t.active ? 'rgba(96,165,250,0.15)' : 'transparent',
+          color: t.active ? c.blue : t.done ? c.muted : c.dim,
+          border: t.active ? '1px solid rgba(96,165,250,0.3)' : '1px solid transparent',
+        }}>
+          {t.done ? '✕ ' : '☐ '}{t.label}
+        </span>
+      ))}
+      <span style={{ color: c.dim }}>→</span>
+    </div>
+  );
+}
+
+function FrameSurveyPicker({ data }: { data: SurveyPicker }) {
+  return (
+    <div>
+      <TabBar tabs={data.tabs} />
+      <div style={{ color: c.white, fontWeight: 600, marginBottom: 10 }}>{data.question}</div>
+      {data.options.map((opt, i) => (
+        <div key={i} style={{ display: 'flex', gap: 6, padding: '3px 0', color: opt.selected ? c.termText : c.dim }}>
+          <span style={{ color: c.green, fontWeight: 700, width: 14, flexShrink: 0 }}>{opt.selected ? '›' : ' '}</span>
+          <span style={{ width: 18, flexShrink: 0 }}>{i + 1}.</span>
+          <div>
+            <div style={{ fontWeight: opt.selected ? 600 : 400, color: opt.selected ? '#fff' : 'inherit' }}>{opt.label}</div>
+            {opt.description && <div style={{ fontSize: 12, color: c.dim }}>{opt.description}</div>}
+          </div>
+        </div>
+      ))}
+      <div style={{ marginTop: 10, fontSize: 12, color: c.dim }}>{data.footer}</div>
+    </div>
+  );
+}
+
+function FrameSurveyReview({ data }: { data: SurveyReview }) {
+  return (
+    <div>
+      <TabBar tabs={data.tabs} />
+      <div style={{ color: c.white, fontWeight: 600, marginBottom: 8 }}>Review your answers</div>
+      {data.answers.map((a, i) => (
+        <div key={i} style={{ marginBottom: 4 }}>
+          <div style={{ display: 'flex', gap: 6, alignItems: 'baseline' }}>
+            <span style={{ color: c.green, fontSize: 9 }}>●</span>
+            <span style={{ color: c.muted }}>{a.question}</span>
+          </div>
+          <div style={{ paddingLeft: 18, color: c.blue, fontWeight: 500 }}>→ {a.answer}</div>
+        </div>
+      ))}
+      <div style={{ marginTop: 10, color: c.muted, marginBottom: 6 }}>Ready to submit your answers?</div>
+      {data.confirmOptions.map((opt, i) => (
+        <div key={i} style={{ display: 'flex', gap: 6, padding: '1px 0', color: opt.selected ? c.termText : c.dim }}>
+          <span style={{ color: c.green, fontWeight: 700, width: 14, flexShrink: 0 }}>{opt.selected ? '›' : ' '}</span>
+          <span style={{ width: 18, flexShrink: 0 }}>{i + 1}.</span>
+          <span style={{ fontWeight: opt.selected ? 600 : 400, color: opt.selected ? '#fff' : 'inherit' }}>{opt.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FrameAnswersSummary({ data }: { data: AnswersSummary }) {
+  return <SummaryAnswers answers={data.answers} />;
+}
+
+function FrameSubagentRunning({ data }: { data: SubagentRunning }) {
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'baseline', marginBottom: 12 }}>
+        <span style={{ color: c.green, fontSize: 9 }}>●</span>
+        <span style={{ color: c.termText }}>{data.agentMessage}</span>
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'baseline' }}>
+        <span style={{ color: c.blue, fontSize: 9 }}>●</span>
+        <span style={{ color: c.blue, fontWeight: 700 }}>{data.label}</span>
+        <span style={{ color: c.termText }}>({data.name})</span>
+      </div>
+      <div style={{ paddingLeft: 20, display: 'flex', gap: 6, alignItems: 'baseline' }}>
+        <span style={{ color: c.dim }}>└</span>
+        <span style={{ color: c.amber }}>Running…</span>
+      </div>
+      <div style={{ paddingLeft: 26, marginTop: 2, fontSize: 12, color: c.dim }}>{data.elapsed}</div>
+    </div>
+  );
+}
+
+function FrameSubagentDone({ data }: { data: SubagentDone }) {
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'baseline', marginBottom: 12 }}>
+        <span style={{ color: c.green, fontSize: 9 }}>●</span>
+        <span style={{ color: c.termText }}>{data.agentMessage}</span>
+      </div>
+      <SummarySubagent label={data.label} name={data.name} stats={data.stats} />
+    </div>
+  );
+}
+
+function FramePlan({ data }: { data: PlanCard }) {
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'baseline', marginBottom: 12 }}>
+        <span style={{ color: c.green, fontSize: 9 }}>●</span>
+        <span style={{ color: c.termText }}>Here's the proposed audit structure.</span>
+      </div>
+      <div style={{ border: '1px solid #262626', borderRadius: 8, overflow: 'hidden', marginLeft: 8 }}>
+        <div style={{ padding: '8px 14px', background: 'rgba(255,255,255,0.03)', borderBottom: '1px solid #262626' }}>
+          <span style={{ color: c.purple, fontWeight: 700, fontSize: 13 }}>{data.title}</span>
+        </div>
+        <div style={{ padding: '12px 14px' }}>
+          {data.steps.map((s, i) => (
+            <div key={i} style={{ display: 'flex', gap: 8, padding: '2px 0', flexWrap: 'wrap' }}>
+              <span style={{ color: c.dim, width: 16, textAlign: 'right', flexShrink: 0 }}>{i + 1}.</span>
+              <span style={{ color: c.white, fontWeight: 600 }}>{s.heading}</span>
+              <span style={{ color: c.muted }}>— {s.detail}</span>
+            </div>
+          ))}
+          <div style={{ height: 1, background: '#262626', margin: '10px 0' }} />
+          <div style={{ color: c.muted, marginBottom: 6 }}>{data.approval.question}</div>
+          {data.approval.options.map((opt, i) => (
+            <div key={i} style={{ display: 'flex', gap: 6, padding: '1px 0', color: opt.selected ? c.termText : c.dim }}>
+              <span style={{ color: c.green, fontWeight: 700, width: 12, flexShrink: 0 }}>{opt.selected ? '›' : ' '}</span>
+              <span style={{ width: 16, flexShrink: 0 }}>{i + 1}.</span>
+              <span style={{ fontWeight: opt.selected ? 600 : 400, color: opt.selected ? '#fff' : 'inherit' }}>{opt.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FrameActionRunning({ data }: { data: ActionRunning }) {
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'baseline', marginBottom: 12 }}>
+        <span style={{ color: c.green, fontSize: 9 }}>●</span>
+        <span style={{ color: c.termText }}>{data.agentMessage}</span>
+      </div>
+      <div style={{ paddingLeft: 20, display: 'flex', gap: 8, alignItems: 'baseline' }}>
+        <span style={{ color: c.amber }}>⟳</span>
+        <span style={{ color: c.amber }}>Running action</span>
+        <span style={{ color: c.dim }}>{data.actionLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+function FrameActionDone({ data }: { data: ActionDone }) {
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 10, alignItems: 'baseline', marginBottom: 12 }}>
+        <span style={{ color: c.green, fontSize: 9 }}>●</span>
+        <span style={{ color: c.green }}>{data.agentMessage}</span>
+      </div>
+      <div style={{ paddingLeft: 20 }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'baseline', marginBottom: 4 }}>
+          <span style={{ color: c.green }}>✓</span>
+          <span style={{ color: c.dim }}>{data.actionLabel}</span>
+        </div>
+        <div style={{ paddingLeft: 20, color: c.muted, fontSize: 12 }}>{data.result}</div>
+      </div>
+    </div>
+  );
+}
+
+function RenderFrame({ frame }: { frame: TerminalFrame }) {
+  switch (frame.type) {
+    case 'survey-picker': return <FrameSurveyPicker data={frame.data} />;
+    case 'survey-review': return <FrameSurveyReview data={frame.data} />;
+    case 'answers-summary': return <FrameAnswersSummary data={frame.data} />;
+    case 'subagent-running': return <FrameSubagentRunning data={frame.data} />;
+    case 'subagent-done': return <FrameSubagentDone data={frame.data} />;
+    case 'plan': return <FramePlan data={frame.data} />;
+    case 'action-running': return <FrameActionRunning data={frame.data} />;
+    case 'action-done': return <FrameActionDone data={frame.data} />;
+  }
+}
+
+// ═══════════════════════════════════════════════════════
+// TERMINAL PANEL: scrolling log with condensed past
+// ═══════════════════════════════════════════════════════
+
+function TerminalPanel({ frameIndex, activeSceneIdx }: { frameIndex: number; activeSceneIdx: number }) {
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom on any change
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (el) requestAnimationFrame(() => el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' }));
+  }, [frameIndex]);
+
+  const currentFrame = allFrames[frameIndex];
+
+  return (
+    <div style={{
+      background: c.termBg, border: `1px solid ${c.termBorder}`, borderRadius: 10,
+      overflow: 'hidden', fontFamily: "'IBM Plex Mono', monospace",
+      fontSize: 13, lineHeight: 1.55, color: c.termText,
+      boxShadow: '0 4px 20px rgba(0,0,0,0.25)',
+      display: 'flex', flexDirection: 'column', height: '100%',
+    }}>
+      {/* Command header */}
+      <div style={{ padding: '12px 20px', borderBottom: `1px solid ${c.termBorder}` }}>
+        <span style={{ color: c.dim, marginRight: 8 }}>▸</span>
+        <span style={{ color: '#fff', fontWeight: 600 }}>{storyboard.command}</span>
+      </div>
+
+      {/* Scrolling log body */}
+      <div ref={bodyRef} style={{
+        flex: 1, padding: '12px 20px', overflowY: 'auto',
+        scrollbarWidth: 'none',
+      }}>
+        {/* Past scenes: render summaries */}
+        {SCENES.slice(0, activeSceneIdx).map((scene, sIdx) => (
+          <div key={`s-${sIdx}`} style={{ marginBottom: 10 }}>
+            {scene.summary.map((line, lIdx) => (
+              <div key={lIdx} style={{ marginBottom: 3 }}>
+                <RenderSummaryLine line={line} />
+              </div>
+            ))}
+          </div>
+        ))}
+
+        {/* Current scene: rich frame */}
+        {currentFrame && (
+          <div key={`active-${frameIndex}`} style={{
+            animation: 'fadeSlideIn 350ms ease both',
+          }}>
+            <RenderFrame frame={currentFrame.content} />
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes fadeSlideIn {
+          from { opacity: 0; transform: translateY(6px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════
+// STEP DOTS (clickable)
+// ═══════════════════════════════════════════════════════
+
+function StepDots({ activeScene, onClickScene }: { activeScene: number; onClickScene: (i: number) => void }) {
+  return (
+    <div style={{ display: 'flex', gap: 6, justifyContent: 'center', alignItems: 'center', padding: '12px 0' }}>
+      {SCENES.map((scene, i) => (
+        <button key={i} onClick={() => onClickScene(i)} title={scene.stepName} style={{
+          width: i === activeScene ? 20 : 8, height: 8, borderRadius: 4,
+          background: i === activeScene ? c.accent : i < activeScene ? c.muted : '#ccc',
+          border: 'none', padding: 0, cursor: 'pointer',
+          transition: 'width 300ms ease, background 300ms ease',
+        }} />
+      ))}
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════
+// ORCHESTRATOR
+// ═══════════════════════════════════════════════════════
+
+export default function HeroDemo() {
+  const [frameIndex, setFrameIndex] = useState(-1);
+  const [paused, setPaused] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startedRef = useRef(false);
+
+  const advance = useCallback(() => {
+    setFrameIndex((prev) => {
+      const next = prev + 1;
+      if (next >= allFrames.length) return -1;
+      return next;
+    });
+  }, []);
+
+  const firstFrameOfScene = useCallback((sceneIdx: number): number => {
+    let idx = 0;
+    for (let s = 0; s < sceneIdx; s++) idx += SCENES[s].frames.length;
+    return idx;
+  }, []);
+
+  const jumpToScene = useCallback((sceneIdx: number) => {
+    setFrameIndex(firstFrameOfScene(sceneIdx));
+  }, [firstFrameOfScene]);
+
+  useEffect(() => {
+    if (!startedRef.current || paused) return;
+    if (frameIndex === -1) {
+      timerRef.current = setTimeout(() => setFrameIndex(0), RESTART_DELAY);
+      return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+    }
+    if (frameIndex >= 0 && frameIndex < allFrames.length) {
+      timerRef.current = setTimeout(advance, allFrames[frameIndex].duration);
+      return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+    }
+  }, [frameIndex, paused, advance]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || startedRef.current) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setFrameIndex(allFrames.length - 1);
+      startedRef.current = true;
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !startedRef.current) {
+          startedRef.current = true;
+          setFrameIndex(0);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.3 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const safeFrameIndex = Math.max(0, frameIndex);
+  const currentFrame = allFrames[safeFrameIndex];
+  const activeStep = currentFrame ? currentFrame.stepName : null;
+  const activeScene = currentFrame ? currentFrame.sceneIdx : 0;
+
+  return (
+    <div
+      ref={containerRef}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      className="hero-demo"
+    >
+      <div className="hero-demo-code">
+        <CodePanel activeStep={activeStep} />
+      </div>
+      <div className="hero-demo-terminal">
+        <TerminalPanel frameIndex={safeFrameIndex} activeSceneIdx={activeScene} />
+        <StepDots activeScene={activeScene} onClickScene={jumpToScene} />
+      </div>
+    </div>
+  );
+}

--- a/docs-site/src/components/HeroDemo.tsx
+++ b/docs-site/src/components/HeroDemo.tsx
@@ -28,11 +28,25 @@ for (let s = 0; s < SCENES.length; s++) {
 // --- Colors ---
 
 const c = {
-  codeBg: '#1e293b', codeBorder: '#334155', codeText: '#e2e8f0',
-  termBg: '#0e0e0e', termBorder: '#1e1e1e', termText: '#d4d4d4',
-  green: '#4ade80', blue: '#60a5fa', purple: '#c084fc', amber: '#fbbf24',
-  dim: '#525252', muted: '#737373', white: '#e5e5e5', accent: '#0f9199',
-  kw: '#c792ea', str: '#c3e88d', fn: '#82aaff', id: '#89ddff', brace: '#7c8ba0',
+  codeBg: '#1e293b',
+  codeBorder: '#334155',
+  codeText: '#e2e8f0',
+  termBg: '#0e0e0e',
+  termBorder: '#1e1e1e',
+  termText: '#d4d4d4',
+  green: '#4ade80',
+  blue: '#60a5fa',
+  purple: '#c084fc',
+  amber: '#fbbf24',
+  dim: '#525252',
+  muted: '#737373',
+  white: '#e5e5e5',
+  accent: '#0f9199',
+  kw: '#c792ea',
+  str: '#c3e88d',
+  fn: '#82aaff',
+  id: '#89ddff',
+  brace: '#7c8ba0',
 };
 
 // ═══════════════════════════════════════════════════════
@@ -50,21 +64,31 @@ function tokenizeLine(raw: string): Token[] {
   let i = 0;
   while (i < raw.length) {
     if (raw[i] === ' ' || raw[i] === '\t') {
-      let j = i; while (j < raw.length && (raw[j] === ' ' || raw[j] === '\t')) j++;
-      tokens.push({ text: raw.slice(i, j) }); i = j;
+      let j = i;
+      while (j < raw.length && (raw[j] === ' ' || raw[j] === '\t')) j++;
+      tokens.push({ text: raw.slice(i, j) });
+      i = j;
     } else if (raw[i] === "'") {
-      let j = i + 1; while (j < raw.length && raw[j] !== "'") j++; j++;
-      tokens.push({ text: raw.slice(i, j), color: c.str }); i = j;
+      let j = i + 1;
+      while (j < raw.length && raw[j] !== "'") j++;
+      j++;
+      tokens.push({ text: raw.slice(i, j), color: c.str });
+      i = j;
     } else if (raw.slice(i, i + 3) === '...') {
-      tokens.push({ text: '...', color: c.id }); i += 3;
+      tokens.push({ text: '...', color: c.id });
+      i += 3;
     } else if ('{}[]()'.includes(raw[i])) {
-      tokens.push({ text: raw[i], color: c.brace }); i++;
+      tokens.push({ text: raw[i], color: c.brace });
+      i++;
     } else if (',:'.includes(raw[i])) {
-      tokens.push({ text: raw[i], color: c.brace }); i++;
+      tokens.push({ text: raw[i], color: c.brace });
+      i++;
     } else if (raw[i] === '.') {
-      tokens.push({ text: '.', color: c.brace }); i++;
+      tokens.push({ text: '.', color: c.brace });
+      i++;
     } else if (/[a-zA-Z_$]/.test(raw[i])) {
-      let j = i; while (j < raw.length && /[a-zA-Z0-9_$]/.test(raw[j])) j++;
+      let j = i;
+      while (j < raw.length && /[a-zA-Z0-9_$]/.test(raw[j])) j++;
       const word = raw.slice(i, j);
       const rest = raw.slice(j).match(/^(\s*)(.)/);
       const nextChar = rest ? rest[2] : '';
@@ -73,9 +97,11 @@ function tokenizeLine(raw: string): Token[] {
       else if (FN_NAMES.has(word) && (nextChar === '(' || nextChar === '.')) color = c.fn;
       else if (PROPS.has(word) && nextChar === ':') color = c.codeText;
       else if (IDS.has(word)) color = c.id;
-      tokens.push({ text: word, color }); i = j;
+      tokens.push({ text: word, color });
+      i = j;
     } else {
-      tokens.push({ text: raw[i] }); i++;
+      tokens.push({ text: raw[i] });
+      i++;
     }
   }
   return tokens;
@@ -91,10 +117,16 @@ function buildStepRanges(code: string): Map<number, string> {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const m = line.match(/\.step\('([^']+)'/);
-    if (m) { currentStep = m[1]; depth = 0; }
+    if (m) {
+      currentStep = m[1];
+      depth = 0;
+    }
     if (currentStep !== null) {
       map.set(i, currentStep);
-      for (const ch of line) { if (ch === '{' || ch === '(') depth++; if (ch === '}' || ch === ')') depth--; }
+      for (const ch of line) {
+        if (ch === '{' || ch === '(') depth++;
+        if (ch === '}' || ch === ')') depth--;
+      }
       if (depth <= 0) currentStep = null;
     }
   }
@@ -104,16 +136,29 @@ const stepRanges = buildStepRanges(storyboard.code);
 
 function CodePanel({ activeStep, onClickStep }: { activeStep: string | null; onClickStep: (step: string) => void }) {
   return (
-    <div style={{
-      background: c.codeBg, border: `1px solid ${c.codeBorder}`, borderRadius: 10,
-      overflow: 'hidden', boxShadow: '0 8px 32px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.12)',
-      fontFamily: "'IBM Plex Mono', monospace", fontSize: 13, lineHeight: 1.65,
-    }}>
+    <div
+      style={{
+        background: c.codeBg,
+        border: `1px solid ${c.codeBorder}`,
+        borderRadius: 10,
+        overflow: 'hidden',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.18), 0 2px 8px rgba(0,0,0,0.12)',
+        fontFamily: "'IBM Plex Mono', monospace",
+        fontSize: 13,
+        lineHeight: 1.65,
+      }}
+    >
       {/* Window chrome */}
-      <div style={{
-        padding: '10px 16px', borderBottom: `1px solid ${c.codeBorder}`,
-        background: 'rgba(0,0,0,0.25)', display: 'flex', alignItems: 'center', gap: 8,
-      }}>
+      <div
+        style={{
+          padding: '10px 16px',
+          borderBottom: `1px solid ${c.codeBorder}`,
+          background: 'rgba(0,0,0,0.25)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
         <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff5f57', flexShrink: 0 }} />
         <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#febc2e', flexShrink: 0 }} />
         <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#28c840', flexShrink: 0 }} />
@@ -124,23 +169,46 @@ function CodePanel({ activeStep, onClickStep }: { activeStep: string | null; onC
           const step = stepRanges.get(i);
           const isActive = step !== undefined && step === activeStep;
           return (
-            <div key={i} onClick={step ? () => onClickStep(step) : undefined} style={{
-              display: 'flex', minHeight: 21, whiteSpace: 'pre',
-              borderLeft: isActive ? `3px solid ${c.accent}` : '3px solid transparent',
-              background: isActive ? 'rgba(15,145,153,0.08)' : 'transparent',
-              transition: 'background 400ms ease, border-color 400ms ease',
-              cursor: step ? 'pointer' : 'default',
-            }}>
+            <div
+              key={i}
+              onClick={step ? () => onClickStep(step) : undefined}
+              style={{
+                display: 'flex',
+                minHeight: 21,
+                whiteSpace: 'pre',
+                borderLeft: isActive ? `3px solid ${c.accent}` : '3px solid transparent',
+                background: isActive ? 'rgba(15,145,153,0.08)' : 'transparent',
+                transition: 'background 400ms ease, border-color 400ms ease',
+                cursor: step ? 'pointer' : 'default',
+              }}
+            >
               {/* Line number */}
-              <span style={{
-                width: 36, flexShrink: 0, textAlign: 'right', paddingRight: 12,
-                color: isActive ? '#64748b' : '#3e4a5c', userSelect: 'none', fontSize: 12,
-              }}>{i + 1}</span>
+              <span
+                style={{
+                  width: 36,
+                  flexShrink: 0,
+                  textAlign: 'right',
+                  paddingRight: 12,
+                  color: isActive ? '#64748b' : '#3e4a5c',
+                  userSelect: 'none',
+                  fontSize: 12,
+                }}
+              >
+                {i + 1}
+              </span>
               {/* Code content */}
               <span style={{ paddingRight: 16 }}>
-                {tokens.length === 0 ? ' ' : tokens.map((t, j) =>
-                  t.color ? <span key={j} style={{ color: t.color }}>{t.text}</span> : <span key={j}>{t.text}</span>
-                )}
+                {tokens.length === 0
+                  ? ' '
+                  : tokens.map((t, j) =>
+                      t.color ? (
+                        <span key={j} style={{ color: t.color }}>
+                          {t.text}
+                        </span>
+                      ) : (
+                        <span key={j}>{t.text}</span>
+                      ),
+                    )}
               </span>
             </div>
           );
@@ -205,10 +273,14 @@ function SummaryMeta({ text }: { text: string }) {
 
 function RenderSummaryLine({ line }: { line: SummaryLine }) {
   switch (line.type) {
-    case 'agent': return <SummaryAgent text={line.text} />;
-    case 'answers': return <SummaryAnswers answers={line.answers} />;
-    case 'subagent': return <SummarySubagent label={line.label} name={line.name} stats={line.stats} />;
-    case 'meta': return <SummaryMeta text={line.text} />;
+    case 'agent':
+      return <SummaryAgent text={line.text} />;
+    case 'answers':
+      return <SummaryAnswers answers={line.answers} />;
+    case 'subagent':
+      return <SummarySubagent label={line.label} name={line.name} stats={line.stats} />;
+    case 'meta':
+      return <SummaryMeta text={line.text} />;
   }
 }
 
@@ -221,13 +293,20 @@ function TabBar({ tabs }: { tabs: SurveyPicker['tabs'] }) {
     <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12 }}>
       <span style={{ color: c.dim }}>←</span>
       {tabs.map((t, i) => (
-        <span key={i} style={{
-          padding: '2px 8px', borderRadius: 3, fontSize: 12, fontWeight: 500,
-          background: t.active ? 'rgba(96,165,250,0.15)' : 'transparent',
-          color: t.active ? c.blue : t.done ? c.muted : c.dim,
-          border: t.active ? '1px solid rgba(96,165,250,0.3)' : '1px solid transparent',
-        }}>
-          {t.done ? '✓ ' : '☐ '}{t.label}
+        <span
+          key={i}
+          style={{
+            padding: '2px 8px',
+            borderRadius: 3,
+            fontSize: 12,
+            fontWeight: 500,
+            background: t.active ? 'rgba(96,165,250,0.15)' : 'transparent',
+            color: t.active ? c.blue : t.done ? c.muted : c.dim,
+            border: t.active ? '1px solid rgba(96,165,250,0.3)' : '1px solid transparent',
+          }}
+        >
+          {t.done ? '✓ ' : '☐ '}
+          {t.label}
         </span>
       ))}
       <span style={{ color: c.dim }}>→</span>
@@ -245,7 +324,9 @@ function FrameSurveyPicker({ data }: { data: SurveyPicker }) {
           <span style={{ color: c.green, fontWeight: 700, width: 14, flexShrink: 0 }}>{opt.selected ? '›' : ' '}</span>
           <span style={{ width: 18, flexShrink: 0 }}>{i + 1}.</span>
           <div>
-            <div style={{ fontWeight: opt.selected ? 600 : 400, color: opt.selected ? '#fff' : 'inherit' }}>{opt.label}</div>
+            <div style={{ fontWeight: opt.selected ? 600 : 400, color: opt.selected ? '#fff' : 'inherit' }}>
+              {opt.label}
+            </div>
             {opt.description && <div style={{ fontSize: 12, color: c.dim }}>{opt.description}</div>}
           </div>
         </div>
@@ -274,7 +355,9 @@ function FrameSurveyReview({ data }: { data: SurveyReview }) {
         <div key={i} style={{ display: 'flex', gap: 6, padding: '1px 0', color: opt.selected ? c.termText : c.dim }}>
           <span style={{ color: c.green, fontWeight: 700, width: 14, flexShrink: 0 }}>{opt.selected ? '›' : ' '}</span>
           <span style={{ width: 18, flexShrink: 0 }}>{i + 1}.</span>
-          <span style={{ fontWeight: opt.selected ? 600 : 400, color: opt.selected ? '#fff' : 'inherit' }}>{opt.label}</span>
+          <span style={{ fontWeight: opt.selected ? 600 : 400, color: opt.selected ? '#fff' : 'inherit' }}>
+            {opt.label}
+          </span>
         </div>
       ))}
     </div>
@@ -340,10 +423,17 @@ function FramePlan({ data }: { data: PlanCard }) {
           <div style={{ height: 1, background: '#262626', margin: '10px 0' }} />
           <div style={{ color: c.muted, marginBottom: 6 }}>{data.approval.question}</div>
           {data.approval.options.map((opt, i) => (
-            <div key={i} style={{ display: 'flex', gap: 6, padding: '1px 0', color: opt.selected ? c.termText : c.dim }}>
-              <span style={{ color: c.green, fontWeight: 700, width: 12, flexShrink: 0 }}>{opt.selected ? '›' : ' '}</span>
+            <div
+              key={i}
+              style={{ display: 'flex', gap: 6, padding: '1px 0', color: opt.selected ? c.termText : c.dim }}
+            >
+              <span style={{ color: c.green, fontWeight: 700, width: 12, flexShrink: 0 }}>
+                {opt.selected ? '›' : ' '}
+              </span>
               <span style={{ width: 16, flexShrink: 0 }}>{i + 1}.</span>
-              <span style={{ fontWeight: opt.selected ? 600 : 400, color: opt.selected ? '#fff' : 'inherit' }}>{opt.label}</span>
+              <span style={{ fontWeight: opt.selected ? 600 : 400, color: opt.selected ? '#fff' : 'inherit' }}>
+                {opt.label}
+              </span>
             </div>
           ))}
         </div>
@@ -388,14 +478,22 @@ function FrameActionDone({ data }: { data: ActionDone }) {
 
 function RenderFrame({ frame }: { frame: TerminalFrame }) {
   switch (frame.type) {
-    case 'survey-picker': return <FrameSurveyPicker data={frame.data} />;
-    case 'survey-review': return <FrameSurveyReview data={frame.data} />;
-    case 'answers-summary': return <FrameAnswersSummary data={frame.data} />;
-    case 'subagent-running': return <FrameSubagentRunning data={frame.data} />;
-    case 'subagent-done': return <FrameSubagentDone data={frame.data} />;
-    case 'plan': return <FramePlan data={frame.data} />;
-    case 'action-running': return <FrameActionRunning data={frame.data} />;
-    case 'action-done': return <FrameActionDone data={frame.data} />;
+    case 'survey-picker':
+      return <FrameSurveyPicker data={frame.data} />;
+    case 'survey-review':
+      return <FrameSurveyReview data={frame.data} />;
+    case 'answers-summary':
+      return <FrameAnswersSummary data={frame.data} />;
+    case 'subagent-running':
+      return <FrameSubagentRunning data={frame.data} />;
+    case 'subagent-done':
+      return <FrameSubagentDone data={frame.data} />;
+    case 'plan':
+      return <FramePlan data={frame.data} />;
+    case 'action-running':
+      return <FrameActionRunning data={frame.data} />;
+    case 'action-done':
+      return <FrameActionDone data={frame.data} />;
   }
 }
 
@@ -415,18 +513,33 @@ function TerminalPanel({ frameIndex, activeSceneIdx }: { frameIndex: number; act
   const currentFrame = allFrames[frameIndex];
 
   return (
-    <div style={{
-      background: c.termBg, border: `1px solid ${c.termBorder}`, borderRadius: 10,
-      overflow: 'hidden', fontFamily: "'IBM Plex Mono', monospace",
-      fontSize: 13, lineHeight: 1.55, color: c.termText,
-      boxShadow: '0 12px 40px rgba(0,0,0,0.35), 0 4px 12px rgba(0,0,0,0.2)',
-      display: 'flex', flexDirection: 'column', height: 380,
-    }}>
+    <div
+      style={{
+        background: c.termBg,
+        border: `1px solid ${c.termBorder}`,
+        borderRadius: 10,
+        overflow: 'hidden',
+        fontFamily: "'IBM Plex Mono', monospace",
+        fontSize: 13,
+        lineHeight: 1.55,
+        color: c.termText,
+        boxShadow: '0 12px 40px rgba(0,0,0,0.35), 0 4px 12px rgba(0,0,0,0.2)',
+        display: 'flex',
+        flexDirection: 'column',
+        height: 380,
+      }}
+    >
       {/* Window chrome + command */}
-      <div style={{
-        padding: '10px 20px', borderBottom: `1px solid ${c.termBorder}`,
-        background: 'rgba(255,255,255,0.02)', display: 'flex', alignItems: 'center', gap: 8,
-      }}>
+      <div
+        style={{
+          padding: '10px 20px',
+          borderBottom: `1px solid ${c.termBorder}`,
+          background: 'rgba(255,255,255,0.02)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
         <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff5f57', flexShrink: 0 }} />
         <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#febc2e', flexShrink: 0 }} />
         <span style={{ width: 12, height: 12, borderRadius: '50%', background: '#28c840', flexShrink: 0 }} />
@@ -435,10 +548,15 @@ function TerminalPanel({ frameIndex, activeSceneIdx }: { frameIndex: number; act
       </div>
 
       {/* Scrolling log body */}
-      <div ref={bodyRef} style={{
-        flex: 1, padding: '12px 20px', overflowY: 'auto',
-        scrollbarWidth: 'none',
-      }}>
+      <div
+        ref={bodyRef}
+        style={{
+          flex: 1,
+          padding: '12px 20px',
+          overflowY: 'auto',
+          scrollbarWidth: 'none',
+        }}
+      >
         {/* Past scenes: render summaries */}
         {SCENES.slice(0, activeSceneIdx).map((scene, sIdx) => (
           <div key={`s-${sIdx}`} style={{ marginBottom: 10 }}>
@@ -452,29 +570,43 @@ function TerminalPanel({ frameIndex, activeSceneIdx }: { frameIndex: number; act
 
         {/* Current scene: rich frame */}
         {currentFrame && (
-          <div key={`active-${frameIndex}`} style={{
-            animation: 'fadeSlideIn 350ms ease both',
-          }}>
+          <div
+            key={`active-${frameIndex}`}
+            style={{
+              animation: 'fadeSlideIn 350ms ease both',
+            }}
+          >
             <RenderFrame frame={currentFrame.content} />
           </div>
         )}
       </div>
 
       {/* Input bar — shown when the terminal isn't showing an interactive picker */}
-      {currentFrame && ['subagent-running', 'subagent-done', 'action-running', 'action-done'].includes(currentFrame.content.type) && (
-        <div style={{
-          borderTop: `1px solid ${c.termBorder}`, padding: '8px 20px',
-          display: 'flex', alignItems: 'center', gap: 8,
-          background: 'rgba(255,255,255,0.02)',
-        }}>
-          <span style={{ color: c.dim }}>›</span>
-          <span style={{
-            display: 'inline-block', width: 7, height: 16,
-            background: c.dim, verticalAlign: 'middle',
-            animation: 'cursorBlink 1s step-end infinite',
-          }} />
-        </div>
-      )}
+      {currentFrame &&
+        ['subagent-running', 'subagent-done', 'action-running', 'action-done'].includes(currentFrame.content.type) && (
+          <div
+            style={{
+              borderTop: `1px solid ${c.termBorder}`,
+              padding: '8px 20px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'rgba(255,255,255,0.02)',
+            }}
+          >
+            <span style={{ color: c.dim }}>›</span>
+            <span
+              style={{
+                display: 'inline-block',
+                width: 7,
+                height: 16,
+                background: c.dim,
+                verticalAlign: 'middle',
+                animation: 'cursorBlink 1s step-end infinite',
+              }}
+            />
+          </div>
+        )}
 
       <style>{`
         @keyframes fadeSlideIn {
@@ -498,12 +630,21 @@ function StepDots({ activeScene, onClickScene }: { activeScene: number; onClickS
   return (
     <div style={{ display: 'flex', gap: 6, justifyContent: 'center', alignItems: 'center', padding: '12px 0' }}>
       {SCENES.map((scene, i) => (
-        <button key={i} onClick={() => onClickScene(i)} title={scene.stepName} style={{
-          width: i === activeScene ? 20 : 8, height: 8, borderRadius: 4,
-          background: i === activeScene ? c.accent : i < activeScene ? c.muted : '#ccc',
-          border: 'none', padding: 0, cursor: 'pointer',
-          transition: 'width 300ms ease, background 300ms ease',
-        }} />
+        <button
+          key={i}
+          onClick={() => onClickScene(i)}
+          title={scene.stepName}
+          style={{
+            width: i === activeScene ? 20 : 8,
+            height: 8,
+            borderRadius: 4,
+            background: i === activeScene ? c.accent : i < activeScene ? c.muted : '#ccc',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
+            transition: 'width 300ms ease, background 300ms ease',
+          }}
+        />
       ))}
     </div>
   );
@@ -534,24 +675,34 @@ export default function HeroDemo() {
     return idx;
   }, []);
 
-  const jumpToScene = useCallback((sceneIdx: number) => {
-    setFrameIndex(firstFrameOfScene(sceneIdx));
-  }, [firstFrameOfScene]);
+  const jumpToScene = useCallback(
+    (sceneIdx: number) => {
+      setFrameIndex(firstFrameOfScene(sceneIdx));
+    },
+    [firstFrameOfScene],
+  );
 
-  const jumpToStep = useCallback((stepName: string) => {
-    const sceneIdx = SCENES.findIndex((s) => s.stepName === stepName);
-    if (sceneIdx >= 0) jumpToScene(sceneIdx);
-  }, [jumpToScene]);
+  const jumpToStep = useCallback(
+    (stepName: string) => {
+      const sceneIdx = SCENES.findIndex((s) => s.stepName === stepName);
+      if (sceneIdx >= 0) jumpToScene(sceneIdx);
+    },
+    [jumpToScene],
+  );
 
   useEffect(() => {
     if (!startedRef.current || paused) return;
     if (frameIndex === -1) {
       timerRef.current = setTimeout(() => setFrameIndex(0), RESTART_DELAY);
-      return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+      return () => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+      };
     }
     if (frameIndex >= 0 && frameIndex < allFrames.length) {
       timerRef.current = setTimeout(advance, allFrames[frameIndex].duration);
-      return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+      return () => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+      };
     }
   }, [frameIndex, paused, advance]);
 

--- a/docs-site/src/components/HeroDemo.tsx
+++ b/docs-site/src/components/HeroDemo.tsx
@@ -419,7 +419,7 @@ function TerminalPanel({ frameIndex, activeSceneIdx }: { frameIndex: number; act
       overflow: 'hidden', fontFamily: "'IBM Plex Mono', monospace",
       fontSize: 13, lineHeight: 1.55, color: c.termText,
       boxShadow: '0 12px 40px rgba(0,0,0,0.35), 0 4px 12px rgba(0,0,0,0.2)',
-      display: 'flex', flexDirection: 'column', height: '100%',
+      display: 'flex', flexDirection: 'column', height: 380,
     }}>
       {/* Window chrome + command */}
       <div style={{
@@ -570,6 +570,9 @@ export default function HeroDemo() {
       {/* Terminal: floating overlay, offset top-right */}
       <div className="hero-demo-terminal">
         <TerminalPanel frameIndex={safeFrameIndex} activeSceneIdx={activeScene} />
+      </div>
+      {/* Step dots below everything */}
+      <div className="hero-demo-dots">
         <StepDots activeScene={activeScene} onClickScene={jumpToScene} />
       </div>
     </div>

--- a/docs-site/src/components/HeroDemo.tsx
+++ b/docs-site/src/components/HeroDemo.tsx
@@ -459,10 +459,30 @@ function TerminalPanel({ frameIndex, activeSceneIdx }: { frameIndex: number; act
         )}
       </div>
 
+      {/* Input bar — shown when the terminal isn't showing an interactive picker */}
+      {currentFrame && ['subagent-running', 'subagent-done', 'action-running', 'action-done'].includes(currentFrame.content.type) && (
+        <div style={{
+          borderTop: `1px solid ${c.termBorder}`, padding: '8px 20px',
+          display: 'flex', alignItems: 'center', gap: 8,
+          background: 'rgba(255,255,255,0.02)',
+        }}>
+          <span style={{ color: c.dim }}>›</span>
+          <span style={{
+            display: 'inline-block', width: 7, height: 16,
+            background: c.dim, verticalAlign: 'middle',
+            animation: 'cursorBlink 1s step-end infinite',
+          }} />
+        </div>
+      )}
+
       <style>{`
         @keyframes fadeSlideIn {
           from { opacity: 0; transform: translateY(6px); }
           to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes cursorBlink {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0; }
         }
       `}</style>
     </div>

--- a/docs-site/src/components/Navbar.astro
+++ b/docs-site/src/components/Navbar.astro
@@ -17,7 +17,7 @@ function isActive(href: string) {
 <nav class="navbar">
   <div class="navbar-inner">
     <a href={base} class="navbar-logo">
-      <span class="logo-marker">▸</span>
+      <span class="logo-marker">&#9656;</span>
       <span class="logo-text">skill-kit</span>
     </a>
 
@@ -59,7 +59,7 @@ function isActive(href: string) {
     top: 0;
     z-index: 100;
     height: var(--nav-height);
-    background: rgba(10, 10, 10, 0.9);
+    background: rgba(250, 248, 245, 0.92);
     backdrop-filter: blur(12px);
     border-bottom: 1px solid var(--color-border);
   }
@@ -103,7 +103,10 @@ function isActive(href: string) {
     color: var(--color-text-muted);
     text-decoration: none;
     padding: var(--space-2) var(--space-3);
-    transition: color var(--transition-fast);
+    border-radius: 4px;
+    transition:
+      color var(--transition-fast),
+      background var(--transition-fast);
     display: flex;
     align-items: center;
     gap: var(--space-1);
@@ -111,6 +114,7 @@ function isActive(href: string) {
 
   .nav-link:hover {
     color: var(--color-text);
+    background: var(--color-bg-inset);
   }
 
   .nav-link.active {
@@ -121,12 +125,18 @@ function isActive(href: string) {
     margin-left: var(--space-3);
     padding-left: var(--space-4);
     border-left: 1px solid var(--color-border);
+    border-radius: 0;
+  }
+
+  .nav-link--github:hover {
+    background: none;
   }
 
   .menu-toggle {
     display: none;
     background: none;
     border: 1px solid var(--color-border);
+    border-radius: 4px;
     padding: var(--space-2);
     cursor: pointer;
     flex-direction: column;

--- a/docs-site/src/components/ProtocolDiagram.astro
+++ b/docs-site/src/components/ProtocolDiagram.astro
@@ -1,0 +1,87 @@
+---
+
+---
+
+<div class="protocol">
+  <div class="protocol-node">
+    <div class="protocol-node-label">Your Skill</div>
+  </div>
+
+  <div class="protocol-arrow">
+    <div class="protocol-arrow-line"></div>
+    <span class="protocol-arrow-text">start / advance</span>
+  </div>
+
+  <div class="protocol-node">
+    <div class="protocol-node-label">Any Agent Host</div>
+  </div>
+</div>
+
+<style>
+  .protocol {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-4);
+    padding: var(--space-4) 0;
+  }
+
+  .protocol-node {
+    padding: var(--space-3) var(--space-5);
+    border: 2px solid var(--color-border-focus);
+    border-radius: 8px;
+    background: var(--color-bg-elevated);
+  }
+
+  .protocol-node-label {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: var(--text-sm);
+    color: var(--color-text);
+  }
+
+  .protocol-arrow {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    min-width: 80px;
+  }
+
+  .protocol-arrow-line {
+    width: 100%;
+    height: 2px;
+    background: var(--color-border-focus);
+    position: relative;
+  }
+
+  .protocol-arrow-line::before,
+  .protocol-arrow-line::after {
+    content: '';
+    position: absolute;
+    top: -3px;
+    border: 4px solid transparent;
+  }
+
+  .protocol-arrow-line::after {
+    right: -1px;
+    border-left-color: var(--color-border-focus);
+  }
+
+  .protocol-arrow-line::before {
+    left: -1px;
+    border-right-color: var(--color-border-focus);
+  }
+
+  .protocol-arrow-text {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-text-dim);
+  }
+
+  @media (max-width: 480px) {
+    .protocol {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/docs-site/src/data/storyboard.ts
+++ b/docs-site/src/data/storyboard.ts
@@ -140,10 +140,7 @@ export const securityAudit: HeroStoryboard = {
                 { question: 'What should the audit focus on?', answer: 'Authentication' },
                 { question: 'Which framework?', answer: 'React' },
               ],
-              confirmOptions: [
-                { label: 'Submit answers', selected: true },
-                { label: 'Cancel' },
-              ],
+              confirmOptions: [{ label: 'Submit answers', selected: true }, { label: 'Cancel' }],
             },
           },
         },
@@ -166,7 +163,12 @@ export const securityAudit: HeroStoryboard = {
     {
       stepName: 'research',
       summary: [
-        { type: 'subagent', label: 'Explore', name: 'Research React auth security', stats: '5 tool uses · 10.3k tokens · 20s' },
+        {
+          type: 'subagent',
+          label: 'Explore',
+          name: 'Research React auth security',
+          stats: '5 tool uses · 10.3k tokens · 20s',
+        },
       ],
       frames: [
         {
@@ -201,9 +203,7 @@ export const securityAudit: HeroStoryboard = {
     // --- plan-and-write: plan card ---
     {
       stepName: 'plan-and-write',
-      summary: [
-        { type: 'agent', text: 'Plan approved — proceeding with the audit.' },
-      ],
+      summary: [{ type: 'agent', text: 'Plan approved — proceeding with the audit.' }],
       frames: [
         {
           duration: 5000,
@@ -218,10 +218,7 @@ export const securityAudit: HeroStoryboard = {
               ],
               approval: {
                 question: 'Does this plan look good?',
-                options: [
-                  { label: 'Yes, proceed', selected: true },
-                  { label: 'Suggest changes' },
-                ],
+                options: [{ label: 'Yes, proceed', selected: true }, { label: 'Suggest changes' }],
               },
             },
           },
@@ -232,9 +229,7 @@ export const securityAudit: HeroStoryboard = {
     // --- save-report: action writes file ---
     {
       stepName: 'save-report',
-      summary: [
-        { type: 'agent', text: 'Done — wrote report to security-audit.md' },
-      ],
+      summary: [{ type: 'agent', text: 'Done — wrote report to security-audit.md' }],
       frames: [
         {
           duration: 3000,
@@ -262,29 +257,29 @@ export const securityAudit: HeroStoryboard = {
   ],
 
   code: [
-    "export default skill({",
+    'export default skill({',
     "  name: 'security-audit',",
     "  entry: 'gather-scope',",
-    "})",
+    '})',
     "  .step('gather-scope', {",
-    "    prompt: act.survey([",
+    '    prompt: act.survey([',
     "      { question: 'Focus area?', options: ['Auth', 'XSS', 'Deps'] },",
     "      { question: 'Framework?', options: ['React', 'Vue', 'Svelte'] },",
-    "    ]),",
+    '    ]),',
     "    next: 'research',",
-    "  })",
+    '  })',
     "  .step('research', {",
     "    prompt: act.subagent({ prompt: 'Research best practices' }),",
     "    next: 'plan-and-write',",
-    "  })",
+    '  })',
     "  .step('plan-and-write', {",
     "    prompt: act.plan({ steps: ['Summary', 'Analysis', 'Findings'] }),",
     "    next: 'save-report',",
-    "  })",
+    '  })',
     "  .step('save-report', {",
-    "    action: { run: saveReport },",
-    "    next: terminal,",
-    "  })",
-    "  .build()",
+    '    action: { run: saveReport },',
+    '    next: terminal,',
+    '  })',
+    '  .build()',
   ].join('\n'),
 };

--- a/docs-site/src/data/storyboard.ts
+++ b/docs-site/src/data/storyboard.ts
@@ -215,7 +215,6 @@ export const securityAudit: HeroStoryboard = {
                 { heading: 'Executive Summary', detail: 'High-level overview of auth posture' },
                 { heading: 'Auth Flow Analysis', detail: 'Token lifecycle, session management' },
                 { heading: 'Vulnerability Assessment', detail: 'XSS vectors, CSRF, injection risks' },
-                { heading: 'Recommendations', detail: 'Prioritized remediation steps' },
               ],
               approval: {
                 question: 'Does this plan look good?',

--- a/docs-site/src/data/storyboard.ts
+++ b/docs-site/src/data/storyboard.ts
@@ -1,0 +1,291 @@
+// --- Terminal frame types: what to render in the terminal ---
+
+export interface SurveyPicker {
+  tabs: { label: string; done: boolean; active: boolean }[];
+  question: string;
+  options: { label: string; description?: string; selected?: boolean }[];
+  footer: string;
+}
+
+export interface SurveyReview {
+  tabs: { label: string; done: boolean; active: boolean }[];
+  answers: { question: string; answer: string }[];
+  confirmOptions: { label: string; selected?: boolean }[];
+}
+
+export interface AnswersSummary {
+  answers: { question: string; answer: string }[];
+}
+
+export interface SubagentRunning {
+  agentMessage: string;
+  label: string;
+  name: string;
+  status: 'running';
+  elapsed: string;
+}
+
+export interface SubagentDone {
+  agentMessage: string;
+  label: string;
+  name: string;
+  status: 'done';
+  stats: string;
+}
+
+export interface PlanCard {
+  title: string;
+  steps: { heading: string; detail: string }[];
+  approval: {
+    question: string;
+    options: { label: string; selected?: boolean }[];
+  };
+}
+
+export interface ActionRunning {
+  agentMessage: string;
+  actionLabel: string;
+}
+
+export interface ActionDone {
+  agentMessage: string;
+  actionLabel: string;
+  result: string;
+}
+
+export type TerminalFrame =
+  | { type: 'survey-picker'; data: SurveyPicker }
+  | { type: 'survey-review'; data: SurveyReview }
+  | { type: 'answers-summary'; data: AnswersSummary }
+  | { type: 'subagent-running'; data: SubagentRunning }
+  | { type: 'subagent-done'; data: SubagentDone }
+  | { type: 'plan'; data: PlanCard }
+  | { type: 'action-running'; data: ActionRunning }
+  | { type: 'action-done'; data: ActionDone };
+
+// --- Scene: one step, multiple frames ---
+
+export type SummaryLine =
+  | { type: 'agent'; text: string }
+  | { type: 'answers'; answers: { question: string; answer: string }[] }
+  | { type: 'subagent'; label: string; name: string; stats: string }
+  | { type: 'meta'; text: string };
+
+export interface Scene {
+  stepName: string;
+  frames: { content: TerminalFrame; duration: number }[];
+  summary: SummaryLine[];
+}
+
+// --- Storyboard ---
+
+export interface HeroStoryboard {
+  id: string;
+  command: string;
+  scenes: Scene[];
+  code: string;
+}
+
+// --- Security Audit ---
+
+export const securityAudit: HeroStoryboard = {
+  id: 'security-audit',
+  command: '/security-audit',
+  scenes: [
+    // --- gather-scope: survey picker → review → summary ---
+    {
+      stepName: 'gather-scope',
+      summary: [
+        { type: 'agent', text: 'Starting the security audit workflow.' },
+        {
+          type: 'answers',
+          answers: [
+            { question: 'Focus area?', answer: 'Authentication' },
+            { question: 'Framework?', answer: 'React' },
+          ],
+        },
+      ],
+      frames: [
+        {
+          duration: 2500,
+          content: {
+            type: 'survey-picker',
+            data: {
+              tabs: [
+                { label: 'Focus area', done: false, active: true },
+                { label: 'Framework', done: false, active: false },
+                { label: 'Submit', done: false, active: false },
+              ],
+              question: 'What should the audit focus on?',
+              options: [
+                { label: 'Authentication', description: 'Login flows, tokens, sessions', selected: true },
+                { label: 'XSS Prevention', description: 'Input sanitization, CSP headers' },
+                { label: 'Dependencies', description: 'Supply chain, outdated packages' },
+              ],
+              footer: 'Enter to select · Tab/Arrow keys to navigate',
+            },
+          },
+        },
+        {
+          duration: 2000,
+          content: {
+            type: 'survey-review',
+            data: {
+              tabs: [
+                { label: 'Focus area', done: true, active: false },
+                { label: 'Framework', done: true, active: false },
+                { label: 'Submit', done: false, active: true },
+              ],
+              answers: [
+                { question: 'What should the audit focus on?', answer: 'Authentication' },
+                { question: 'Which framework?', answer: 'React' },
+              ],
+              confirmOptions: [
+                { label: 'Submit answers', selected: true },
+                { label: 'Cancel' },
+              ],
+            },
+          },
+        },
+        {
+          duration: 1500,
+          content: {
+            type: 'answers-summary',
+            data: {
+              answers: [
+                { question: 'What should the audit focus on?', answer: 'Authentication' },
+                { question: 'Which framework?', answer: 'React' },
+              ],
+            },
+          },
+        },
+      ],
+    },
+
+    // --- research: subagent running → done ---
+    {
+      stepName: 'research',
+      summary: [
+        { type: 'subagent', label: 'Explore', name: 'Research React auth security', stats: '5 tool uses · 10.3k tokens · 20s' },
+      ],
+      frames: [
+        {
+          duration: 2000,
+          content: {
+            type: 'subagent-running',
+            data: {
+              agentMessage: 'Researching authentication security for React projects.',
+              label: 'Explore',
+              name: 'Research React auth security',
+              status: 'running',
+              elapsed: '12s · 4.2k tokens · thinking more',
+            },
+          },
+        },
+        {
+          duration: 1500,
+          content: {
+            type: 'subagent-done',
+            data: {
+              agentMessage: 'Got the research back. Let me continue with the findings.',
+              label: 'Explore',
+              name: 'Research React auth security',
+              status: 'done',
+              stats: '5 tool uses · 10.3k tokens · 20s',
+            },
+          },
+        },
+      ],
+    },
+
+    // --- plan-and-write: plan card ---
+    {
+      stepName: 'plan-and-write',
+      summary: [
+        { type: 'agent', text: 'Plan approved — proceeding with the audit.' },
+      ],
+      frames: [
+        {
+          duration: 3500,
+          content: {
+            type: 'plan',
+            data: {
+              title: 'Security Audit — React Authentication',
+              steps: [
+                { heading: 'Executive Summary', detail: 'High-level overview of auth posture' },
+                { heading: 'Auth Flow Analysis', detail: 'Token lifecycle, session management' },
+                { heading: 'Vulnerability Assessment', detail: 'XSS vectors, CSRF, injection risks' },
+                { heading: 'Recommendations', detail: 'Prioritized remediation steps' },
+              ],
+              approval: {
+                question: 'Does this plan look good?',
+                options: [
+                  { label: 'Yes, proceed', selected: true },
+                  { label: 'Suggest changes' },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+
+    // --- save-report: action writes file ---
+    {
+      stepName: 'save-report',
+      summary: [
+        { type: 'agent', text: 'Done — wrote report to security-audit.md' },
+      ],
+      frames: [
+        {
+          duration: 2000,
+          content: {
+            type: 'action-running',
+            data: {
+              agentMessage: 'Writing the report based on the approved plan.',
+              actionLabel: 'save-report',
+            },
+          },
+        },
+        {
+          duration: 2500,
+          content: {
+            type: 'action-done',
+            data: {
+              agentMessage: 'Done — wrote report to security-audit.md',
+              actionLabel: 'save-report',
+              result: 'Wrote 4 sections (3.2 KB) → /tmp/security-audit.md',
+            },
+          },
+        },
+      ],
+    },
+  ],
+
+  code: [
+    "export default skill({",
+    "  name: 'security-audit',",
+    "  entry: 'gather-scope',",
+    "})",
+    "  .step('gather-scope', {",
+    "    prompt: act.survey([",
+    "      { question: 'Focus area?', options: ['Auth', 'XSS', 'Deps'] },",
+    "      { question: 'Framework?', options: ['React', 'Vue', 'Svelte'] },",
+    "    ]),",
+    "    next: 'research',",
+    "  })",
+    "  .step('research', {",
+    "    prompt: act.subagent({ prompt: 'Research best practices' }),",
+    "    next: 'plan-and-write',",
+    "  })",
+    "  .step('plan-and-write', {",
+    "    prompt: act.plan({ steps: ['Summary', 'Analysis', 'Findings', 'Recs'] }),",
+    "    next: 'save-report',",
+    "  })",
+    "  .step('save-report', {",
+    "    action: { run: saveReport },",
+    "    next: terminal,",
+    "  })",
+    "  .build()",
+  ].join('\n'),
+};

--- a/docs-site/src/data/storyboard.ts
+++ b/docs-site/src/data/storyboard.ts
@@ -279,7 +279,7 @@ export const securityAudit: HeroStoryboard = {
     "    next: 'plan-and-write',",
     "  })",
     "  .step('plan-and-write', {",
-    "    prompt: act.plan({ steps: ['Summary', 'Analysis', 'Findings', 'Recs'] }),",
+    "    prompt: act.plan({ steps: ['Summary', 'Analysis', 'Findings'] }),",
     "    next: 'save-report',",
     "  })",
     "  .step('save-report', {",

--- a/docs-site/src/data/storyboard.ts
+++ b/docs-site/src/data/storyboard.ts
@@ -107,7 +107,7 @@ export const securityAudit: HeroStoryboard = {
       ],
       frames: [
         {
-          duration: 2500,
+          duration: 3800,
           content: {
             type: 'survey-picker',
             data: {
@@ -127,7 +127,7 @@ export const securityAudit: HeroStoryboard = {
           },
         },
         {
-          duration: 2000,
+          duration: 3000,
           content: {
             type: 'survey-review',
             data: {
@@ -148,7 +148,7 @@ export const securityAudit: HeroStoryboard = {
           },
         },
         {
-          duration: 1500,
+          duration: 2200,
           content: {
             type: 'answers-summary',
             data: {
@@ -170,7 +170,7 @@ export const securityAudit: HeroStoryboard = {
       ],
       frames: [
         {
-          duration: 2000,
+          duration: 3000,
           content: {
             type: 'subagent-running',
             data: {
@@ -183,7 +183,7 @@ export const securityAudit: HeroStoryboard = {
           },
         },
         {
-          duration: 1500,
+          duration: 2200,
           content: {
             type: 'subagent-done',
             data: {
@@ -206,7 +206,7 @@ export const securityAudit: HeroStoryboard = {
       ],
       frames: [
         {
-          duration: 3500,
+          duration: 5000,
           content: {
             type: 'plan',
             data: {
@@ -238,7 +238,7 @@ export const securityAudit: HeroStoryboard = {
       ],
       frames: [
         {
-          duration: 2000,
+          duration: 3000,
           content: {
             type: 'action-running',
             data: {
@@ -248,7 +248,7 @@ export const securityAudit: HeroStoryboard = {
           },
         },
         {
-          duration: 2500,
+          duration: 3500,
           content: {
             type: 'action-done',
             data: {

--- a/docs-site/src/layouts/BaseLayout.astro
+++ b/docs-site/src/layouts/BaseLayout.astro
@@ -19,7 +19,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
-    <meta name="theme-color" content="#0a0a0a" />
+    <meta name="theme-color" content="#faf8f5" />
     <link rel="canonical" href={canonicalURL} />
 
     <meta property="og:title" content={title} />
@@ -30,10 +30,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Instrument+Sans:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
-    <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap" rel="stylesheet" />
 
     <ViewTransitions />
     <title>{title}</title>

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Hero from '../components/Hero.astro';
 import FeatureCard from '../components/FeatureCard.astro';
+import ProtocolDiagram from '../components/ProtocolDiagram.astro';
 
 const base = import.meta.env.BASE_URL;
 ---
@@ -10,93 +11,70 @@ const base = import.meta.env.BASE_URL;
   <Hero />
 
   <section class="features">
-    <div class="features-inner">
-      <h2 class="section-label">What you get</h2>
+    <div class="section-inner">
+      <h2 class="section-heading">Why skill-kit</h2>
       <div class="feature-grid">
-        <FeatureCard title="Workflow Skills" icon="◇">
-          Typed state machines — steps with prompts, Zod schemas, branching, cross-step state, and explicit transitions.
-          The agent sees one step at a time.
+        <FeatureCard title="One SDK call, a full TUI element.">
+          <code>act.askUser()</code> becomes a structured question. <code>act.plan()</code> becomes an approval flow.
+          <code>act.subagent()</code> spawns a research agent. You define the interaction; every host renders its best
+          UI.
         </FeatureCard>
-        <FeatureCard title="Reference Skills" icon="◈">
-          Progressive disclosure for large docs. Agents read the SKILL.md, then load topics on demand. No JSON, no
-          state machine — just <code>topic &lt;name&gt;</code> → text.
+        <FeatureCard title="Deterministic routing, intelligent steps.">
+          Steps, schemas, and transitions are TypeScript. Branching is code, not hope. The agent reasons within each
+          step; the skill decides what happens next. Loops have guards. Output has Zod validation.
         </FeatureCard>
-        <FeatureCard title="Host-Aware Primitives" icon="◆">
-          Abstract verbs (<code>ASK_STRUCTURED</code>, <code>PRESENT_PLAN</code>) map to host-specific tools. Same
-          skill works in Claude Code, Codex, and OpenCode.
-        </FeatureCard>
-        <FeatureCard title="Build & Ship" icon="▸">
-          Compile to standalone executables (Bun) or lightweight Node.js bundles. Output is an agentskills.io-compliant
-          directory that any agent host can invoke via Bash.
-        </FeatureCard>
-        <FeatureCard title="Test Without an Agent" icon="▹">
-          <code>runSkill()</code> drives your skill through its steps with <code>mockModel()</code> responses. Full
-          path, output, and history assertions — no agent required.
-        </FeatureCard>
-        <FeatureCard title="Compose & Combine" icon="▷">
-          Extract shared steps into modules with <code>.register()</code>. Combine related skills into composites with
-          <code>.subskill()</code> and <code>.topic()</code> — one dispatcher, shared references, independent sub-skills.
+        <FeatureCard title="Test offline. Ship everywhere.">
+          <code>runSkill()</code> + <code>mockModel()</code> drives every step without an agent. Then
+          <code>skill-kit build</code> compiles to an MCP server or standalone CLI. One binary, any host — Claude Code,
+          Codex, any MCP client.
         </FeatureCard>
       </div>
     </div>
   </section>
 
   <section class="how-it-works">
-    <div class="how-inner">
-      <h2 class="section-label">How it works</h2>
-      <div class="protocol-diagram">
-        <pre><code>┌─────────┐  scripts/run         ┌─────────────┐
-│         │ ───────────────────► │             │
-│  Agent  │  ◄ JSON: prompt,     │  Skill CLI  │
-│         │    schema            │  (bundled)  │
-│         │                      │             │
-│         │  scripts/run advance │             │
-│         │ ───────────────────► │             │
-│         │  ◄ JSON: next prompt │             │
-│         │       ...or done     │             │
-└─────────┘                      └─────────────┘</code></pre>
-      </div>
+    <div class="section-inner section-inner--narrow">
+      <h2 class="section-heading">How it works</h2>
+      <ProtocolDiagram />
       <p class="how-text">
-        Two invocation modes. <strong>Session mode</strong> (recommended) writes protocol data to a temp file — no
-        verbose JSON in stdout. <strong>Stateless mode</strong> passes full conversation history via
-        <code>--history</code> on every call. Both reconstruct state, validate against Zod schemas, and return the next
-        prompt. No persistent processes — just Bash calls.
+        The agent calls <code>start</code> to begin a session, receives a prompt and Zod schema for the current step,
+        then calls <code>advance</code> with structured output. The skill validates, updates state, and returns the next
+        prompt — or signals done.
       </p>
       <div class="how-actions">
         <a href={`${base}architecture/`} class="how-link">
-          Read the architecture doc
-          <span aria-hidden="true">→</span>
+          Read the architecture doc <span aria-hidden="true">&rarr;</span>
         </a>
       </div>
     </div>
   </section>
 
   <section class="examples-section">
-    <div class="examples-inner">
-      <h2 class="section-label">Examples</h2>
+    <div class="section-inner">
+      <h2 class="section-heading">Examples</h2>
       <div class="example-grid">
         <a href={`${base}examples/get-to-know-you/`} class="example-card">
           <span class="example-type">workflow</span>
           <h3 class="example-name">get-to-know-you</h3>
           <p class="example-desc">
-            Playful interview that builds a developer trading card. Branching, askUser, confirm, fragments, render
-            helpers, actions, and loop guards.
+            Playful interview that builds a developer trading card. Branching, askUser, confirm, render helpers,
+            actions, and loop guards.
           </p>
         </a>
         <a href={`${base}examples/ts-patterns/`} class="example-card">
           <span class="example-type">reference</span>
           <h3 class="example-name">ts-patterns</h3>
           <p class="example-desc">
-            TypeScript patterns reference with on-demand topic loading. Uses render.table, render.code, and refs.load()
-            for external markdown.
+            TypeScript patterns reference with on-demand topic loading. Progressive disclosure — agents load topics as
+            needed, not all at once.
           </p>
         </a>
         <a href={`${base}examples/contentful-help/`} class="example-card">
           <span class="example-type">composite</span>
           <h3 class="example-name">contentful-help</h3>
           <p class="example-desc">
-            Composite dispatcher that routes to doctor and setup sub-skills or resolves FAQ topics directly. Uses
-            .subskill(), .topic(), context mapping, and runComposite for testing.
+            Composite dispatcher that routes to sub-skills or resolves FAQ topics directly. One entry point, multiple
+            workflows, shared context.
           </p>
         </a>
       </div>
@@ -105,80 +83,61 @@ const base = import.meta.env.BASE_URL;
 </BaseLayout>
 
 <style>
-  /* Shared section styling */
-  .section-label {
+  .section-inner {
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 0 var(--space-5);
+  }
+
+  .section-inner--narrow {
+    max-width: 48rem;
+  }
+
+  .section-heading {
     font-family: var(--font-display);
-    font-size: var(--text-xs);
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-accent);
-    margin-bottom: var(--space-6);
-    padding-bottom: var(--space-3);
-    border-bottom: 1px solid var(--color-border);
+    font-size: var(--text-xl);
+    font-weight: 700;
+    color: var(--color-text);
+    margin-bottom: var(--space-5);
+    border-bottom: none;
+    margin-top: 0;
+    padding-bottom: 0;
   }
 
   /* Features */
   .features {
-    padding: var(--space-8) var(--space-5);
-  }
-
-  .features-inner {
-    max-width: 72rem;
-    margin: 0 auto;
+    padding: var(--space-6) 0;
   }
 
   .feature-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: 1px;
-    background: var(--color-border);
-    border: 1px solid var(--color-border);
-  }
-
-  .feature-grid > :global(.feature-card) {
-    border: none;
+    gap: var(--space-5);
   }
 
   /* How it works */
   .how-it-works {
-    padding: var(--space-8) var(--space-5);
-  }
-
-  .how-inner {
-    max-width: 48rem;
-    margin: 0 auto;
-  }
-
-  .protocol-diagram {
-    margin-bottom: var(--space-5);
-  }
-
-  .protocol-diagram pre {
-    text-align: center;
-    border-left-color: var(--color-accent);
-  }
-
-  .protocol-diagram code {
-    font-size: var(--text-sm);
-    color: var(--color-text-muted);
+    padding: var(--space-6) 0;
   }
 
   .how-text {
     color: var(--color-text-muted);
     font-size: var(--text-base);
-    max-width: 40rem;
-    margin: 0 auto var(--space-5);
+    max-width: 38rem;
+    margin: var(--space-4) auto;
     text-align: center;
+    line-height: 1.7;
   }
 
   .how-actions {
     text-align: center;
+    margin-top: var(--space-4);
   }
 
   .how-link {
     font-family: var(--font-display);
     font-size: var(--text-sm);
+    font-weight: 600;
     color: var(--color-accent);
     text-decoration: none;
     display: inline-flex;
@@ -194,49 +153,48 @@ const base = import.meta.env.BASE_URL;
 
   /* Examples */
   .examples-section {
-    padding: var(--space-8) var(--space-5);
-  }
-
-  .examples-inner {
-    max-width: 72rem;
-    margin: 0 auto;
+    padding: var(--space-6) 0;
   }
 
   .example-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-4);
+    gap: var(--space-5);
   }
 
   .example-card {
     display: block;
     background: var(--color-bg-elevated);
     border: 1px solid var(--color-border);
+    border-radius: 8px;
     padding: var(--space-5);
     text-decoration: none;
     transition:
       border-color var(--transition-fast),
-      background var(--transition-fast);
+      transform var(--transition-fast),
+      box-shadow var(--transition-fast);
   }
 
   .example-card:hover {
-    border-color: var(--color-accent-dim);
-    background: var(--color-bg-inset);
+    border-color: var(--color-accent);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   }
 
   .example-type {
-    font-family: var(--font-display);
+    font-family: var(--font-mono);
     font-size: var(--text-xs);
-    color: var(--color-text-dim);
+    color: var(--color-secondary);
     text-transform: uppercase;
     letter-spacing: 0.08em;
+    font-weight: 500;
   }
 
   .example-name {
     font-family: var(--font-display);
     font-size: var(--text-lg);
     font-weight: 700;
-    color: var(--color-accent);
+    color: var(--color-text);
     margin: var(--space-2) 0;
   }
 
@@ -248,20 +206,14 @@ const base = import.meta.env.BASE_URL;
   }
 
   @media (max-width: 768px) {
-    .feature-grid {
-      grid-template-columns: 1fr;
-    }
-
+    .feature-grid,
     .example-grid {
       grid-template-columns: 1fr;
     }
   }
 
   @media (max-width: 1024px) and (min-width: 769px) {
-    .feature-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
+    .feature-grid,
     .example-grid {
       grid-template-columns: repeat(2, 1fr);
     }

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -13,16 +13,16 @@ const base = import.meta.env.BASE_URL;
     <div class="section-inner">
       <h2 class="section-heading">Why skill-kit</h2>
       <div class="feature-grid">
-        <FeatureCard title="One SDK call, a full TUI element.">
+        <FeatureCard icon="terminal" title="One SDK call, a full TUI element.">
           <code>act.askUser()</code> becomes a structured question. <code>act.plan()</code> becomes an approval flow.
           <code>act.subagent()</code> spawns a research agent. You define the interaction; every host renders its best
           UI.
         </FeatureCard>
-        <FeatureCard title="Deterministic routing, intelligent steps.">
+        <FeatureCard icon="git-branch" title="Deterministic routing, intelligent steps.">
           Steps, schemas, and transitions are TypeScript. Branching is code, not hope. The agent reasons within each
           step; the skill decides what happens next. Loops have guards. Output has Zod validation.
         </FeatureCard>
-        <FeatureCard title="Test offline. Ship everywhere.">
+        <FeatureCard icon="package" title="Test offline. Ship everywhere.">
           <code>runSkill()</code> + <code>mockModel()</code> drives every step without an agent. Then
           <code>skill-kit build</code> compiles to an MCP server or standalone CLI. One binary, any host: Claude Code,
           Codex, or any MCP client.
@@ -84,13 +84,13 @@ const base = import.meta.env.BASE_URL;
 
   /* Features */
   .features {
-    padding: var(--space-6) 0;
+    padding: var(--space-5) 0 var(--space-6);
   }
 
   .feature-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-5);
+    gap: var(--space-4);
   }
 
   /* Examples */

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -9,6 +9,32 @@ const base = import.meta.env.BASE_URL;
 <BaseLayout title="skill-kit — TypeScript SDK for Agent Skills">
   <Hero />
 
+  <section class="story">
+    <div class="story-inner">
+      <div class="story-block">
+        <h2 class="story-headline">Agent skills are simple. Until they're not.</h2>
+        <p class="story-body">
+          A one-shot task is easy to prompt. But the moment you need to gather input, delegate research,
+          get approval, and produce a report, a prompt blob is not a workflow. It's a wish.
+        </p>
+      </div>
+      <div class="story-block">
+        <h2 class="story-headline">skill-kit makes the workflow explicit.</h2>
+        <p class="story-body">
+          Each step is typed. Transitions are code, not hope. The agent reasons within each step.
+          The skill decides what happens next.
+        </p>
+      </div>
+      <div class="story-block">
+        <h2 class="story-headline">You get the structure. Your users get the experience.</h2>
+        <p class="story-body">
+          Surveys, plan approvals, subagent delegation, structured output.
+          The SDK renders the right UI for every host, from Claude Code to Codex to any MCP client.
+        </p>
+      </div>
+    </div>
+  </section>
+
   <section class="features">
     <div class="section-inner">
       <h2 class="section-heading">Why skill-kit</h2>
@@ -80,6 +106,41 @@ const base = import.meta.env.BASE_URL;
     border-bottom: none;
     margin-top: 0;
     padding-bottom: 0;
+  }
+
+  /* Story */
+  .story {
+    padding: var(--space-7) 0 var(--space-6);
+  }
+
+  .story-inner {
+    max-width: 36rem;
+    margin: 0 auto;
+    padding: 0 var(--space-5);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-7);
+  }
+
+  .story-block {
+    text-align: center;
+  }
+
+  .story-headline {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    font-weight: 700;
+    color: var(--color-text);
+    margin-bottom: var(--space-3);
+    line-height: 1.3;
+    letter-spacing: -0.02em;
+  }
+
+  .story-body {
+    font-size: var(--text-base);
+    color: var(--color-text-muted);
+    line-height: 1.7;
+    margin: 0;
   }
 
   /* Features */

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -66,7 +66,7 @@ const base = import.meta.env.BASE_URL;
 
 <style>
   .section-inner {
-    max-width: 72rem;
+    max-width: 60rem;
     margin: 0 auto;
     padding: 0 var(--space-5);
   }

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -78,7 +78,7 @@ const base = import.meta.env.BASE_URL;
     color: var(--color-text);
     margin-bottom: var(--space-4);
     border-bottom: none;
-    margin-top: 0 !important;
+    margin-top: 0;
     padding-bottom: 0;
   }
 

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -518,7 +518,7 @@ const base = import.meta.env.BASE_URL;
 
   .story-cta-lead {
     font-family: var(--font-display);
-    font-size: var(--text-2xl);
+    font-size: var(--text-3xl);
     font-weight: 700;
     color: #e2e8f0;
     margin: 0;

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -2,7 +2,6 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Hero from '../components/Hero.astro';
 import FeatureCard from '../components/FeatureCard.astro';
-import ProtocolDiagram from '../components/ProtocolDiagram.astro';
 
 const base = import.meta.env.BASE_URL;
 ---
@@ -25,26 +24,9 @@ const base = import.meta.env.BASE_URL;
         </FeatureCard>
         <FeatureCard title="Test offline. Ship everywhere.">
           <code>runSkill()</code> + <code>mockModel()</code> drives every step without an agent. Then
-          <code>skill-kit build</code> compiles to an MCP server or standalone CLI. One binary, any host — Claude Code,
-          Codex, any MCP client.
+          <code>skill-kit build</code> compiles to an MCP server or standalone CLI. One binary, any host: Claude Code,
+          Codex, or any MCP client.
         </FeatureCard>
-      </div>
-    </div>
-  </section>
-
-  <section class="how-it-works">
-    <div class="section-inner section-inner--narrow">
-      <h2 class="section-heading">How it works</h2>
-      <ProtocolDiagram />
-      <p class="how-text">
-        The agent calls <code>start</code> to begin a session, receives a prompt and Zod schema for the current step,
-        then calls <code>advance</code> with structured output. The skill validates, updates state, and returns the next
-        prompt — or signals done.
-      </p>
-      <div class="how-actions">
-        <a href={`${base}architecture/`} class="how-link">
-          Read the architecture doc <span aria-hidden="true">&rarr;</span>
-        </a>
       </div>
     </div>
   </section>
@@ -89,10 +71,6 @@ const base = import.meta.env.BASE_URL;
     padding: 0 var(--space-5);
   }
 
-  .section-inner--narrow {
-    max-width: 48rem;
-  }
-
   .section-heading {
     font-family: var(--font-display);
     font-size: var(--text-xl);
@@ -113,42 +91,6 @@ const base = import.meta.env.BASE_URL;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: var(--space-5);
-  }
-
-  /* How it works */
-  .how-it-works {
-    padding: var(--space-6) 0;
-  }
-
-  .how-text {
-    color: var(--color-text-muted);
-    font-size: var(--text-base);
-    max-width: 38rem;
-    margin: var(--space-4) auto;
-    text-align: center;
-    line-height: 1.7;
-  }
-
-  .how-actions {
-    text-align: center;
-    margin-top: var(--space-4);
-  }
-
-  .how-link {
-    font-family: var(--font-display);
-    font-size: var(--text-sm);
-    font-weight: 600;
-    color: var(--color-accent);
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    transition: gap var(--transition-fast);
-  }
-
-  .how-link:hover {
-    gap: var(--space-3);
-    color: var(--color-accent-bright);
   }
 
   /* Examples */

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -268,6 +268,7 @@ const base = import.meta.env.BASE_URL;
     line-height: 1.6;
     color: #94a3b8;
     position: relative;
+    height: 300px;
   }
 
   .prose-blob-header {
@@ -287,6 +288,19 @@ const base = import.meta.env.BASE_URL;
 
   .prose-blob-body {
     padding: 16px;
+    animation: prose-scroll 20s linear infinite;
+  }
+
+  @keyframes prose-scroll {
+    0% { transform: translateY(0); }
+    80% { transform: translateY(-40%); }
+    100% { transform: translateY(-40%); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prose-blob-body {
+      animation: none;
+    }
   }
 
   .prose-blob::after {

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -76,9 +76,9 @@ const base = import.meta.env.BASE_URL;
     font-size: var(--text-xl);
     font-weight: 700;
     color: var(--color-text);
-    margin-bottom: var(--space-5);
+    margin-bottom: var(--space-4);
     border-bottom: none;
-    margin-top: 0;
+    margin-top: 0 !important;
     padding-bottom: 0;
   }
 

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -274,12 +274,14 @@ const base = import.meta.env.BASE_URL;
   .prose-blob-header {
     padding: 8px 16px;
     border-bottom: 1px solid var(--color-code-border);
-    background: rgba(0, 0, 0, 0.2);
+    background: #171f2b;
     color: #64748b;
     font-size: 12px;
     display: flex;
     align-items: center;
     gap: 6px;
+    position: relative;
+    z-index: 2;
   }
 
   .prose-blob-icon {

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -242,16 +242,16 @@ const base = import.meta.env.BASE_URL;
 
   .story-title {
     font-family: var(--font-display);
-    font-size: var(--text-2xl);
+    font-size: var(--text-3xl);
     font-weight: 700;
     color: var(--color-text);
-    margin-bottom: var(--space-3);
-    line-height: 1.25;
+    margin-bottom: var(--space-4);
+    line-height: 1.2;
     letter-spacing: -0.02em;
   }
 
   .story-body {
-    font-size: var(--text-base);
+    font-size: var(--text-lg);
     color: var(--color-text-muted);
     line-height: 1.7;
     margin: 0;

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -507,8 +507,9 @@ const base = import.meta.env.BASE_URL;
 
   /* Story CTA */
   .story-cta {
+    background: var(--color-code-bg);
+    padding: var(--space-7) var(--space-5);
     text-align: center;
-    padding: var(--space-6) 0 var(--space-8);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -517,10 +518,11 @@ const base = import.meta.env.BASE_URL;
 
   .story-cta-lead {
     font-family: var(--font-display);
-    font-size: var(--text-xl);
-    font-weight: 600;
-    color: var(--color-text);
+    font-size: var(--text-2xl);
+    font-weight: 700;
+    color: #e2e8f0;
     margin: 0;
+    letter-spacing: -0.02em;
   }
 
   .story-cta-btn {
@@ -528,28 +530,28 @@ const base = import.meta.env.BASE_URL;
     font-size: var(--text-lg);
     font-weight: 600;
     text-decoration: none;
-    padding: var(--space-4) var(--space-8);
+    padding: var(--space-3) var(--space-7);
     border-radius: 8px;
-    background: var(--color-accent);
+    background: var(--color-accent-bright);
     color: #ffffff;
-    border: 1px solid var(--color-accent);
+    border: 1px solid var(--color-accent-bright);
     transition:
       background var(--transition-fast),
       box-shadow var(--transition-fast);
   }
 
   .story-cta-btn:hover {
-    background: var(--color-accent-bright);
+    background: #11a5ad;
     color: #ffffff;
-    box-shadow: 0 4px 16px rgba(13, 115, 119, 0.3);
+    box-shadow: 0 4px 20px rgba(15, 145, 153, 0.4);
   }
 
   .story-cta-install {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
-    color: var(--color-text-dim);
-    background: var(--color-bg-inset);
-    border: 1px solid var(--color-border);
+    color: #64748b;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--color-code-border);
     padding: var(--space-2) var(--space-5);
     border-radius: 6px;
   }

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -10,39 +10,117 @@ const base = import.meta.env.BASE_URL;
   <Hero />
 
   <section class="story">
-    <div class="story-inner">
-      <div class="story-lead">
-        <h2 class="story-lead-headline">Agent skills are simple. Until they're not.</h2>
-        <p class="story-lead-body">
-          One-shot prompts work great. But multi-step workflows need gathering input, delegating research,
-          getting approval, producing output. Prompt blobs fall apart here. You need structure.
-        </p>
-      </div>
-
-      <div class="story-grid">
-        <div class="story-card">
+    {/* --- Block 1: The problem (prose blob fading out) --- */}
+    <div class="story-block">
+      <div class="story-block-inner">
+        <div class="story-text">
           <span class="story-num">01</span>
-          <h3 class="story-card-title">Steps, not blobs</h3>
-          <p class="story-card-body">
-            Each step has a typed schema, a prompt, and an explicit transition to the next step.
-            The agent reasons freely within the step. The skill controls the flow.
+          <h2 class="story-title">Agent skills are simple. Until they're not.</h2>
+          <p class="story-body">
+            One-shot prompts work great. But multi-step workflows need gathering input, delegating research,
+            getting approval, producing output. A single prompt file gets long, tangled, and fragile fast.
           </p>
         </div>
-        <div class="story-card">
+        <div class="story-visual">
+          <div class="prose-blob">
+            <div class="prose-blob-header">
+              <span class="prose-blob-icon">📄</span> SKILL.md
+            </div>
+            <div class="prose-blob-body">
+              <p>First, greet the user and ask what kind of report they want. If they say "security", ask which framework. If they say "performance", skip straight to the analysis section. But if they previously mentioned accessibility concerns, combine both paths.</p>
+              <p>When gathering preferences, present options one at a time. Wait for confirmation before moving on. If the user changes their mind about a previous answer, go back to that question but keep the answers to questions that came after, unless those answers depended on the changed answer.</p>
+              <p>For the research phase, search the codebase for relevant files. If you find more than 10 files, summarize first and ask the user which to focus on. If fewer than 3, expand the search scope. Do not search node_modules unless explicitly asked.</p>
+              <p>Once research is complete, draft an outline. Present the outline for approval. If rejected, ask what to change, then re-draft. Limit to 3 revision rounds. On the 4th rejection, proceed with the last version and note the disagreement.</p>
+              <p>Write each section one at a time. After each section, confirm with the user. If they want changes, revise that section before continuing. Track which sections are done. If the user asks to skip ahead, mark skipped sections as "TODO" and continue.</p>
+              <p>When all sections are written, compile the final report. Save it to disk. If the save fails, retry once, then report the error. Present a summary with word count, sections completed, and time elapsed.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {/* --- Block 2: Branching is code --- */}
+    <div class="story-block">
+      <div class="story-block-inner story-block-inner--reverse">
+        <div class="story-text">
           <span class="story-num">02</span>
-          <h3 class="story-card-title">Branching is code</h3>
-          <p class="story-card-body">
-            Conditional transitions, loop guards, and validation are all TypeScript.
-            No more hoping the model picks the right path from a long prompt.
+          <h2 class="story-title">Branching is code, not hope.</h2>
+          <p class="story-body">
+            With skill-kit, each step has a typed schema and an explicit transition. Conditional paths,
+            loop guards, and validation are TypeScript. The agent reasons freely within each step.
+            The skill controls where it goes next.
           </p>
         </div>
-        <div class="story-card">
+        <div class="story-visual">
+          <div class="branch-compare">
+            <div class="branch-prose">
+              <div class="branch-label">Prose approach</div>
+              <div class="branch-content branch-content--prose">
+                <p>"If the user chose security, proceed to the security research section. However, if they also mentioned performance concerns earlier, you should combine both into a joint analysis. If neither was selected, ask again, but only up to two more times before defaulting to a general overview..."</p>
+              </div>
+            </div>
+            <div class="branch-code">
+              <div class="branch-label">skill-kit</div>
+              <pre class="branch-content branch-content--code"><code><span class="hl-fn">next</span>: ({ <span class="hl-id">stepOutput</span> }) =>
+  <span class="hl-id">stepOutput</span>.<span class="hl-id">focus</span> === <span class="hl-str">'security'</span>
+    ? <span class="hl-str">'research-security'</span>
+    : <span class="hl-str">'research-general'</span></code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {/* --- Block 3: Rich UI for free --- */}
+    <div class="story-block">
+      <div class="story-block-inner">
+        <div class="story-text">
           <span class="story-num">03</span>
-          <h3 class="story-card-title">Rich UI for free</h3>
-          <p class="story-card-body">
-            Surveys, plan approvals, subagent delegation, checklists.
-            The SDK renders the best UI each host can offer. One skill, every agent.
+          <h2 class="story-title">Rich UI for free.</h2>
+          <p class="story-body">
+            Surveys, plan approvals, subagent delegation, structured output. One SDK call produces
+            native interactive UI on every host. You write <code>act.plan()</code> once. Claude Code,
+            Codex, and every MCP client render their best version of it.
           </p>
+        </div>
+        <div class="story-visual">
+          <div class="primitives-grid">
+            <div class="primitive-card">
+              <div class="primitive-label">act.survey()</div>
+              <div class="primitive-preview">
+                <div class="prim-tabs">
+                  <span class="prim-tab prim-tab--done">✓ Theme</span>
+                  <span class="prim-tab prim-tab--active">Framework</span>
+                  <span class="prim-tab">Submit</span>
+                </div>
+                <div class="prim-option prim-option--selected">› React</div>
+                <div class="prim-option">&nbsp; Vue</div>
+                <div class="prim-option">&nbsp; Svelte</div>
+              </div>
+            </div>
+            <div class="primitive-card">
+              <div class="primitive-label">act.plan()</div>
+              <div class="primitive-preview">
+                <div class="prim-plan-title">Audit Plan</div>
+                <div class="prim-plan-item">1. Executive Summary</div>
+                <div class="prim-plan-item">2. Auth Flow Analysis</div>
+                <div class="prim-plan-item">3. Vulnerability Assessment</div>
+                <div class="prim-plan-sep"></div>
+                <div class="prim-option prim-option--selected">› Approve</div>
+              </div>
+            </div>
+            <div class="primitive-card">
+              <div class="primitive-label">act.subagent()</div>
+              <div class="primitive-preview">
+                <div class="prim-subagent">
+                  <span class="prim-dot prim-dot--blue">●</span>
+                  <span class="prim-subagent-label">Explore</span>
+                  <span class="prim-subagent-name">(Research auth)</span>
+                </div>
+                <div class="prim-subagent-status">└ Done (5 tools · 20s)</div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -121,49 +199,35 @@ const base = import.meta.env.BASE_URL;
     padding-bottom: 0;
   }
 
-  /* Story */
+  /* ─── Story section ─── */
   .story {
-    padding: var(--space-8) 0 var(--space-7);
+    padding: var(--space-7) 0;
   }
 
-  .story-inner {
+  .story-block {
+    padding: var(--space-7) 0;
+  }
+
+  .story-block-inner {
     max-width: 72rem;
     margin: 0 auto;
     padding: 0 var(--space-5);
-  }
-
-  .story-lead {
-    max-width: 40rem;
-    margin: 0 auto var(--space-7);
-    text-align: center;
-  }
-
-  .story-lead-headline {
-    font-family: var(--font-display);
-    font-size: var(--text-3xl);
-    font-weight: 700;
-    color: var(--color-text);
-    margin-bottom: var(--space-4);
-    line-height: 1.2;
-    letter-spacing: -0.02em;
-  }
-
-  .story-lead-body {
-    font-size: var(--text-lg);
-    color: var(--color-text-muted);
-    line-height: 1.7;
-    margin: 0;
-  }
-
-  .story-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-5);
+    grid-template-columns: 1fr 1.2fr;
+    gap: var(--space-7);
+    align-items: center;
   }
 
-  .story-card {
-    padding: var(--space-5) 0;
-    border-top: 2px solid var(--color-accent);
+  .story-block-inner--reverse {
+    grid-template-columns: 1.2fr 1fr;
+  }
+
+  .story-block-inner--reverse .story-text {
+    order: 2;
+  }
+
+  .story-block-inner--reverse .story-visual {
+    order: 1;
   }
 
   .story-num {
@@ -176,35 +240,242 @@ const base = import.meta.env.BASE_URL;
     margin-bottom: var(--space-3);
   }
 
-  .story-card-title {
+  .story-title {
     font-family: var(--font-display);
-    font-size: var(--text-lg);
+    font-size: var(--text-2xl);
     font-weight: 700;
     color: var(--color-text);
-    margin-bottom: var(--space-2);
-    line-height: 1.3;
+    margin-bottom: var(--space-3);
+    line-height: 1.25;
+    letter-spacing: -0.02em;
   }
 
-  .story-card-body {
-    font-size: var(--text-sm);
+  .story-body {
+    font-size: var(--text-base);
     color: var(--color-text-muted);
     line-height: 1.7;
     margin: 0;
   }
 
+  /* --- Prose blob visual (fading SKILL.md) --- */
+  .prose-blob {
+    background: var(--color-code-bg);
+    border: 1px solid var(--color-code-border);
+    border-radius: 10px;
+    overflow: hidden;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.6;
+    color: #94a3b8;
+    position: relative;
+    max-height: 320px;
+  }
+
+  .prose-blob-header {
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--color-code-border);
+    background: rgba(0, 0, 0, 0.2);
+    color: #64748b;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .prose-blob-icon {
+    font-size: 14px;
+  }
+
+  .prose-blob-body {
+    padding: 16px;
+    -webkit-mask-image: linear-gradient(to bottom, black 40%, transparent 95%);
+    mask-image: linear-gradient(to bottom, black 40%, transparent 95%);
+  }
+
+  .prose-blob-body p {
+    margin-bottom: 12px;
+    color: #7a8ba0;
+  }
+
+  /* --- Branch comparison visual --- */
+  .branch-compare {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .branch-label {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-dim);
+    margin-bottom: var(--space-2);
+  }
+
+  .branch-content {
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.6;
+  }
+
+  .branch-content--prose {
+    background: var(--color-bg-inset);
+    border: 1px solid var(--color-border);
+    padding: 14px 16px;
+    color: var(--color-text-muted);
+    font-family: var(--font-body);
+    font-style: italic;
+    position: relative;
+    -webkit-mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+    mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+  }
+
+  .branch-content--prose p {
+    margin: 0;
+  }
+
+  .branch-content--code {
+    background: var(--color-code-bg);
+    border: 1px solid var(--color-code-border);
+    padding: 14px 16px;
+    color: var(--color-code-text);
+    font-family: var(--font-mono);
+    margin: 0;
+    border-left: 3px solid var(--color-accent);
+  }
+
+  .branch-content--code .hl-fn { color: #82aaff; }
+  .branch-content--code .hl-id { color: #89ddff; }
+  .branch-content--code .hl-str { color: #c3e88d; }
+
+  /* --- Primitives gallery --- */
+  .primitives-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-3);
+  }
+
+  .primitive-card {
+    background: var(--color-terminal-bg);
+    border: 1px solid var(--color-terminal-border);
+    border-radius: 8px;
+    overflow: hidden;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--color-terminal-text);
+  }
+
+  .primitive-label {
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--color-terminal-border);
+    color: #82aaff;
+    font-weight: 500;
+    font-size: 11px;
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .primitive-preview {
+    padding: 10px 12px;
+  }
+
+  .prim-tabs {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 8px;
+    font-size: 11px;
+  }
+
+  .prim-tab {
+    color: #525252;
+    padding: 1px 6px;
+    border-radius: 3px;
+  }
+
+  .prim-tab--active {
+    background: rgba(96, 165, 250, 0.15);
+    color: #60a5fa;
+    border: 1px solid rgba(96, 165, 250, 0.3);
+  }
+
+  .prim-tab--done {
+    color: #737373;
+  }
+
+  .prim-option {
+    color: #525252;
+    padding: 1px 0;
+  }
+
+  .prim-option--selected {
+    color: #fff;
+    font-weight: 500;
+  }
+
+  .prim-plan-title {
+    color: #c084fc;
+    font-weight: 700;
+    margin-bottom: 6px;
+    font-size: 12px;
+  }
+
+  .prim-plan-item {
+    color: #e5e5e5;
+    padding: 1px 0;
+  }
+
+  .prim-plan-sep {
+    height: 1px;
+    background: #262626;
+    margin: 6px 0;
+  }
+
+  .prim-subagent {
+    display: flex;
+    gap: 6px;
+    align-items: baseline;
+  }
+
+  .prim-dot {
+    font-size: 8px;
+  }
+
+  .prim-dot--blue {
+    color: #60a5fa;
+  }
+
+  .prim-subagent-label {
+    color: #60a5fa;
+    font-weight: 700;
+  }
+
+  .prim-subagent-name {
+    color: #d4d4d4;
+  }
+
+  .prim-subagent-status {
+    padding-left: 16px;
+    color: #525252;
+    margin-top: 2px;
+  }
+
   @media (max-width: 768px) {
-    .story-grid {
+    .story-block-inner,
+    .story-block-inner--reverse {
       grid-template-columns: 1fr;
     }
 
-    .story-lead-headline {
-      font-size: var(--text-2xl);
-    }
-  }
+    .story-block-inner--reverse .story-text { order: 1; }
+    .story-block-inner--reverse .story-visual { order: 2; }
 
-  @media (max-width: 1024px) and (min-width: 769px) {
-    .story-grid {
-      grid-template-columns: repeat(3, 1fr);
+    .primitives-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .story-title {
+      font-size: var(--text-xl);
     }
   }
 

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -84,7 +84,7 @@ const base = import.meta.env.BASE_URL;
 
   /* Features */
   .features {
-    padding: var(--space-5) 0 var(--space-6);
+    padding: var(--space-4) 0 var(--space-6);
   }
 
   .feature-grid {

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -127,7 +127,9 @@ const base = import.meta.env.BASE_URL;
   </section>
 
   <div class="story-cta">
+    <p class="story-cta-lead">Ready to build your first skill?</p>
     <a href={`${base}getting-started/`} class="story-cta-btn">Get Started</a>
+    <code class="story-cta-install">$ npm install @contentful/skill-kit</code>
   </div>
 
   <section class="features">
@@ -506,16 +508,28 @@ const base = import.meta.env.BASE_URL;
   /* Story CTA */
   .story-cta {
     text-align: center;
-    padding: var(--space-5) 0 var(--space-7);
+    padding: var(--space-6) 0 var(--space-8);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .story-cta-lead {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0;
   }
 
   .story-cta-btn {
     font-family: var(--font-display);
-    font-size: var(--text-base);
+    font-size: var(--text-lg);
     font-weight: 600;
     text-decoration: none;
-    padding: var(--space-3) var(--space-6);
-    border-radius: 6px;
+    padding: var(--space-4) var(--space-8);
+    border-radius: 8px;
     background: var(--color-accent);
     color: #ffffff;
     border: 1px solid var(--color-accent);
@@ -527,7 +541,17 @@ const base = import.meta.env.BASE_URL;
   .story-cta-btn:hover {
     background: var(--color-accent-bright);
     color: #ffffff;
-    box-shadow: 0 4px 12px rgba(13, 115, 119, 0.3);
+    box-shadow: 0 4px 16px rgba(13, 115, 119, 0.3);
+  }
+
+  .story-cta-install {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text-dim);
+    background: var(--color-bg-inset);
+    border: 1px solid var(--color-border);
+    padding: var(--space-2) var(--space-5);
+    border-radius: 6px;
   }
 
   /* Features */

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -11,26 +11,39 @@ const base = import.meta.env.BASE_URL;
 
   <section class="story">
     <div class="story-inner">
-      <div class="story-block">
-        <h2 class="story-headline">Agent skills are simple. Until they're not.</h2>
-        <p class="story-body">
-          A one-shot task is easy to prompt. But the moment you need to gather input, delegate research,
-          get approval, and produce a report, a prompt blob is not a workflow. It's a wish.
+      <div class="story-lead">
+        <h2 class="story-lead-headline">Agent skills are simple. Until they're not.</h2>
+        <p class="story-lead-body">
+          One-shot prompts work great. But multi-step workflows need gathering input, delegating research,
+          getting approval, producing output. Prompt blobs fall apart here. You need structure.
         </p>
       </div>
-      <div class="story-block">
-        <h2 class="story-headline">skill-kit makes the workflow explicit.</h2>
-        <p class="story-body">
-          Each step is typed. Transitions are code, not hope. The agent reasons within each step.
-          The skill decides what happens next.
-        </p>
-      </div>
-      <div class="story-block">
-        <h2 class="story-headline">You get the structure. Your users get the experience.</h2>
-        <p class="story-body">
-          Surveys, plan approvals, subagent delegation, structured output.
-          The SDK renders the right UI for every host, from Claude Code to Codex to any MCP client.
-        </p>
+
+      <div class="story-grid">
+        <div class="story-card">
+          <span class="story-num">01</span>
+          <h3 class="story-card-title">Steps, not blobs</h3>
+          <p class="story-card-body">
+            Each step has a typed schema, a prompt, and an explicit transition to the next step.
+            The agent reasons freely within the step. The skill controls the flow.
+          </p>
+        </div>
+        <div class="story-card">
+          <span class="story-num">02</span>
+          <h3 class="story-card-title">Branching is code</h3>
+          <p class="story-card-body">
+            Conditional transitions, loop guards, and validation are all TypeScript.
+            No more hoping the model picks the right path from a long prompt.
+          </p>
+        </div>
+        <div class="story-card">
+          <span class="story-num">03</span>
+          <h3 class="story-card-title">Rich UI for free</h3>
+          <p class="story-card-body">
+            Surveys, plan approvals, subagent delegation, checklists.
+            The SDK renders the best UI each host can offer. One skill, every agent.
+          </p>
+        </div>
       </div>
     </div>
   </section>
@@ -110,37 +123,89 @@ const base = import.meta.env.BASE_URL;
 
   /* Story */
   .story {
-    padding: var(--space-7) 0 var(--space-6);
+    padding: var(--space-8) 0 var(--space-7);
   }
 
   .story-inner {
-    max-width: 36rem;
+    max-width: 72rem;
     margin: 0 auto;
     padding: 0 var(--space-5);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-7);
   }
 
-  .story-block {
+  .story-lead {
+    max-width: 40rem;
+    margin: 0 auto var(--space-7);
     text-align: center;
   }
 
-  .story-headline {
+  .story-lead-headline {
     font-family: var(--font-display);
-    font-size: var(--text-2xl);
+    font-size: var(--text-3xl);
     font-weight: 700;
     color: var(--color-text);
-    margin-bottom: var(--space-3);
-    line-height: 1.3;
+    margin-bottom: var(--space-4);
+    line-height: 1.2;
     letter-spacing: -0.02em;
   }
 
-  .story-body {
-    font-size: var(--text-base);
+  .story-lead-body {
+    font-size: var(--text-lg);
     color: var(--color-text-muted);
     line-height: 1.7;
     margin: 0;
+  }
+
+  .story-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-5);
+  }
+
+  .story-card {
+    padding: var(--space-5) 0;
+    border-top: 2px solid var(--color-accent);
+  }
+
+  .story-num {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    color: var(--color-accent);
+    letter-spacing: 0.05em;
+    display: block;
+    margin-bottom: var(--space-3);
+  }
+
+  .story-card-title {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    font-weight: 700;
+    color: var(--color-text);
+    margin-bottom: var(--space-2);
+    line-height: 1.3;
+  }
+
+  .story-card-body {
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+    line-height: 1.7;
+    margin: 0;
+  }
+
+  @media (max-width: 768px) {
+    .story-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .story-lead-headline {
+      font-size: var(--text-2xl);
+    }
+  }
+
+  @media (max-width: 1024px) and (min-width: 769px) {
+    .story-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
   }
 
   /* Features */

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -268,7 +268,6 @@ const base = import.meta.env.BASE_URL;
     line-height: 1.6;
     color: #94a3b8;
     position: relative;
-    max-height: 320px;
   }
 
   .prose-blob-header {
@@ -288,8 +287,17 @@ const base = import.meta.env.BASE_URL;
 
   .prose-blob-body {
     padding: 16px;
-    -webkit-mask-image: linear-gradient(to bottom, black 40%, transparent 95%);
-    mask-image: linear-gradient(to bottom, black 40%, transparent 95%);
+  }
+
+  .prose-blob::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 50%;
+    background: linear-gradient(to bottom, transparent, var(--color-code-bg));
+    pointer-events: none;
   }
 
   .prose-blob-body p {
@@ -352,8 +360,8 @@ const base = import.meta.env.BASE_URL;
 
   /* --- Primitives gallery --- */
   .primitives-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    display: flex;
+    flex-direction: column;
     gap: var(--space-3);
   }
 
@@ -469,10 +477,6 @@ const base = import.meta.env.BASE_URL;
 
     .story-block-inner--reverse .story-text { order: 1; }
     .story-block-inner--reverse .story-visual { order: 2; }
-
-    .primitives-grid {
-      grid-template-columns: 1fr;
-    }
 
     .story-title {
       font-size: var(--text-xl);

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -66,7 +66,7 @@ const base = import.meta.env.BASE_URL;
 
 <style>
   .section-inner {
-    max-width: 60rem;
+    max-width: 72rem;
     margin: 0 auto;
     padding: 0 var(--space-5);
   }

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -558,7 +558,7 @@ const base = import.meta.env.BASE_URL;
 
   /* Features */
   .features {
-    padding: var(--space-4) 0 var(--space-6);
+    padding: var(--space-7) 0 var(--space-6);
   }
 
   .feature-grid {

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -126,6 +126,10 @@ const base = import.meta.env.BASE_URL;
     </div>
   </section>
 
+  <div class="story-cta">
+    <a href={`${base}getting-started/`} class="story-cta-btn">Get Started</a>
+  </div>
+
   <section class="features">
     <div class="section-inner">
       <h2 class="section-heading">Why skill-kit</h2>
@@ -497,6 +501,33 @@ const base = import.meta.env.BASE_URL;
     .story-title {
       font-size: var(--text-xl);
     }
+  }
+
+  /* Story CTA */
+  .story-cta {
+    text-align: center;
+    padding: var(--space-5) 0 var(--space-7);
+  }
+
+  .story-cta-btn {
+    font-family: var(--font-display);
+    font-size: var(--text-base);
+    font-weight: 600;
+    text-decoration: none;
+    padding: var(--space-3) var(--space-6);
+    border-radius: 6px;
+    background: var(--color-accent);
+    color: #ffffff;
+    border: 1px solid var(--color-accent);
+    transition:
+      background var(--transition-fast),
+      box-shadow var(--transition-fast);
+  }
+
+  .story-cta-btn:hover {
+    background: var(--color-accent-bright);
+    color: #ffffff;
+    box-shadow: 0 4px 12px rgba(13, 115, 119, 0.3);
   }
 
   /* Features */

--- a/docs-site/src/styles/global.css
+++ b/docs-site/src/styles/global.css
@@ -304,7 +304,7 @@ details[open] summary {
 }
 
 .hero-demo-code {
-  width: 65%;
+  width: 100%;
   min-width: 0;
 }
 
@@ -314,6 +314,12 @@ details[open] summary {
   right: 0;
   width: 50%;
   z-index: 2;
+}
+
+.hero-demo-dots {
+  position: relative;
+  z-index: 3;
+  margin-top: var(--space-4);
 }
 
 @media (max-width: 1024px) {

--- a/docs-site/src/styles/global.css
+++ b/docs-site/src/styles/global.css
@@ -299,7 +299,6 @@ details[open] summary {
   position: relative;
   width: 100%;
   max-width: 72rem;
-  /* Bottom padding to make room for the terminal overflow */
   padding-bottom: 60px;
 }
 

--- a/docs-site/src/styles/global.css
+++ b/docs-site/src/styles/global.css
@@ -112,21 +112,37 @@ h6 {
   color: var(--color-text);
 }
 
-h1 { font-size: var(--text-4xl); }
-h2 { font-size: var(--text-2xl); }
-h3 { font-size: var(--text-xl); }
-h4 { font-size: var(--text-lg); }
+h1 {
+  font-size: var(--text-4xl);
+}
+h2 {
+  font-size: var(--text-2xl);
+}
+h3 {
+  font-size: var(--text-xl);
+}
+h4 {
+  font-size: var(--text-lg);
+}
 
 /* Prose spacing only inside docs pages */
-.docs-content h1 { margin-bottom: var(--space-6); }
+.docs-content h1 {
+  margin-bottom: var(--space-6);
+}
 .docs-content h2 {
   margin-top: var(--space-8);
   margin-bottom: var(--space-4);
   padding-bottom: var(--space-2);
   border-bottom: 1px solid var(--color-border);
 }
-.docs-content h3 { margin-top: var(--space-6); margin-bottom: var(--space-3); }
-.docs-content h4 { margin-top: var(--space-5); margin-bottom: var(--space-2); }
+.docs-content h3 {
+  margin-top: var(--space-6);
+  margin-bottom: var(--space-3);
+}
+.docs-content h4 {
+  margin-top: var(--space-5);
+  margin-bottom: var(--space-2);
+}
 
 p {
   margin-bottom: var(--space-4);
@@ -286,7 +302,6 @@ details[open] summary {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-text-dim);
 }
-
 
 /* ─── Hero Demo Layout: layered windows ─── */
 .hero-demo {

--- a/docs-site/src/styles/global.css
+++ b/docs-site/src/styles/global.css
@@ -1,24 +1,43 @@
 /* ─── Tokens ─── */
 :root {
-  --color-bg: #0a0a0a;
-  --color-bg-elevated: #141414;
-  --color-bg-inset: #1a1a1a;
-  --color-border: #2a2a2a;
-  --color-border-focus: #3a3a3a;
+  /* Backgrounds */
+  --color-bg: #faf8f5;
+  --color-bg-elevated: #ffffff;
+  --color-bg-inset: #f0ece6;
+  --color-border: #e2ddd5;
+  --color-border-focus: #c9c2b8;
 
-  --color-text: #f0f0f0;
-  --color-text-muted: #a0a0a0;
-  --color-text-dim: #707070;
+  /* Text */
+  --color-text: #1a1a1a;
+  --color-text-muted: #5c5650;
+  --color-text-dim: #8a837a;
 
-  --color-accent: #f5a623;
-  --color-accent-bright: #ffc857;
-  --color-accent-dim: #a67c1a;
-  --color-accent-glow: rgba(245, 166, 35, 0.15);
+  /* Primary accent: deep teal */
+  --color-accent: #0d7377;
+  --color-accent-bright: #0f9199;
+  --color-accent-dim: #095557;
+  --color-accent-glow: rgba(13, 115, 119, 0.08);
 
-  --color-success: #4ade80;
-  --color-error: #f87171;
-  --color-warning: #fbbf24;
+  /* Secondary: warm amber */
+  --color-secondary: #d4860a;
+  --color-secondary-glow: rgba(212, 134, 10, 0.1);
 
+  /* Status */
+  --color-success: #2d8a56;
+  --color-error: #c94040;
+  --color-warning: #c08b2a;
+
+  /* Code blocks (dark contrast islands) */
+  --color-code-bg: #1e293b;
+  --color-code-border: #334155;
+  --color-code-text: #e2e8f0;
+
+  /* Terminal mockup */
+  --color-terminal-bg: #0e0e0e;
+  --color-terminal-border: #1e1e1e;
+  --color-terminal-text: #d4d4d4;
+
+  /* Spacing */
   --space-1: 0.25rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;
@@ -29,6 +48,7 @@
   --space-8: 4rem;
   --space-9: 6rem;
 
+  /* Typography scale */
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;
   --text-base: 1rem;
@@ -39,13 +59,17 @@
   --text-4xl: 2.5rem;
   --text-5xl: 3.5rem;
 
-  --font-display: 'JetBrains Mono', 'Cascadia Code', 'Fira Code', monospace;
-  --font-body: 'Satoshi', 'DM Sans', system-ui, sans-serif;
+  /* Fonts */
+  --font-display: 'Instrument Sans', 'General Sans', system-ui, sans-serif;
+  --font-body: 'Instrument Sans', system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', 'Source Code Pro', monospace;
 
+  /* Layout */
   --content-width: 52rem;
   --sidebar-width: 16rem;
   --nav-height: 3.5rem;
 
+  /* Motion */
   --transition-fast: 150ms ease;
   --transition-normal: 250ms ease;
 }
@@ -60,7 +84,6 @@
 }
 
 html {
-  color-scheme: dark;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   scroll-behavior: smooth;
@@ -72,11 +95,6 @@ body {
   line-height: 1.7;
   color: var(--color-text);
   background-color: var(--color-bg);
-  background-image:
-    linear-gradient(var(--color-border) 1px, transparent 1px),
-    linear-gradient(90deg, var(--color-border) 1px, transparent 1px);
-  background-size: 64px 64px;
-  background-position: -1px -1px;
   min-height: 100vh;
 }
 
@@ -136,31 +154,36 @@ strong {
 
 /* ─── Code ─── */
 code {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 0.9em;
 }
 
 :not(pre) > code {
-  background: var(--color-bg-elevated);
+  background: var(--color-accent-glow);
   border: 1px solid var(--color-border);
+  color: var(--color-accent-dim);
   padding: 0.15em 0.4em;
+  border-radius: 3px;
 }
 
 pre {
-  background: var(--color-bg-elevated) !important;
-  border: 1px solid var(--color-border);
+  background: var(--color-code-bg) !important;
+  border: 1px solid var(--color-code-border);
   border-left: 3px solid var(--color-accent-dim);
   padding: var(--space-4);
   overflow-x: auto;
   margin-bottom: var(--space-5);
   font-size: var(--text-sm);
   line-height: 1.6;
+  border-radius: 6px;
+  color: var(--color-code-text);
 }
 
 pre code {
   background: none;
   border: none;
   padding: 0;
+  color: inherit;
 }
 
 /* ─── Lists ─── */
@@ -213,6 +236,7 @@ blockquote {
   background: var(--color-accent-glow);
   padding: var(--space-4) var(--space-5);
   margin-bottom: var(--space-5);
+  border-radius: 0 6px 6px 0;
 }
 
 blockquote p:last-child {
@@ -231,6 +255,7 @@ details {
   border: 1px solid var(--color-border);
   padding: var(--space-4);
   margin-bottom: var(--space-5);
+  border-radius: 6px;
 }
 
 details summary {
@@ -249,7 +274,7 @@ details[open] summary {
 /* ─── Selection ─── */
 ::selection {
   background: var(--color-accent);
-  color: var(--color-bg);
+  color: #ffffff;
 }
 
 /* ─── Scrollbar ─── */
@@ -262,20 +287,36 @@ details[open] summary {
 }
 ::-webkit-scrollbar-thumb {
   background: var(--color-border-focus);
+  border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-text-dim);
 }
 
-/* ─── Scan line animation ─── */
-@keyframes scanline {
-  0% {
-    transform: translateY(-100%);
-    opacity: 1;
-  }
-  100% {
-    transform: translateY(100vh);
-    opacity: 0;
+
+/* ─── Hero Demo Layout ─── */
+.hero-demo {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: var(--space-5);
+  width: 100%;
+  max-width: 72rem;
+  align-items: stretch;
+}
+
+.hero-demo-code {
+  min-width: 0;
+}
+
+.hero-demo-terminal {
+  position: relative;
+  min-width: 0;
+}
+
+@media (max-width: 1024px) {
+  .hero-demo {
+    grid-template-columns: 1fr;
+    max-width: 40rem;
   }
 }
 

--- a/docs-site/src/styles/global.css
+++ b/docs-site/src/styles/global.css
@@ -310,7 +310,7 @@ details[open] summary {
 
 .hero-demo-terminal {
   position: absolute;
-  top: 40px;
+  top: 32px;
   right: 24px;
   width: 46%;
   z-index: 2;

--- a/docs-site/src/styles/global.css
+++ b/docs-site/src/styles/global.css
@@ -112,27 +112,21 @@ h6 {
   color: var(--color-text);
 }
 
-h1 {
-  font-size: var(--text-4xl);
-  margin-bottom: var(--space-6);
-}
-h2 {
-  font-size: var(--text-2xl);
+h1 { font-size: var(--text-4xl); }
+h2 { font-size: var(--text-2xl); }
+h3 { font-size: var(--text-xl); }
+h4 { font-size: var(--text-lg); }
+
+/* Prose spacing only inside docs pages */
+.docs-content h1 { margin-bottom: var(--space-6); }
+.docs-content h2 {
   margin-top: var(--space-8);
   margin-bottom: var(--space-4);
   padding-bottom: var(--space-2);
   border-bottom: 1px solid var(--color-border);
 }
-h3 {
-  font-size: var(--text-xl);
-  margin-top: var(--space-6);
-  margin-bottom: var(--space-3);
-}
-h4 {
-  font-size: var(--text-lg);
-  margin-top: var(--space-5);
-  margin-bottom: var(--space-2);
-}
+.docs-content h3 { margin-top: var(--space-6); margin-bottom: var(--space-3); }
+.docs-content h4 { margin-top: var(--space-5); margin-bottom: var(--space-2); }
 
 p {
   margin-bottom: var(--space-4);

--- a/docs-site/src/styles/global.css
+++ b/docs-site/src/styles/global.css
@@ -294,29 +294,43 @@ details[open] summary {
 }
 
 
-/* ─── Hero Demo Layout ─── */
+/* ─── Hero Demo Layout: layered windows ─── */
 .hero-demo {
-  display: grid;
-  grid-template-columns: 1.15fr 1fr;
-  gap: var(--space-5);
+  position: relative;
   width: 100%;
   max-width: 72rem;
-  align-items: stretch;
+  /* Bottom padding to make room for the terminal overflow */
+  padding-bottom: 60px;
 }
 
 .hero-demo-code {
+  width: 65%;
   min-width: 0;
 }
 
 .hero-demo-terminal {
-  position: relative;
-  min-width: 0;
+  position: absolute;
+  top: 40px;
+  right: 0;
+  width: 50%;
+  z-index: 2;
 }
 
 @media (max-width: 1024px) {
   .hero-demo {
-    grid-template-columns: 1fr;
-    max-width: 40rem;
+    padding-bottom: 0;
+  }
+
+  .hero-demo-code {
+    width: 100%;
+  }
+
+  .hero-demo-terminal {
+    position: relative;
+    top: auto;
+    right: auto;
+    width: 100%;
+    margin-top: var(--space-5);
   }
 }
 

--- a/docs-site/src/styles/global.css
+++ b/docs-site/src/styles/global.css
@@ -311,8 +311,8 @@ details[open] summary {
 .hero-demo-terminal {
   position: absolute;
   top: 40px;
-  right: 0;
-  width: 50%;
+  right: 24px;
+  width: 46%;
   z-index: 2;
 }
 


### PR DESCRIPTION
## Summary

- **Hero section**: Code editor (full-width, line numbers, window chrome) with an overlapping terminal window showing animated agent TUI. Code highlight walks through each `.step()` while the terminal shows the corresponding rich interaction (survey picker, subagent, plan card, action result). Scrolling conversation log with condensed past + rich active frame. Auto-loops, clickable step dots, clickable code regions, hover-to-pause.

- **Storytelling section**: Three editorial blocks between hero and feature cards, each with text + visual side-by-side (alternating). A slowly scrolling prose blob showing tangled SKILL.md instructions, a prose-vs-code branching comparison, and a primitives gallery showing survey/plan/subagent components.

- **Homepage cleanup**: Rewrote subtitle copy, real install command (`npm install`), removed broken "How it works" section with orphaned protocol diagram, scoped heading margins to docs pages only, added SVG icons to feature cards.

- **Storyboard data layer**: Scene-based architecture with multi-frame scenes, designed for future persona targeting or A/B testing. Security-audit example storyboard with 4 steps.

## Test plan

- [ ] `cd docs-site && pnpm dev` — watch full animation loop, click step dots and code regions
- [ ] Verify terminal shows rich TUI for each step (survey picker → review → answers, subagent running → done, plan card, action running → done)
- [ ] Check responsive layout at mobile (< 768px) and tablet (< 1024px)
- [ ] Verify docs pages (getting-started, api, guides) still render correctly with heading margins
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)