### PR TITLE
fix: pin hashicorp/vault-action to commit SHA

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Retrieve Secrets from Vault
         id: vault
-        uses: hashicorp/vault-action@v3.4.0
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
           url: ${{ secrets.VAULT_URL }}
           role: ${{ github.event.repository.name }}-github-action


### PR DESCRIPTION
## Summary
- Pins `hashicorp/vault-action` to commit SHA `4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b` instead of mutable tag `v3.4.0`
- Matches the stronger pinning pattern already used in the skills repo
- Mitigates supply-chain risk from tag reassignment

## Test plan
- [ ] CI workflow still retrieves Vault secrets successfully on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)