### PR TITLE
chore: remove obsolete dependabot Vault policy [MEC-3526]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -2,6 +2,5 @@ version: 1
 services:
   github-action:
     policies:
-      - dependabot
       - semantic-release
       - packages-read


### PR DESCRIPTION
Removes the `dependabot` entry from `.contentful/vault-secrets.yaml`.

This policy was used when Dependabot needed Vault-sourced secrets for GitHub Actions. The repo has since been migrated to Renovate, which runs as an org-level GitHub App and does not require a repo-local Vault secret policy. The entry is now dead weight.

No functional change — this is a cleanup of a leftover artifact from the Dependabot-to-Renovate migration.

## Migration Confidence: 🟢 High

### Summary

Removed the `- dependabot` entry from the `policies` list under `services.github-action` in `.contentful/vault-secrets.yaml`. The remaining two policies (`semantic-release`, `packages-read`) are intact, no empty YAML structures were left behind, and no other files were modified.