### PR TITLE
docs: add contribution license section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,10 @@ pnpm run update-licenses
 - Update docs when behavior or usage changes.
 - Do not include secrets or credentials.
 
+## Contribution license
+
+By submitting a contribution to this project, you agree that your contribution is licensed under the MIT License that applies to this repository.
+
 ## Code of conduct
 
 By participating in this project, you agree to follow the Contentful Developer Code of Conduct:


### PR DESCRIPTION
## Summary
- Adds a "Contribution license" section clarifying that contributions are licensed under the repository's MIT License

## Test plan
- [x] Verify section appears before Code of conduct in CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)