### PR TITLE
feat: publish to npmjs with OIDC trusted publishing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @TimBeyer

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,6 @@ permissions:
   pull-requests: write
   issues: write
   actions: read
-  packages: write
 
 jobs:
   ci:
@@ -24,11 +23,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Typecheck
         run: pnpm exec tsc --noEmit
       - name: Test
@@ -84,17 +81,12 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: pnpm run build
-      - name: Restore .npmrc
-        run: git checkout -- .npmrc
       - name: Release
         run: pnpm exec release-it --ci
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ permissions:
   pull-requests: write
   issues: write
   actions: read
-  packages: read
 
 jobs:
   ci:
@@ -21,11 +20,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Typecheck
         run: pnpm exec tsc --noEmit
       - name: Test

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-@contentful:registry=https://npm.pkg.github.com/
+@contentful:registry=https://registry.npmjs.org
 ignore-scripts=true
 engine-strict=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Example skills import `@contentful/skill-kit` which resolves via the `exports` f
 - ESM only (`"type": "module"`)
 - Tests colocated next to source files
 - oxlint for correctness linting, Prettier for formatting (no ESLint)
-- Published to GitHub Packages (`@contentful:registry=https://npm.pkg.github.com/`)
+- Published to npm (`@contentful:registry=https://registry.npmjs.org`)
 
 ## Workflow
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,7 @@
+# Contentful Community Code of Conduct
+
+The **Contentful Community** and the **Code of Conduct** governs all interactions with the contentful community.
+
+The **Contentful Community** is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all community participants, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, religion (or lack thereof), or other identity markers.
+
+Our **Code of Conduct** exists because of that dedication, and we do not tolerate harassment in any form. See our full Code of Conduct and reporting guidelines at this [link](https://www.contentful.com/developers/code-of-conduct/).

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "bin"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "packageManager": "pnpm@10.24.0",
   "engines": {

--- a/tasks/2026-05-11_1152_publish-to-npmjs/TASK.md
+++ b/tasks/2026-05-11_1152_publish-to-npmjs/TASK.md
@@ -27,8 +27,8 @@
 
 ### Community files
 
-- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
-- `.github/CODEOWNERS` — `@contentful/team-optimization`
+- `CODE_OF_CONDUCT.md` — Contentful standard (links to contentful.com/developers/code-of-conduct/)
+- `.github/CODEOWNERS` — `@TimBeyer`
 
 ### Prerequisites (manual, outside PR)
 
@@ -38,16 +38,22 @@
 ## Steps
 
 - [x] Create branch and task file
-- [ ] Update `.npmrc`
-- [ ] Update `package.json` publishConfig
-- [ ] Update `.github/workflows/ci.yml`
-- [ ] Update `.github/workflows/ci-cd.yml`
-- [ ] Update `CLAUDE.md`
-- [ ] Create `CODE_OF_CONDUCT.md`
-- [ ] Create `.github/CODEOWNERS`
-- [ ] Run verification (typecheck, lint, format)
-- [ ] Commit and push
+- [x] Update `.npmrc`
+- [x] Update `package.json` publishConfig
+- [x] Update `.github/workflows/ci.yml`
+- [x] Update `.github/workflows/ci-cd.yml`
+- [x] Update `CLAUDE.md`
+- [x] Create `CODE_OF_CONDUCT.md`
+- [x] Create `.github/CODEOWNERS`
+- [x] Run verification (typecheck, lint, format)
+- [x] Commit and push
+- [x] Open PR
 
 ## Notes
 
-(Running log of decisions during implementation)
+- CODE_OF_CONDUCT.md uses Contentful's standard format (from github.com/contentful/.github) rather than inlining the full Contributor Covenant. This matches other Contentful open-source repos.
+- CODEOWNERS set to `@TimBeyer` rather than a team for now.
+- Removed the "Restore .npmrc" step from ci-cd.yml release job — it was only needed to undo pnpm's injection of GitHub Packages auth into .npmrc.
+- Audited against Confluence's "Open Source Repository Guidelines" (page 5567283282). All items pass except branch protections (GitHub setting) and SAST (currently disabled in catalog-info.yaml).
+- NPM org access is managed by IT (admin: Michael Pearce). OIDC trusted publishing must be configured on npmjs.org before first release — see https://contentful.atlassian.net/wiki/pages/viewpage.action?pageId=776045263
+- PR: https://github.com/contentful/skill-kit/pull/68

--- a/tasks/2026-05-11_1152_publish-to-npmjs/TASK.md
+++ b/tasks/2026-05-11_1152_publish-to-npmjs/TASK.md
@@ -1,0 +1,53 @@
+# Publish to npmjs + Open-Source Readiness
+
+## Scope
+
+**In:** Switch package publishing from GitHub Packages to npmjs.org (public), add community files for open-source readiness.
+
+**Out:** Changing release tooling (keep release-it), removing internal infra files (catalog-info.yaml, vault-secrets.yaml stay).
+
+## Context
+
+`@contentful/skill-kit` is being open-sourced. GitHub Packages requires credentials to install — public users need the package on npmjs.org. contentful.js already publishes to npmjs using OIDC trusted publishing (GitHub Actions mints ephemeral identity tokens that npm accepts, no stored npm token). We adopt the same approach.
+
+## Plan
+
+### Registry switch
+
+- `.npmrc`: point `@contentful:registry` to `https://registry.npmjs.org`
+- `package.json`: set `publishConfig` to `{ "registry": "https://registry.npmjs.org/", "access": "public" }`
+- Workflows: change `registry-url` to npmjs, remove `NODE_AUTH_TOKEN` from install steps
+
+### npm auth model (OIDC trusted publishing)
+
+- `id-token: write` permission (already present) enables GitHub Actions to mint OIDC tokens
+- `actions/setup-node` with `registry-url` configures npm to use OIDC automatically
+- No `NODE_AUTH_TOKEN` needed for publish — npm authenticates via OIDC identity
+- Vault continues to provide GitHub token for release-it (GitHub releases, git push)
+
+### Community files
+
+- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
+- `.github/CODEOWNERS` — `@contentful/team-optimization`
+
+### Prerequisites (manual, outside PR)
+
+1. Configure `@contentful/skill-kit` on npmjs.org for OIDC trusted publishing from `contentful/skill-kit`
+2. Make repo public on GitHub
+
+## Steps
+
+- [x] Create branch and task file
+- [ ] Update `.npmrc`
+- [ ] Update `package.json` publishConfig
+- [ ] Update `.github/workflows/ci.yml`
+- [ ] Update `.github/workflows/ci-cd.yml`
+- [ ] Update `CLAUDE.md`
+- [ ] Create `CODE_OF_CONDUCT.md`
+- [ ] Create `.github/CODEOWNERS`
+- [ ] Run verification (typecheck, lint, format)
+- [ ] Commit and push
+
+## Notes
+
+(Running log of decisions during implementation)


### PR DESCRIPTION
## Summary

- Switch package publishing from GitHub Packages to the public npm registry (registry.npmjs.org)
- Use OIDC trusted publishing for npm auth (same as contentful.js) — no stored npm tokens
- Add CODE_OF_CONDUCT.md (Contentful standard) and CODEOWNERS
- Update all workflow files to use `registry.npmjs.org` and remove `NODE_AUTH_TOKEN` / `packages:` permissions

## Prerequisites (before merging)

1. **OIDC trusted publishing:** Configure `@contentful/skill-kit` on npmjs.org to trust GitHub Actions from `contentful/skill-kit` — IT manages npm access (see [NPM Confluence page](https://contentful.atlassian.net/wiki/pages/viewpage.action?pageId=776045263))
2. **Make repo public** on GitHub

## Open-source checklist (from [Confluence guidelines](https://contentful.atlassian.net/wiki/pages/viewpage.action?pageId=5567283282))

- [x] README.md with badges
- [x] CONTRIBUTING.md
- [x] CODE_OF_CONDUCT.md
- [x] LICENSE (MIT)
- [x] NOTICE + /licenses directory
- [x] Issue/PR templates
- [x] CODEOWNERS
- [x] Renovate configured
- [x] CI + test coverage
- [x] catalog-info.yaml
- [x] Linters/formatters (oxlint + Prettier)
- [ ] Branch protections (GitHub setting)
- [ ] SAST enabled (currently `sast-disabled` in catalog-info.yaml)

## Test plan

- [ ] Verify `grep -r "npm.pkg.github.com" .` returns no matches in tracked files
- [ ] Verify `package.json` publishConfig has `"access": "public"` and registry points to npmjs
- [ ] After merge: confirm release job publishes to npmjs.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)