### PR TITLE
fix(docs-site): add /skill-kit/ base path for GitHub Pages

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -3,8 +3,8 @@ import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
 
 export default defineConfig({
-  // TODO: set custom domain or make Pages public so this serves at contentful.github.io/skill-kit/
-  site: 'https://contentful.github.io',
+  site: 'https://contentful.github.io/skill-kit',
+  base: '/skill-kit/',
   trailingSlash: 'always',
   output: 'static',
   integrations: [mdx(), react()],


### PR DESCRIPTION
## Summary

- Add `base: '/skill-kit/'` to Astro config so all generated links resolve correctly at `contentful.github.io/skill-kit/`
- Update `site` to include the full path for correct canonical URL generation
- Remove the TODO comment that described this exact fix

## Test plan

- [x] `pnpm run build` succeeds in docs-site/
- [x] Generated `dist/index.html` links all start with `/skill-kit/`
- [ ] After deploy: verify navigation works at https://contentful.github.io/skill-kit/

🤖 Generated with [Claude Code](https://claude.com/claude-code)