### PR TITLE
fix(docs-site): prevent iOS Safari text auto-sizing in code blocks

### DIFF
--- a/docs-site/src/styles/global.css
+++ b/docs-site/src/styles/global.css
@@ -86,6 +86,8 @@
 html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   scroll-behavior: smooth;
 }
 


### PR DESCRIPTION
## Summary

- Adds `text-size-adjust: 100%` to the `html` element to prevent iOS Safari from inflating text on narrow viewports
- Fixes code blocks in the hero where some lines rendered at different font sizes on mobile

## Test plan

- [ ] Check on iOS Safari that all code lines in the hero render at the same size

🤖 Generated with [Claude Code](https://claude.com/claude-code)