### PR TITLE
fix: set MIT license holder to Contentful Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Contentful GmbH
+Copyright (c) 2026 Contentful Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/licenses/MIT.txt
+++ b/licenses/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) YEAR COPYRIGHT HOLDER
+Copyright (c) YEAR Contentful Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update the repository `LICENSE` to use `Contentful Inc.` as the licensing entity
- update `licenses/MIT.txt` so generated/templated MIT text also specifies `Contentful Inc.`
- align both MIT license references to the same legal entity for consistency