### PR TITLE
chore(release): sync package.json to v1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/skill-kit",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "TypeScript SDK for building agent skills with CLI-driven workflows",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump package.json from 1.9.1 to 1.10.0 to match what's already published on npm as `latest`

## Context

A prior CI run published 1.10.0 to npm but branch protection prevented it from committing the version bump back to main. A subsequent release then bumped to 1.9.1 (patch from 1.9.0). This leaves main out of sync — the next `feat:` merge would try to publish 1.10.0 again and fail.

This PR syncs the version so the next release correctly produces 1.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)