### PR TITLE
feat: inline action shorthand and mapInput rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ No tool names in the XML. The preamble handles the mapping. Same skill, same XML
 Each step follows a fixed lifecycle. Understanding the order matters when using actions and the `save` callback:
 
 ```
-prompt -> model -> validate(response) -> action.input -> action.run -> save -> store -> next
+prompt -> model -> validate(response) -> action.mapInput -> action.run -> save -> store -> next
 ```
 
 1. **prompt** -- the CLI emits the step's prompt and schema to the agent (steps without a prompt auto-advance immediately)
 2. **model** -- the agent reads the prompt, does the work, returns structured output
 3. **validate(response)** -- the CLI validates the output against the step's ArkType schema (skipped for response-less steps)
-4. **action.input** -- if the step has an action, `action.input` transforms the validated response into action input
+4. **action.mapInput** -- if the step has an action, `action.mapInput` transforms the validated response into action input
 5. **action.run** -- the action executes CLI-side (file writes, API calls, etc.)
 6. **save** -- the `save` callback returns `{ step?, ...subStoreWrites }`. The `step` property controls what gets stored as the step result (defaults to action output or response). Additional keys are deep-merged into the corresponding sub-stores.
 7. **store** -- the step result is appended to `store.steps`, and sub-store writes are merged into their top-level store properties
@@ -418,7 +418,7 @@ skill-kit check <skill.ts>                          # Lint for portability issue
   next: 'step-name' | NextBranch[] | ((ctx) => 'step-name') | terminal,
   action?: {
     run: ActionDefinition,                                     // the action to execute
-    input?: (ctx: { response; store; params }) => unknown,     // transform response to action input
+    mapInput?: (ctx: { response; store; params }) => unknown,  // transform response to action input
   },
   save?: (ctx: { response; actionResult; store; params }) => { step?: unknown; [subStore: string]: unknown } | void,
   maxVisits?: number,
@@ -426,7 +426,7 @@ skill-kit check <skill.ts>                          # Lint for portability issue
 }
 ```
 
-**Step lifecycle:** `prompt` -> `model` -> `validate(response)` -> `action.input` -> `action.run` -> `save` -> `store` -> `next`
+**Step lifecycle:** `prompt` -> `model` -> `validate(response)` -> `action.mapInput` -> `action.run` -> `save` -> `store` -> `next`
 
 `PromptContext` fields available in dynamic prompts:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -754,7 +754,7 @@ skill({
 
 Steps write to sub-stores via the `save` callback (see below). Sub-store writes are deep-merged — each step can contribute a slice without overwriting the rest.
 
-The store is available in prompt callbacks, `next` callbacks, `save` callbacks, and `action.input` callbacks. It provides typed access to step results and sub-store state based on what the builder has accumulated — no manual annotations needed. There is no `updateState`, no `setState`, no reducers, no manual wiring. Step results flow into the store automatically.
+The store is available in prompt callbacks, `next` callbacks, `save` callbacks, and `action.mapInput` callbacks. It provides typed access to step results and sub-store state based on what the builder has accumulated — no manual annotations needed. There is no `updateState`, no `setState`, no reducers, no manual wiring. Step results flow into the store automatically.
 
 ### The `save` callback
 
@@ -884,14 +884,14 @@ step({
 });
 ```
 
-**Decoupling action input from step response** — when the model's reasoning response doesn't match what the action needs, use `action.input` to transform:
+**Decoupling action input from step response** — when the model's reasoning response doesn't match what the action needs, use `action.mapInput` to transform:
 
 ```typescript
 step({
   response: type({ reasoning: 'string', fileName: 'string', body: 'string' }),
   action: {
     run: writeReport,
-    input: ({ response, store, params }) => ({
+    mapInput: ({ response, store, params }) => ({
       path: `${store.steps['setup']?.outDir ?? '.'}/${response.fileName}`,
       content: response.body,
     }),
@@ -906,11 +906,32 @@ step({
 });
 ```
 
-**`action.input`** receives `{ response, store, params }` — the step's validated response, the store accessor, and the skill params. Use it to transform the model's response into the shape the action expects.
+**Inline actions** — when the action is specific to one step and doesn't need to be reused, pass a function directly instead of an object with `run`:
+
+```typescript
+step({
+  response: type({ url: 'string' }),
+  action: async ({ response, store, params, signal }) => {
+    const data = await fetch(response.url);
+    return { status: data.status };
+  },
+  save: ({ actionResult }) => ({ step: { status: actionResult.status } }),
+  next: 'report',
+});
+```
+
+Inline actions receive the full step context — `{ response, store, params, signal }` — with no schemas, no name, and no input mapping needed. The return type is inferred and flows into `actionResult` in `save`, `next`, and the store. Like reusable actions, inline actions are not re-executed during replay: the persisted `actionResult` is passed directly to `save`.
+
+The discriminant is `typeof action === 'function'` (inline) vs an object with a `run` property (reusable).
+
+**`action.mapInput`** receives `{ response, store, params }` — the step's validated response, the store accessor, and the skill params. Use it to transform the model's response into the shape the action expects. Only applicable to the reusable action form.
 
 **The `save` callback** runs after the action completes (or after response validation if no action exists), receiving `{ response, actionResult, store, params }`. Its return value routes data to the store: the `step` key is stored under `store.steps.<stepName>`, and other keys write to named sub-stores via deep merge. When `save` is omitted, the step-keyed result defaults to the action result (if an action exists) or the response.
 
-The lifecycle of a step with an action: prompt → model → validate(response) → action.input → action.run → save → next.
+The lifecycle of a step with an action depends on the form:
+
+- **Inline action:** prompt → model → validate(response) → action(ctx) → save → next
+- **Reusable action:** prompt → model → validate(response) → action.mapInput → action.run → save → next
 
 Actions accept an `AbortSignal` so long-running operations can be cancelled cleanly when the skill is interrupted.
 

--- a/docs-site/src/pages/api/index.mdx
+++ b/docs-site/src/pages/api/index.mdx
@@ -98,7 +98,7 @@ The full shape of a step's config object, passed to `.step()` or `step()`:
   next: string | NextBranch[] | TransitionFn | { terminal: true },  // required
   action?: {
     run: ActionDefinition,
-    input?: (ctx: { response; store; params }) => unknown,
+    mapInput?: (ctx: { response; store; params }) => unknown,
   },
   save?: (ctx: { response; actionResult; store; params }) => { step?; ...storeWrites },
   maxVisits?: number,
@@ -930,7 +930,7 @@ When the model's response doesn't match action input exactly:
   response: type({ reasoning: 'string', profile: ProfileSchema }),
   action: {
     run: writeProfile,
-    input: ({ response }) => ({ profile: response.profile }),
+    mapInput: ({ response }) => ({ profile: response.profile }),
   },
   save: ({ response, actionResult }) => ({
     step: { profile: response.profile, savedPath: actionResult.path },
@@ -939,7 +939,7 @@ When the model's response doesn't match action input exactly:
 })
 ```
 
-- `action.input` transforms step response into action input (runs before action)
+- `action.mapInput` transforms step response into action input (runs before action)
 - The `save` callback controls what gets stored (runs after action, receives `{ response, actionResult, store, params }`)
 - `next` receives action result for conditional routing
 
@@ -952,7 +952,7 @@ When the model's response doesn't match action input exactly:
 | `output` | `type.Any`                                                 | yes      | Schema for what the action returns  |
 | `run`    | `(ctx: { input, signal: AbortSignal }) => Promise<output>` | yes      | Async function with typed I/O       |
 
-The `run` function receives input parsed through the `input` schema and an `AbortSignal`. By default, the step's validated response is parsed as action input; use `action.input` on the step config to customize.
+The `run` function receives input parsed through the `input` schema and an `AbortSignal`. By default, the step's validated response is parsed as action input; use `action.mapInput` on the step config to customize.
 
 ---
 

--- a/docs-site/src/pages/architecture/index.mdx
+++ b/docs-site/src/pages/architecture/index.mdx
@@ -397,7 +397,7 @@ The `WorkflowEngine` (`src/runtime/engine.ts`) is the core state machine.
 
 1. **Validate** response against step's ArkType schema. Steps without a `response` schema skip validation.
 2. If invalid: fire `onStepValidationFailed`, return `ValidationErrorResult` with `retry: true`.
-3. **Map action input** via `action.input` (if configured), or use validated response directly.
+3. **Map action input** via `action.mapInput` (if configured), or use validated response directly.
 4. **Execute action** (if configured). Action receives typed input and AbortSignal.
 5. **Compute save** — call the `save` callback (if configured) with `{ response, actionResult, store, params }`. The return value is `{ step?, ...subStoreWrites }`. The `step` property determines what gets stored as the step result (priority: `save().step` > action output > response). Additional keys are deep-merged into the corresponding sub-stores via `applySave()`.
 6. **Freeze** the step result object.

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,7 +95,7 @@ The full shape of a step's config object, passed to `.step()` or `step()`:
   next: string | NextBranch[] | TransitionFn | { terminal: true },  // required
   action?: {
     run: ActionDefinition,
-    input?: (ctx: { response; store; params }) => unknown,
+    mapInput?: (ctx: { response; store; params }) => unknown,
   },
   save?: (ctx: { response; actionResult; store; params }) => { step?; ...storeWrites },
   maxVisits?: number,
@@ -907,7 +907,7 @@ Attach to a step via the `action` field:
   response: type({ reasoning: 'string', profile: ProfileSchema }),
   action: {
     run: writeProfile,
-    input: ({ response }) => ({ profile: response.profile }),
+    mapInput: ({ response }) => ({ profile: response.profile }),
   },
   save: ({ response, actionResult }) => ({
     step: { profile: response.profile, savedPath: actionResult.path },
@@ -916,11 +916,14 @@ Attach to a step via the `action` field:
 })
 ```
 
-- `action.input` transforms step response into action input (runs before action)
+- `action.mapInput` transforms step response into action input (runs before action)
 - The `save` callback controls what gets stored (runs after action, receives `{ response, actionResult, store, params }`)
 - `next` receives action result for conditional routing
 
-Step lifecycle with action: `prompt -> model -> validate(response) -> action.input -> action.run -> save -> store -> next`
+Step lifecycle with action:
+
+- Reusable: `prompt -> model -> validate(response) -> action.mapInput -> action.run -> save -> store -> next`
+- Inline: `prompt -> model -> validate(response) -> action(ctx) -> save -> store -> next`
 
 ### `action()` config (ActionDefinition)
 
@@ -933,12 +936,37 @@ Step lifecycle with action: `prompt -> model -> validate(response) -> action.inp
 
 ### Step `action` field config
 
-| Field   | Type                                            | Required | Description                                                        |
-| ------- | ----------------------------------------------- | -------- | ------------------------------------------------------------------ |
-| `run`   | `ActionDefinition`                              | yes      | The action to execute                                              |
-| `input` | `(ctx: { response; store; params }) => unknown` | no       | Transform step response into action input (default: pass response) |
+| Field      | Type                                            | Required | Description                                                        |
+| ---------- | ----------------------------------------------- | -------- | ------------------------------------------------------------------ |
+| `run`      | `ActionDefinition`                              | yes      | The action to execute                                              |
+| `mapInput` | `(ctx: { response; store; params }) => unknown` | no       | Transform step response into action input (default: pass response) |
 
-The `run` function on the `ActionDefinition` receives input parsed through the `input` schema and an `AbortSignal`. By default, the step's validated response is parsed as action input; use `action.input` to customize.
+The `run` function on the `ActionDefinition` receives input parsed through the `input` schema and an `AbortSignal`. By default, the step's validated response is parsed as action input; use `action.mapInput` to customize.
+
+### Inline action (function form)
+
+When an action is a one-off side effect, pass an async function directly instead of creating an `ActionDefinition`:
+
+```typescript
+.step('fetch', {
+  response: type({ url: 'string' }),
+  action: async ({ response, store, params, signal }) => {
+    const data = await fetch(response.url);
+    return { status: data.status };
+  },
+  save: ({ actionResult }) => ({ step: { status: actionResult.status } }),
+  next: 'report',
+})
+```
+
+| Context field | Description                              |
+| ------------- | ---------------------------------------- |
+| `response`    | The step's validated model response      |
+| `store`       | Store accessor for reading prior results |
+| `params`      | The skill's params                       |
+| `signal`      | AbortSignal for cancellation             |
+
+The return type is inferred and flows into `actionResult` in `save` and `next`. No input/output schemas or name required. The discriminant: `typeof action === 'function'` indicates inline, an object with `run` indicates reusable.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -407,7 +407,7 @@ The `WorkflowEngine` (`src/runtime/engine.ts`) is the core state machine.
 
 1. **Validate** response against step's ArkType schema. Steps without a `response` schema skip validation.
 2. If invalid: fire `onStepValidationFailed`, return `ValidationErrorResult` with `retry: true`.
-3. **Map action input** via `action.input` (if configured), or use validated response directly.
+3. **Map action input** via `action.mapInput` (if configured), or use validated response directly.
 4. **Execute action** (if configured). Action receives typed input and AbortSignal.
 5. **Compute save** — call the `save` callback (if configured) with `{ response, actionResult, store, params }`. The return value is `{ step?, ...subStoreWrites }`. The `step` property determines what gets stored as the step result (priority: `save().step` > action output > response). Additional keys are deep-merged into the corresponding sub-stores via `applySave()`.
 6. **Freeze** the step result object.
@@ -423,7 +423,7 @@ The `WorkflowEngine` (`src/runtime/engine.ts`) is the core state machine.
 11. If the next step has no prompt, auto-advance through it immediately (no agent round-trip needed).
 12. Return next step's `PromptResult`.
 
-The full lifecycle for a step with an action: prompt -> model -> validate(response) -> action.input -> action.run -> save -> store -> next.
+The full lifecycle for a step with an action: prompt -> model -> validate(response) -> action.mapInput -> action.run -> save -> store -> next.
 
 **Auto-advance for prompt-less steps:** When a step omits `prompt`, the engine skips agent interaction and immediately processes the step. This is useful for computation-only steps that route based on store or params without requiring a model round-trip. The step's `save`, action, and `next` callbacks still execute normally. Multiple prompt-less steps can chain — the engine advances through them until it reaches a step with a prompt or a terminal transition.
 

--- a/examples/game-jam/src/skill.ts
+++ b/examples/game-jam/src/skill.ts
@@ -263,7 +263,7 @@ export default skill({
     response: type({ summary: 'string' }),
     action: {
       run: saveGameConfig,
-      input: ({ store }) => ({
+      mapInput: ({ store }) => ({
         config: {
           name: store.steps['name-game']?.name ?? '',
           variant: store.steps['choose-variant']?.variant ?? 'classic',

--- a/src/protocol/fixtures/composite-skill.ts
+++ b/src/protocol/fixtures/composite-skill.ts
@@ -14,7 +14,7 @@ const doctorSkill = skill({ name: 'doctor', entry: 'diagnose' })
     response: type({ issue: 'string' }),
     action: {
       run: scanAction,
-      input: ({ response }) => ({ path: response.issue }),
+      mapInput: ({ response }) => ({ path: response.issue }),
     },
     next: 'triage',
   })

--- a/src/protocol/subskill-engine.test.ts
+++ b/src/protocol/subskill-engine.test.ts
@@ -21,7 +21,7 @@ const doctorSkill = skill({ name: 'doctor', entry: 'diagnose' })
     response: type({ issue: 'string' }),
     action: {
       run: scanAction,
-      input: ({ response }) => ({ path: response.issue }),
+      mapInput: ({ response }) => ({ path: response.issue }),
     },
     next: 'report',
   })

--- a/src/runtime/engine.test.ts
+++ b/src/runtime/engine.test.ts
@@ -326,7 +326,7 @@ test('actionInput mapping decouples step output from action input', async () => 
       response: type({ fileName: 'string', body: 'string' }),
       action: {
         run: writeAction,
-        input: ({ response }) => ({ path: `/out/${response.fileName}`, content: response.body }),
+        mapInput: ({ response }) => ({ path: `/out/${response.fileName}`, content: response.body }),
       },
       next: { terminal: true },
     })
@@ -362,7 +362,7 @@ test('actionInput receives store accessor', async () => {
       response: type({ val: 'string' }),
       action: {
         run: myAction,
-        input: ({ response, store }) => ({
+        mapInput: ({ response, store }) => ({
           prefix: store.steps.setup?.prefix ?? '',
           val: response.val,
         }),
@@ -610,7 +610,7 @@ test('result callback transforms what gets stored', async () => {
       response: type({ links: 'string[]' }),
       action: {
         run: checkLinks,
-        input: ({ response }) => ({ urls: response.links }),
+        mapInput: ({ response }) => ({ urls: response.links }),
       },
       save: ({ response, actionResult }) => ({
         step: {

--- a/src/runtime/engine.test.ts
+++ b/src/runtime/engine.test.ts
@@ -1762,3 +1762,110 @@ test('sub-store named same as step: no collision at runtime', async () => {
   // Sub-store at top level
   assert.deepEqual(storeSubStore, { extra: 'meta' });
 });
+
+// ============================================================
+// Inline action form
+// ============================================================
+
+test('inline action function runs and result is stored', async () => {
+  let receivedCtx: unknown;
+
+  const s = skill({ name: 'inline-action', entry: 'fetch' })
+    .step('fetch', {
+      prompt: 'Fetch data',
+      response: type({ url: 'string' }),
+      action: async (ctx) => {
+        receivedCtx = ctx;
+        return { status: 200, body: 'ok' };
+      },
+      save: ({ actionResult }) => ({ step: { code: (actionResult as { status: number }).status } }),
+      next: { terminal: true },
+    })
+    .build();
+
+  const engine = new WorkflowEngine(s, genericHost, {});
+  engine.start();
+  const result = await engine.advance('fetch', { url: 'https://example.com' });
+
+  assert.equal((result as DoneResult).done, true);
+  assert.deepEqual((result as DoneResult).completed?.actionResult, { status: 200, body: 'ok' });
+  // ctx receives response, store, params, signal
+  assert.ok(receivedCtx);
+  assert.deepEqual((receivedCtx as Record<string, unknown>).response, { url: 'https://example.com' });
+  assert.ok((receivedCtx as Record<string, unknown>).store);
+  assert.ok((receivedCtx as Record<string, unknown>).signal instanceof AbortSignal);
+});
+
+test('inline action result flows into save and transitions', async () => {
+  const s = skill({ name: 'inline-transition', entry: 'call' })
+    .step('call', {
+      prompt: 'Call API',
+      response: type({ url: 'string' }),
+      action: async () => ({ status: 200 }),
+      next: ({ actionResult }) => ((actionResult as { status: number }).status === 200 ? 'ok' : 'fail'),
+    })
+    .step('ok', { prompt: 'OK', response: type({}), next: { terminal: true } })
+    .step('fail', { prompt: 'Fail', response: type({}), next: { terminal: true } })
+    .build();
+
+  const engine = new WorkflowEngine(s, genericHost, {});
+  engine.start();
+  const result = await engine.advance('call', { url: 'https://example.com' });
+  assert.equal((result as PromptResult).step, 'ok');
+});
+
+test('inline action result defaults to store result when no save', async () => {
+  let storedResult: unknown;
+
+  const s = skill({ name: 'inline-store', entry: 'run' })
+    .step('run', {
+      prompt: 'Run',
+      response: type({ input: 'string' }),
+      action: async ({ response }) => ({ processed: response.input.toUpperCase() }),
+      next: 'report',
+    })
+    .step('report', {
+      prompt: (ctx) => {
+        storedResult = ctx.store.steps.run;
+        return 'Report';
+      },
+      response: type({}),
+      next: { terminal: true },
+    })
+    .build();
+
+  const engine = new WorkflowEngine(s, genericHost, {});
+  engine.start();
+  await engine.advance('run', { input: 'hello' });
+  await engine.advance('report', {});
+
+  assert.deepEqual(storedResult, { processed: 'HELLO' });
+});
+
+test('inline action receives store from previous steps', async () => {
+  let capturedStore: unknown;
+
+  const s = skill({ name: 'inline-store-ctx', entry: 'setup' })
+    .step('setup', {
+      prompt: 'Setup',
+      response: type({ prefix: 'string' }),
+      next: 'run',
+    })
+    .step('run', {
+      prompt: 'Run',
+      response: type({ val: 'string' }),
+      action: async ({ store }) => {
+        capturedStore = store;
+        return { ok: true };
+      },
+      next: { terminal: true },
+    })
+    .build();
+
+  const engine = new WorkflowEngine(s, genericHost, {});
+  engine.start();
+  await engine.advance('setup', { prefix: 'pre' });
+  await engine.advance('run', { val: 'test' });
+
+  assert.deepEqual((capturedStore as { steps: { setup: { prefix: string } } }).steps.setup, { prefix: 'pre' });
+});

--- a/src/runtime/engine.ts
+++ b/src/runtime/engine.ts
@@ -126,10 +126,18 @@ export class WorkflowEngine implements SkillEngine {
     }
 
     let actionResult: unknown = undefined;
-    if (stepDef.config.action) {
-      const { run: actionDef, input: inputFn } = stepDef.config.action;
-      const rawActionInput = inputFn
-        ? inputFn({ response, store: this.state.buildAccessor(), params: this.skillParams })
+    if (typeof stepDef.config.action === 'function') {
+      actionResult = await stepDef.config.action({
+        response,
+        store: this.state.buildAccessor(),
+        params: this.skillParams,
+        signal: this.abortController.signal,
+      });
+      actionResult = Object.freeze(actionResult);
+    } else if (stepDef.config.action) {
+      const { run: actionDef, mapInput } = stepDef.config.action;
+      const rawActionInput = mapInput
+        ? mapInput({ response, store: this.state.buildAccessor(), params: this.skillParams })
         : response;
       const actionInput = actionDef.input.assert(rawActionInput);
       actionResult = await actionDef.run({

--- a/src/skill-builder.ts
+++ b/src/skill-builder.ts
@@ -74,22 +74,18 @@ interface InlineActionContext<TOutput, TSteps, TStores, TStoreWrites, TParams> {
 }
 
 /**
- * Extracts the action result type from any valid action config shape:
- * - Inline fn: `(ctx) => Promise<R>` → `R`
- * - ActionDefinition directly: `ActionDefinition<_, TOut>` → `TOut['infer']`
- * - Reusable config object: `{ run: ActionDefinition<_, TOut> }` → `TOut['infer']`
- * - Absent: `undefined` → `undefined`
+ * Derives the action result type from the generic parameter.
+ *
+ * The builder infers TReusableAction as the ActionDefinition from `{ run: T }`,
+ * so this helper receives the definition directly — not the config object.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ExtractActionResult<TAction> = TAction extends (...args: any[]) => Promise<infer R>
+type ExtractActionResult<T> = T extends (...args: any[]) => Promise<infer R>
   ? R
   : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    TAction extends { run: ActionDefinition<any, infer TOut> }
+    T extends ActionDefinition<any, infer TOut>
     ? TOut['infer']
-    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      TAction extends ActionDefinition<any, infer TOut>
-      ? TOut['infer']
-      : undefined;
+    : undefined;
 
 /**
  * Fluent builder for defining a skill's step graph with full type safety.

--- a/src/skill-builder.ts
+++ b/src/skill-builder.ts
@@ -6,7 +6,6 @@ import type {
   StepDefinition,
   ModuleDefinition,
   ActionDefinition,
-  InferActionResult,
   SubskillRegistration,
   TopicConfig,
 } from './types.js';
@@ -58,6 +57,39 @@ function checkActionInputCompat(stepName: string, outputSchema: type.Any, action
  * optional (`store.env?.host`) to required (`store.env.host`) downstream.
  */
 type ExtractStoreWrites<T> = T extends void ? {} : Omit<T, 'step'>;
+
+/**
+ * Context passed to inline action functions.
+ */
+interface InlineActionContext<TOutput, TSteps, TStores, TStoreWrites, TParams> {
+  response: TOutput;
+  store: StoreAccessor<
+    TSteps & Record<string, unknown>,
+    never,
+    TStores & Record<string, unknown>,
+    TStoreWrites & Record<string, unknown>
+  >;
+  params: TParams;
+  signal: AbortSignal;
+}
+
+/**
+ * Extracts the action result type from any valid action config shape:
+ * - Inline fn: `(ctx) => Promise<R>` → `R`
+ * - ActionDefinition directly: `ActionDefinition<_, TOut>` → `TOut['infer']`
+ * - Reusable config object: `{ run: ActionDefinition<_, TOut> }` → `TOut['infer']`
+ * - Absent: `undefined` → `undefined`
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ExtractActionResult<TAction> = TAction extends (...args: any[]) => Promise<infer R>
+  ? R
+  : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TAction extends { run: ActionDefinition<any, infer TOut> }
+    ? TOut['infer']
+    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      TAction extends ActionDefinition<any, infer TOut>
+      ? TOut['infer']
+      : undefined;
 
 /**
  * Fluent builder for defining a skill's step graph with full type safety.
@@ -254,33 +286,37 @@ export class SkillBuilder<
   step<
     Name extends string,
     TOutput extends type.Any,
+    /**
+     * TReusableAction — inferred from `action: { run: TReusableAction, ... }`.
+     * TypeScript infers this from the `run` property of the object form.
+     * The conditional `T extends ActionDefinition ? { run: T } : never` is the
+     * canonical pattern: TypeScript infers T from the structural `{ run: T }` position.
+     */
+    TReusableAction extends ActionDefinition<any, any> | undefined = undefined,
+    /**
+     * TInlineAction — inferred from `action: async ctx => ...`.
+     * TypeScript infers this from the direct function value at the call site
+     * via `T extends fn ? T : never` — T appears in both condition and result,
+     * which triggers inference from the provided value.
+     */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    A extends ActionDefinition<any, any> | ((...args: any[]) => Promise<unknown>) | undefined = undefined,
+    TInlineAction extends ((ctx: any) => Promise<unknown>) | undefined = undefined,
     TSaveReturn extends ({ step?: unknown } & DeepPartial<TStores>) | void = void,
+    TActionResult = ExtractActionResult<TReusableAction extends undefined ? TInlineAction : TReusableAction>,
     TResultValue = TSaveReturn extends { step: infer S }
       ? S
-      : A extends ActionDefinition<any, infer TActionOut>
-        ? TActionOut['infer']
-        : TOutput extends type.Any
-          ? TOutput['infer']
-          : unknown,
+      : TActionResult extends undefined
+        ? TOutput['infer']
+        : TActionResult,
     const TNext extends StepConfig<
       TOutput,
       TParams,
-      A extends ActionDefinition<any, any> ? InferActionResult<A> : undefined,
+      TActionResult,
       TSteps,
       never,
       TStores,
       TGuarantees['storeWrites']
-    >['next'] = StepConfig<
-      TOutput,
-      TParams,
-      A extends ActionDefinition<any, any> ? InferActionResult<A> : undefined,
-      TSteps,
-      never,
-      TStores,
-      TGuarantees['storeWrites']
-    >['next'],
+    >['next'] = StepConfig<TOutput, TParams, TActionResult, TSteps, never, TStores, TGuarantees['storeWrites']>['next'],
   >(
     name: Name,
     configOrDef:
@@ -288,7 +324,7 @@ export class SkillBuilder<
           StepConfig<
             TOutput,
             TParams,
-            A extends ActionDefinition<any, any> ? InferActionResult<A> : undefined,
+            TActionResult,
             TSteps,
             Exclude<TGuarantees['steps'], Name>,
             TStores,
@@ -299,22 +335,36 @@ export class SkillBuilder<
           next: TNext;
           save?: (ctx: {
             response: TOutput['infer'];
-            actionResult: A extends ActionDefinition<any, any> ? InferActionResult<A> : undefined;
+            actionResult: TActionResult;
             store: StoreAccessor<TSteps, Exclude<TGuarantees['steps'], Name>, TStores, TGuarantees['storeWrites']>;
             params: Readonly<TParams>;
           }) => TSaveReturn;
-          action?: A extends ActionDefinition<any, any>
+          /**
+           * Accepts either form:
+           * - Reusable: `{ run: ActionDefinition, mapInput?: fn }` — TypeScript infers
+           *   TReusableAction from the `run` property (structural inference position).
+           * - Inline: `async ctx => ...` — TypeScript infers TInlineAction from the
+           *   conditional `TInlineAction extends fn ? TInlineAction : never`. The T
+           *   appears in both condition and result, enabling inference from the value.
+           *
+           * Both conditionals resolve to `never` when their respective generic is absent
+           * (default `undefined`). TypeScript eliminates `never` from the union.
+           */
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          action?: TReusableAction extends ActionDefinition<any, any>
             ? {
-                run: A;
+                run: TReusableAction;
                 mapInput?: (ctx: {
                   response: TOutput['infer'];
                   store: StoreAccessor<TSteps, never, TStores, TGuarantees['storeWrites']>;
                   params: TParams;
                 }) => unknown;
               }
-            : A extends (...args: any[]) => Promise<unknown>
-              ? A
-              : undefined;
+            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                | (TInlineAction extends (ctx: any) => Promise<unknown> ? TInlineAction : never)
+                | ((
+                    ctx: InlineActionContext<TOutput['infer'], TSteps, TStores, TGuarantees['storeWrites'], TParams>,
+                  ) => Promise<unknown>);
         })
       | StepDefinition,
   ): SkillBuilder<

--- a/src/skill-builder.ts
+++ b/src/skill-builder.ts
@@ -16,7 +16,7 @@ import type { DeepPartial, BranchState, GuaranteeState, AddStepGuarantees, AddSt
 
 /**
  * Build-time check that a step's response schema provides the properties
- * required by its action's input schema, when no explicit `action.input`
+ * required by its action's input schema, when no explicit `mapInput`
  * mapper is provided. This prevents a common misconfiguration where the
  * action would receive missing fields at runtime.
  */
@@ -33,7 +33,7 @@ function checkActionInputCompat(stepName: string, outputSchema: type.Any, action
       throw new Error(
         `Step "${stepName}" uses action "${actionDef.name}" without an input mapper, ` +
           `but the step output is missing properties required by the action input: [${missing.join(', ')}]. ` +
-          `Add an action.input mapper to transform the step output.`,
+          `Add an action.mapInput mapper to transform the step output.`,
       );
     }
   } catch (err) {
@@ -95,7 +95,7 @@ type ExtractStoreWrites<T> = T extends void ? {} : Omit<T, 'step'>;
  *
  * @template TParams — The skill's input parameters type, inferred from the
  *   `params` ArkType schema in the skill config. Passed to every step's `prompt`,
- *   `save`, and `action.input` callbacks as `ctx.params`.
+ *   `save`, and `action.mapInput` callbacks as `ctx.params`.
  *
  * @template TSteps — An intersection of `{ [stepName]: resultType }` entries,
  *   one per `.step()` call. This is the "step result map" — it tracks what type
@@ -224,7 +224,7 @@ export class SkillBuilder<
    * can't read your own result from the store. After `.step()` returns, Name
    * gets added to the guarantee set for subsequent steps.
    *
-   * The same self-exclusion does NOT apply to `action.input` — that callback
+   * The same self-exclusion does NOT apply to `action.mapInput` — that callback
    * uses `never` for guaranteed steps because the action runs after the response
    * is validated but before save, so it only has access to the response and
    * the store's current state without any guarantee about which steps ran.
@@ -254,7 +254,8 @@ export class SkillBuilder<
   step<
     Name extends string,
     TOutput extends type.Any,
-    A extends ActionDefinition<any, any> | undefined = undefined,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    A extends ActionDefinition<any, any> | ((...args: any[]) => Promise<unknown>) | undefined = undefined,
     TSaveReturn extends ({ step?: unknown } & DeepPartial<TStores>) | void = void,
     TResultValue = TSaveReturn extends { step: infer S }
       ? S
@@ -305,13 +306,15 @@ export class SkillBuilder<
           action?: A extends ActionDefinition<any, any>
             ? {
                 run: A;
-                input?: (ctx: {
+                mapInput?: (ctx: {
                   response: TOutput['infer'];
                   store: StoreAccessor<TSteps, never, TStores, TGuarantees['storeWrites']>;
                   params: TParams;
                 }) => unknown;
               }
-            : undefined;
+            : A extends (...args: any[]) => Promise<unknown>
+              ? A
+              : undefined;
         })
       | StepDefinition,
   ): SkillBuilder<
@@ -325,7 +328,7 @@ export class SkillBuilder<
       this.steps[name] = configOrDef;
     } else {
       const config = configOrDef as StepConfig;
-      if (config.action && !config.action.input && config.response) {
+      if (config.action && typeof config.action !== 'function' && !config.action.mapInput && config.response) {
         checkActionInputCompat(name, config.response, config.action.run);
       }
       this.steps[name] = createStep(config);

--- a/src/skill.test.ts
+++ b/src/skill.test.ts
@@ -299,7 +299,7 @@ test('step with compatible action input schema does not throw', () => {
   );
 });
 
-test('step with action.input mapper skips compat check', () => {
+test('step with action.mapInput mapper skips compat check', () => {
   const writeAction = action({
     name: 'write',
     input: type({ path: 'string' }),
@@ -314,7 +314,7 @@ test('step with action.input mapper skips compat check', () => {
         response: type({ title: 'string' }),
         action: {
           run: writeAction,
-          input: ({ response }) => ({ path: response.title }),
+          mapInput: ({ response }) => ({ path: response.title }),
         },
         next: { terminal: true },
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,7 +157,12 @@ export type SystemBuilder = {
 // --- Type helpers ---
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type InferActionResult<A> = A extends ActionDefinition<any, infer TOut> ? TOut['infer'] : undefined;
+export type InferActionResult<A> = A extends (...args: any[]) => Promise<infer R>
+  ? R
+  : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    A extends ActionDefinition<any, infer TOut>
+    ? TOut['infer']
+    : undefined;
 
 // --- Steps ---
 
@@ -241,7 +246,7 @@ export type NextTarget<
   | { terminal: true };
 
 /**
- * Lifecycle: prompt → model → validate(response) → action.input → action.run → result → next
+ * Lifecycle: prompt → model → validate(response) → action (inline fn or mapInput+run) → save → next
  *
  * When prompt is omitted the engine auto-advances (no LLM round-trip).
  * When response is omitted no schema block is emitted and validation is skipped.
@@ -264,14 +269,21 @@ interface BaseStepFields<
     | TransitionFn<TOutput['infer'], TActionResult, TParams, TSteps, TStores, TStoreWrites>
     | readonly NextBranch<TOutput['infer'], TActionResult, TParams, TSteps, TStores, TStoreWrites>[]
     | { terminal: true };
-  action?: {
-    run: ActionDefinition;
-    input?: (ctx: {
-      response: TOutput['infer'];
-      store: StoreAccessor<TSteps, never, TStores, TStoreWrites>;
-      params: Readonly<TParams>;
-    }) => unknown;
-  };
+  action?:
+    | ((ctx: {
+        response: TOutput['infer'];
+        store: StoreAccessor<TSteps, never, TStores, TStoreWrites>;
+        params: TParams;
+        signal: AbortSignal;
+      }) => Promise<unknown>)
+    | {
+        run: ActionDefinition;
+        mapInput?: (ctx: {
+          response: TOutput['infer'];
+          store: StoreAccessor<TSteps, never, TStores, TStoreWrites>;
+          params: Readonly<TParams>;
+        }) => unknown;
+      };
   maxVisits?: number;
   onMaxVisits?: string;
 }

--- a/src/types/builder-narrowing.test-d.ts
+++ b/src/types/builder-narrowing.test-d.ts
@@ -165,7 +165,7 @@ skill({ name: 'action-store', entry: 'find' })
     response: type({ links: 'string[]' }),
     action: {
       run: checkLinks,
-      input: ({ response }) => ({ urls: response.links }),
+      mapInput: ({ response }) => ({ urls: response.links }),
     },
     next: 'report',
   })

--- a/src/types/edge-cases.test-d.ts
+++ b/src/types/edge-cases.test-d.ts
@@ -576,7 +576,7 @@ skill({
     response: type({ url: 'string' }),
     action: {
       run: fetchAction,
-      input: ({ response }) => ({ url: response.url }),
+      mapInput: ({ response }) => ({ url: response.url }),
     },
     save: ({ response, actionResult }) => {
       // response is the step output

--- a/src/types/edge-cases.test-d.ts
+++ b/src/types/edge-cases.test-d.ts
@@ -660,3 +660,106 @@ void (0 as unknown as _g2w);
 void (0 as unknown as _fb1);
 void (0 as unknown as _ac1);
 void (0 as unknown as MethodNameView);
+
+// ============================================================
+// 23. Inline action: function form accepted, result flows to save
+// ============================================================
+
+skill({ name: 'inline-action-save', entry: 'a' }).step('a', {
+  prompt: 'Go',
+  response: type({ url: 'string' }),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  action: async (ctx: any) => ({ status: 200 }),
+  save: ({ actionResult }) => {
+    const s: number = actionResult.status;
+    void s;
+  },
+  next: { terminal: true },
+});
+
+// ============================================================
+// 24. Inline action: result becomes store step value when no save
+// ============================================================
+
+skill({ name: 'inline-action-store', entry: 'a' })
+  .step('a', {
+    prompt: 'Go',
+    response: type({ url: 'string' }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    action: async (ctx: any) => ({ fetched: true, code: 200 }),
+    next: 'b',
+  })
+  .step('b', {
+    prompt: ({ store }) => {
+      // store.steps.a carries the inline action return type, not the response
+      const fetched: boolean = store.steps.a.fetched;
+      const code: number = store.steps.a.code;
+      void fetched;
+      void code;
+
+      // @ts-expect-error - 'url' is on the response, not the inline action return
+      store.steps.a.url;
+
+      return 'B';
+    },
+    response: type({}),
+    next: { terminal: true },
+  });
+
+// ============================================================
+// 25. Inline action: save.step overrides store value
+// ============================================================
+
+skill({ name: 'inline-action-save-override', entry: 'a' })
+  .step('a', {
+    prompt: 'Go',
+    response: type({ url: 'string' }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    action: async (ctx: any) => ({ status: 200 }),
+    save: ({ actionResult }) => ({
+      step: { statusText: actionResult.status === 200 ? 'ok' : 'fail' },
+    }),
+    next: 'b',
+  })
+  .step('b', {
+    prompt: ({ store }) => {
+      const text: string = store.steps.a.statusText;
+      void text;
+      return 'B';
+    },
+    response: type({}),
+    next: { terminal: true },
+  });
+
+// ============================================================
+// 26. Inline action: contextual typing provides response, store, params, signal
+// ============================================================
+
+skill({ name: 'inline-action-ctx', entry: 'a', params: type({ apiKey: 'string' }) }).step('a', {
+  prompt: 'Go',
+  response: type({ url: 'string' }),
+  action: async (ctx) => {
+    const url: string = ctx.response.url;
+    const key: string = ctx.params.apiKey;
+    const sig: AbortSignal = ctx.signal;
+    void url;
+    void key;
+    void sig;
+    return { ok: true };
+  },
+  next: { terminal: true },
+});
+
+// ============================================================
+// 27. No action: actionResult is undefined
+// ============================================================
+
+skill({ name: 'no-action-undefined', entry: 'a' }).step('a', {
+  prompt: 'Go',
+  response: type({ val: 'string' }),
+  save: ({ actionResult }) => {
+    const u: undefined = actionResult;
+    void u;
+  },
+  next: { terminal: true },
+});

--- a/src/types/sub-store.test-d.ts
+++ b/src/types/sub-store.test-d.ts
@@ -510,6 +510,127 @@ skill({
     next: { terminal: true },
   });
 
+// ============================================================
+// Inline action: save writes actionResult to sub-store
+// ============================================================
+
+skill({
+  name: 'inline-sub-store',
+  entry: 'a',
+  stores: {
+    env: type({ host: 'string', status: 'number' }),
+  },
+})
+  .step('a', {
+    prompt: 'A',
+    response: type({ url: 'string' }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    action: async (ctx: any) => ({ host: 'api.example.com', status: 200 }),
+    save: ({ actionResult }) => ({
+      step: { fetched: true },
+      env: { host: actionResult.host, status: actionResult.status },
+    }),
+    next: 'b',
+  })
+  .step('b', {
+    prompt: ({ store }) => {
+      // step result is save().step
+      const fetched: boolean = store.steps.a.fetched;
+      void fetched;
+
+      // @ts-expect-error - 'host' is on actionResult, not save().step
+      store.steps.a.host;
+
+      // sub-store written
+      const host = store.env?.host;
+      const status = store.env?.status;
+      void host;
+      void status;
+
+      return 'B';
+    },
+    response: type({}),
+    next: { terminal: true },
+  });
+
+// ============================================================
+// Inline action: no save → result defaults to action return, sub-store untouched
+// ============================================================
+
+skill({
+  name: 'inline-no-save',
+  entry: 'a',
+  stores: {
+    env: type({ host: 'string' }),
+  },
+})
+  .step('a', {
+    prompt: 'A',
+    response: type({ url: 'string' }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    action: async (ctx: any) => ({ code: 200, body: 'ok' }),
+    next: 'b',
+  })
+  .step('b', {
+    prompt: ({ store }) => {
+      // step result defaults to inline action return (no save)
+      const code: number = store.steps.a.code;
+      const body: string = store.steps.a.body;
+      void code;
+      void body;
+
+      // @ts-expect-error - 'url' is from response, not action return
+      store.steps.a.url;
+
+      // sub-store not written — still optional
+      const host = store.env?.host;
+      void host;
+
+      return 'B';
+    },
+    response: type({}),
+    next: { terminal: true },
+  });
+
+// ============================================================
+// Inline action: only sub-store writes in save → step defaults to action return
+// ============================================================
+
+skill({
+  name: 'inline-sub-store-only',
+  entry: 'a',
+  stores: {
+    results: type({ lastPath: 'string' }),
+  },
+})
+  .step('a', {
+    prompt: 'A',
+    response: type({ val: 'string' }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    action: async (ctx: any) => ({ path: '/tmp/out', bytes: 42 }),
+    save: ({ actionResult }) => ({
+      results: { lastPath: actionResult.path },
+    }),
+    next: 'b',
+  })
+  .step('b', {
+    prompt: ({ store }) => {
+      // No step key in save → defaults to action return
+      const path: string = store.steps.a.path;
+      const bytes: number = store.steps.a.bytes;
+      void path;
+      void bytes;
+
+      // Sub-store written
+      const lastPath = store.results?.lastPath;
+      void lastPath;
+
+      return 'B';
+    },
+    response: type({}),
+    next: { terminal: true },
+  });
+
 // Suppress unused type warnings
 void (0 as unknown as _dp1);
 void (0 as unknown as _dp2);

--- a/src/types/sub-store.test-d.ts
+++ b/src/types/sub-store.test-d.ts
@@ -129,7 +129,7 @@ skill({
     response: type({ val: 'string' }),
     action: {
       run: writeFile,
-      input: ({ response }) => ({ content: response.val }),
+      mapInput: ({ response }) => ({ content: response.val }),
     },
     save: ({ actionResult }) => ({
       env: { host: actionResult.path },
@@ -326,7 +326,7 @@ skill({
     response: type({ val: 'string' }),
     action: {
       run: dummyAction,
-      input: ({ response, store }) => {
+      mapInput: ({ response, store }) => {
         const prefix = store.config?.prefix;
         void prefix;
         return { val: response.val };

--- a/tasks/2026-05-03_1956_inline-action-shorthand/TASK.md
+++ b/tasks/2026-05-03_1956_inline-action-shorthand/TASK.md
@@ -1,0 +1,171 @@
+# Inline Action Shorthand
+
+## Scope
+
+**In:**
+- `action` field on `StepConfig` becomes a discriminated union: inline function or reusable object
+- Rename `action.input` → `action.mapInput` on the reusable form
+- Type inference for inline action return type flows to `actionResult` in `save` / `TResultValue`
+- Engine branching for inline vs. reusable action execution
+- Update all existing usages: `action.input` → `action.mapInput` (engine tests, skill tests, examples, fixtures, type tests)
+- Update `InferActionResult` helper or add parallel helper for inline actions
+- Update docs: SPEC.md, docs/api.md, docs/architecture.md, README.md, docs-site
+
+**Out:**
+- Input/output schema validation on inline actions (by design)
+- Input compatibility check (`checkActionInputCompat`) for inline actions (not applicable)
+
+## Context
+
+The existing `action: { run, input }` API forces double-wrapping for single-use side effects:
+a `name`, `input` schema, `output` schema, separate `input` mapper — all for a one-off file read.
+The inline form makes the common single-use case concise while keeping the reusable form for
+shared, schema-validated actions. The rename from `input` → `mapInput` makes the mapper's
+purpose explicit.
+
+User-requested design (verbatim from conversation):
+
+```typescript
+// Inline form
+.step('foo', {
+  action: async ({ response, store, params, signal }) => {
+    const data = await fetch(store.steps.gather.host);
+    return { status: data.status };
+  },
+  save: ({ actionResult }) => ({ step: { status: actionResult.status } }),
+  next: 'report',
+})
+
+// Reusable form (mapInput replaces input)
+.step('foo', {
+  action: {
+    run: checkLinks,
+    mapInput: ({ response, store, params }) => ({ urls: response.links }),
+  },
+  save: ({ actionResult }) => ({ step: { broken: actionResult.broken } }),
+  next: 'report',
+})
+```
+
+## Plan
+
+### Type changes
+
+#### `InferActionResult<A>` helper — generalize
+
+Current: `A extends ActionDefinition<any, infer TOut> ? TOut['infer'] : undefined`
+
+New: two-form conditional:
+```typescript
+export type InferActionResult<A> =
+  A extends (...args: any[]) => Promise<infer R>
+    ? R
+    : A extends ActionDefinition<any, infer TOut>
+      ? TOut['infer']
+      : undefined;
+```
+
+#### `BaseStepFields.action` union type (`src/types.ts`)
+
+```typescript
+action?:
+  | ((ctx: {
+      response: TOutput['infer'];
+      store: StoreAccessor<TSteps, never, TStores, TStoreWrites>;
+      params: TParams;
+      signal: AbortSignal;
+    }) => Promise<unknown>)
+  | {
+      run: ActionDefinition;
+      mapInput?: (ctx: {
+        response: TOutput['infer'];
+        store: StoreAccessor<TSteps, never, TStores, TStoreWrites>;
+        params: Readonly<TParams>;
+      }) => unknown;
+    };
+```
+
+#### `SkillBuilder.step()` generic `A` (`src/skill-builder.ts`)
+
+Current: `A extends ActionDefinition<any, any> | undefined = undefined`
+
+New: `A extends ActionDefinition<any, any> | ((...args: any[]) => Promise<unknown>) | undefined = undefined`
+
+The `TResultValue` conditional already handles the inline case via `InferActionResult<A>` — once `InferActionResult` is updated, it falls through correctly.
+
+The `action?` field in the `configOrDef` object also needs to accept the inline function form:
+```typescript
+action?: A extends ActionDefinition<any, any>
+  ? { run: A; mapInput?: (...) => unknown }
+  : A extends (...args: any[]) => Promise<unknown>
+    ? A
+    : undefined;
+```
+
+#### `checkActionInputCompat` guard — reusable form only
+
+The guard `if (config.action && !config.action.input && config.response)` must change to:
+- Only run when action is the reusable object form
+- Check `!config.action.mapInput` instead of `!config.action.input`
+
+### Engine changes (`src/runtime/engine.ts`)
+
+In `advance()`, action execution branch:
+```typescript
+if (typeof stepDef.config.action === 'function') {
+  actionResult = await stepDef.config.action({
+    response,
+    store: this.state.buildAccessor(),
+    params: this.skillParams,
+    signal: this.abortController.signal,
+  });
+} else if (stepDef.config.action) {
+  const { run: actionDef, mapInput } = stepDef.config.action;
+  const rawActionInput = mapInput
+    ? mapInput({ response, store: this.state.buildAccessor(), params: this.skillParams })
+    : response;
+  const actionInput = actionDef.input.assert(rawActionInput);
+  actionResult = await actionDef.run({ input: actionInput, signal: this.abortController.signal });
+}
+actionResult = actionResult !== undefined ? Object.freeze(actionResult) : undefined;
+```
+
+Replay path is unchanged — it never re-runs actions.
+
+### Rename `input` → `mapInput`
+
+All files with `action: { run, input }`:
+- `src/runtime/engine.ts` (destructuring)
+- `src/runtime/engine.test.ts` (test cases using `input:`)
+- `src/skill-builder.ts` (type definition + compat guard)
+- `src/skill.test.ts` (`action.input` test description + usage)
+- `src/types.ts` (field name in `BaseStepFields`)
+- `src/types/edge-cases.test-d.ts`
+- `src/protocol/fixtures/composite-skill.ts`
+- `src/protocol/subskill-engine.test.ts`
+- `examples/game-jam/src/skill.ts`
+
+### Lifecycle comment update
+
+The comment on `BaseStepFields` currently says:
+`Lifecycle: prompt → model → validate(response) → action.input → action.run → result → next`
+Update to:
+`Lifecycle: prompt → model → validate(response) → action(inline) or action.mapInput+action.run → save → next`
+
+## Steps
+
+- [x] Create TASK.md and commit
+- [ ] Update `src/types.ts`: union action type, rename `input` → `mapInput`, update `InferActionResult`
+- [ ] Update `src/skill-builder.ts`: generalize `A` generic, update action field type, update compat guard
+- [ ] Update `src/runtime/engine.ts`: inline action branch, `input` → `mapInput`
+- [ ] Update test files: `engine.test.ts`, `skill.test.ts`, type test-d files, fixtures, subskill-engine.test.ts
+- [ ] Update examples: `game-jam/src/skill.ts`
+- [ ] Run typecheck + tests + format — pass
+- [ ] Update docs: SPEC.md, docs/api.md, docs/architecture.md, README.md, docs-site MDX
+- [ ] Final typecheck + tests + format — pass
+
+## Notes
+
+- `input` inside `ActionConfig` / `ActionDefinition` (the action's own input schema field) is NOT renamed — only the step-level mapper `action.input` → `action.mapInput`
+- The `checkActionInputCompat` function still validates reusable actions when `mapInput` is absent
+- Inline actions get full context including `signal` for cancellation; reusable actions already have `signal` via their `run` ctx

--- a/tasks/2026-05-03_1956_inline-action-shorthand/TASK.md
+++ b/tasks/2026-05-03_1956_inline-action-shorthand/TASK.md
@@ -3,6 +3,7 @@
 ## Scope
 
 **In:**
+
 - `action` field on `StepConfig` becomes a discriminated union: inline function or reusable object
 - Rename `action.input` → `action.mapInput` on the reusable form
 - Type inference for inline action return type flows to `actionResult` in `save` / `TResultValue`
@@ -12,6 +13,7 @@
 - Update docs: SPEC.md, docs/api.md, docs/architecture.md, README.md, docs-site
 
 **Out:**
+
 - Input/output schema validation on inline actions (by design)
 - Input compatibility check (`checkActionInputCompat`) for inline actions (not applicable)
 
@@ -56,13 +58,13 @@ User-requested design (verbatim from conversation):
 Current: `A extends ActionDefinition<any, infer TOut> ? TOut['infer'] : undefined`
 
 New: two-form conditional:
+
 ```typescript
-export type InferActionResult<A> =
-  A extends (...args: any[]) => Promise<infer R>
-    ? R
-    : A extends ActionDefinition<any, infer TOut>
-      ? TOut['infer']
-      : undefined;
+export type InferActionResult<A> = A extends (...args: any[]) => Promise<infer R>
+  ? R
+  : A extends ActionDefinition<any, infer TOut>
+    ? TOut['infer']
+    : undefined;
 ```
 
 #### `BaseStepFields.action` union type (`src/types.ts`)
@@ -94,6 +96,7 @@ New: `A extends ActionDefinition<any, any> | ((...args: any[]) => Promise<unknow
 The `TResultValue` conditional already handles the inline case via `InferActionResult<A>` — once `InferActionResult` is updated, it falls through correctly.
 
 The `action?` field in the `configOrDef` object also needs to accept the inline function form:
+
 ```typescript
 action?: A extends ActionDefinition<any, any>
   ? { run: A; mapInput?: (...) => unknown }
@@ -105,12 +108,14 @@ action?: A extends ActionDefinition<any, any>
 #### `checkActionInputCompat` guard — reusable form only
 
 The guard `if (config.action && !config.action.input && config.response)` must change to:
+
 - Only run when action is the reusable object form
 - Check `!config.action.mapInput` instead of `!config.action.input`
 
 ### Engine changes (`src/runtime/engine.ts`)
 
 In `advance()`, action execution branch:
+
 ```typescript
 if (typeof stepDef.config.action === 'function') {
   actionResult = await stepDef.config.action({
@@ -135,6 +140,7 @@ Replay path is unchanged — it never re-runs actions.
 ### Rename `input` → `mapInput`
 
 All files with `action: { run, input }`:
+
 - `src/runtime/engine.ts` (destructuring)
 - `src/runtime/engine.test.ts` (test cases using `input:`)
 - `src/skill-builder.ts` (type definition + compat guard)

--- a/tasks/2026-05-03_1956_inline-action-shorthand/TASK.md
+++ b/tasks/2026-05-03_1956_inline-action-shorthand/TASK.md
@@ -161,17 +161,19 @@ Update to:
 ## Steps
 
 - [x] Create TASK.md and commit
-- [ ] Update `src/types.ts`: union action type, rename `input` → `mapInput`, update `InferActionResult`
-- [ ] Update `src/skill-builder.ts`: generalize `A` generic, update action field type, update compat guard
-- [ ] Update `src/runtime/engine.ts`: inline action branch, `input` → `mapInput`
-- [ ] Update test files: `engine.test.ts`, `skill.test.ts`, type test-d files, fixtures, subskill-engine.test.ts
-- [ ] Update examples: `game-jam/src/skill.ts`
-- [ ] Run typecheck + tests + format — pass
-- [ ] Update docs: SPEC.md, docs/api.md, docs/architecture.md, README.md, docs-site MDX
-- [ ] Final typecheck + tests + format — pass
+- [x] Update `src/types.ts`: union action type, rename `input` → `mapInput`, update `InferActionResult`
+- [x] Update `src/skill-builder.ts`: generalize `A` generic, update action field type, update compat guard
+- [x] Update `src/runtime/engine.ts`: inline action branch, `input` → `mapInput`
+- [x] Update test files: `engine.test.ts`, `skill.test.ts`, type test-d files, fixtures, subskill-engine.test.ts
+- [x] Update examples: `game-jam/src/skill.ts`
+- [x] Run typecheck + tests + format — pass
+- [x] Update docs: SPEC.md, docs/api.md, docs/architecture.md, README.md, docs-site MDX
+- [x] Final typecheck + tests + format — pass
 
 ## Notes
 
 - `input` inside `ActionConfig` / `ActionDefinition` (the action's own input schema field) is NOT renamed — only the step-level mapper `action.input` → `action.mapInput`
+- The builder uses two separate generics (`TReusableAction` + `TInlineAction`) instead of one conditional generic for the action field. This is required because TypeScript cannot infer a type parameter from a conditional position (`T extends X ? ... : T`) when the default resolves first. With two generics, each has its own inference site in the `action?` union.
+- The `action?` union includes a broad `((ctx: InlineActionContext<...>) => Promise<unknown>)` member alongside `TInlineAction` to provide contextual typing for inline function parameters (response, store, params, signal) — without this, TypeScript requires explicit `ctx: any` annotation.
 - The `checkActionInputCompat` function still validates reusable actions when `mapInput` is absent
 - Inline actions get full context including `signal` for cancellation; reusable actions already have `signal` via their `run` ctx


### PR DESCRIPTION
## Summary

- **Inline action form**: `action` on step config now accepts an async function directly for one-off side effects — no `ActionDefinition`, schemas, or mapping needed. Full context (`response`, `store`, `params`, `signal`) is provided with contextual typing.
- **Reusable form rename**: `action.input` → `action.mapInput` to make the mapper's purpose explicit.
- **Type inference**: inline action return types flow into `actionResult` in `save`, `next`, and the step's store result via `ExtractActionResult` helper and two-generic inference (`TReusableAction` + `TInlineAction`).

```typescript
// Inline — one-off side effects
.step('fetch', {
  action: async ({ response, store, params, signal }) => {
    const data = await fetch(response.url);
    return { status: data.status };
  },
  save: ({ actionResult }) => ({ step: { status: actionResult.status } }),
  next: 'report',
})

// Reusable — shared, schema-validated actions (input renamed to mapInput)
.step('save', {
  action: {
    run: writeReport,
    mapInput: ({ response }) => ({ path: response.fileName, content: response.body }),
  },
  next: 'confirm',
})
```

## Test plan

- [x] 419 SDK tests pass (4 new inline action runtime tests)
- [x] 22 example tests pass
- [x] `tsc --noEmit` clean (SDK + examples)
- [x] 5 new type-level tests in `edge-cases.test-d.ts` (inline result → save, result → store, save.step override, contextual typing, no-action baseline)
- [x] `prettier --check .` clean
- [x] All 5 doc locations updated (SPEC.md, docs/api.md, docs/architecture.md, README.md, docs-site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)